### PR TITLE
Version provider runner policy independently

### DIFF
--- a/crates/automata-ci-provisioning-postgres/src/github_provider.rs
+++ b/crates/automata-ci-provisioning-postgres/src/github_provider.rs
@@ -168,6 +168,7 @@ impl PostgresGithubProviderConfigurationApplier {
         )?;
         let webhook_verifier_revision =
             next_webhook_revision(current.as_ref(), webhook_secret_hash.as_slice())?;
+        let runner_policy_revision = next_runner_policy_revision(current.as_ref(), &runner_policy)?;
         let applied_at_ms = database_time_milliseconds(&mut transaction)
             .await
             .map_err(provider_database_failure)?;
@@ -209,14 +210,14 @@ impl PostgresGithubProviderConfigurationApplier {
                 webhook_secret_sha256, webhook_secret_envelope_schema,
                 webhook_secret_wrapping_key_id, webhook_secret_wrapped_data_key,
                 webhook_secret_nonce, webhook_secret_ciphertext, check_name,
-                runner_policy, schedule_poll_millis,
+                runner_policy_revision, runner_policy, schedule_poll_millis,
                 schedule_discovery_claim_millis, schedule_fire_claim_millis,
                 schedule_retry_millis, schedule_staleness_millis,
                 schedule_maximum_manifests, schedule_maximum_fires_per_pass,
                 applied_at_ms
             ) VALUES (
                 true,$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,
-                $17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32
+                $17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33
             )
             ",
         )
@@ -243,6 +244,7 @@ impl PostgresGithubProviderConfigurationApplier {
         .bind(webhook_secret.nonce)
         .bind(webhook_secret.ciphertext)
         .bind(configuration.check_name().as_str())
+        .bind(runner_policy_revision)
         .bind(runner_policy)
         .bind(schedule.poll_millis())
         .bind(schedule.discovery_claim_millis())
@@ -648,6 +650,7 @@ impl PostgresGithubProviderDesiredStateReader {
             GithubProviderConfigurationRevision::new(revision).map_err(|_| desired_corrupt())?,
             positive_u64(provider.app_configuration_revision)?,
             positive_u64(provider.webhook_verifier_revision)?,
+            positive_u64(provider.runner_policy_revision)?,
             configuration,
             workspaces,
         )
@@ -693,6 +696,7 @@ struct ProviderDesiredStateRow {
     webhook_secret_nonce: Vec<u8>,
     webhook_secret_ciphertext: Vec<u8>,
     check_name: String,
+    runner_policy_revision: i64,
     runner_policy: Vec<u8>,
     schedule_poll_millis: i64,
     schedule_discovery_claim_millis: i64,
@@ -951,6 +955,8 @@ struct CurrentProviderEvidence {
     app_private_key_sha256: Vec<u8>,
     webhook_verifier_revision: i64,
     webhook_secret_sha256: Vec<u8>,
+    runner_policy_revision: i64,
+    runner_policy: Vec<u8>,
 }
 
 async fn load_current_provider_evidence(
@@ -960,7 +966,8 @@ async fn load_current_provider_evidence(
         r"
         SELECT github_app_id, github_app_client_id, github_app_jwt_issuer_kind,
                app_configuration_revision, app_private_key_sha256,
-               webhook_verifier_revision, webhook_secret_sha256
+               webhook_verifier_revision, webhook_secret_sha256,
+               runner_policy_revision, runner_policy
         FROM github_provider_configuration_current WHERE singleton=true
         ",
     )
@@ -1006,6 +1013,23 @@ fn next_webhook_revision(
     } else {
         current
             .webhook_verifier_revision
+            .checked_add(1)
+            .ok_or_else(provider_internal)
+    }
+}
+
+fn next_runner_policy_revision(
+    current: Option<&CurrentProviderEvidence>,
+    runner_policy: &[u8],
+) -> Result<i64, GithubProviderConfigurationFailure> {
+    let Some(current) = current else {
+        return Ok(1);
+    };
+    if current.runner_policy == runner_policy {
+        Ok(current.runner_policy_revision)
+    } else {
+        current
+            .runner_policy_revision
             .checked_add(1)
             .ok_or_else(provider_internal)
     }

--- a/crates/automata-ci-provisioning/src/github_provider.rs
+++ b/crates/automata-ci-provisioning/src/github_provider.rs
@@ -776,6 +776,7 @@ pub struct GithubProviderDesiredState {
     configuration_revision: GithubProviderConfigurationRevision,
     app_configuration_revision: u64,
     webhook_verifier_revision: u64,
+    runner_policy_revision: u64,
     configuration: GithubProviderConfiguration,
     workspaces: Vec<WorkspaceGithubRepositoriesDesiredState>,
 }
@@ -791,10 +792,14 @@ impl GithubProviderDesiredState {
         configuration_revision: GithubProviderConfigurationRevision,
         app_configuration_revision: u64,
         webhook_verifier_revision: u64,
+        runner_policy_revision: u64,
         configuration: GithubProviderConfiguration,
         mut workspaces: Vec<WorkspaceGithubRepositoriesDesiredState>,
     ) -> Result<Self, GithubProviderValueError> {
-        if app_configuration_revision == 0 || webhook_verifier_revision == 0 {
+        if app_configuration_revision == 0
+            || webhook_verifier_revision == 0
+            || runner_policy_revision == 0
+        {
             return Err(GithubProviderValueError::InvalidProviderRevision);
         }
         workspaces.sort_unstable_by_key(WorkspaceGithubRepositoriesDesiredState::workspace_id);
@@ -809,6 +814,7 @@ impl GithubProviderDesiredState {
             configuration_revision,
             app_configuration_revision,
             webhook_verifier_revision,
+            runner_policy_revision,
             configuration,
             workspaces,
         })
@@ -838,6 +844,12 @@ impl GithubProviderDesiredState {
         self.webhook_verifier_revision
     }
 
+    /// Returns the independently versioned canonical runner-policy revision.
+    #[must_use]
+    pub const fn runner_policy_revision(&self) -> u64 {
+        self.runner_policy_revision
+    }
+
     /// Returns the validated shard-wide provider configuration.
     #[must_use]
     pub const fn configuration(&self) -> &GithubProviderConfiguration {
@@ -859,6 +871,7 @@ impl GithubProviderDesiredState {
         GithubProviderConfigurationRevision,
         u64,
         u64,
+        u64,
         GithubProviderConfiguration,
         Vec<WorkspaceGithubRepositoriesDesiredState>,
     ) {
@@ -867,6 +880,7 @@ impl GithubProviderDesiredState {
             self.configuration_revision,
             self.app_configuration_revision,
             self.webhook_verifier_revision,
+            self.runner_policy_revision,
             self.configuration,
             self.workspaces,
         )
@@ -884,6 +898,7 @@ impl fmt::Debug for GithubProviderDesiredState {
                 &self.app_configuration_revision,
             )
             .field("webhook_verifier_revision", &self.webhook_verifier_revision)
+            .field("runner_policy_revision", &self.runner_policy_revision)
             .field("configuration", &self.configuration)
             .field("workspace_count", &self.workspaces.len())
             .field(

--- a/crates/automata-ci-store-postgres/migrations/0059_provider_runner_policy_revision.sql
+++ b/crates/automata-ci-store-postgres/migrations/0059_provider_runner_policy_revision.sql
@@ -1,0 +1,9 @@
+ALTER TABLE github_provider_configuration_current
+    ADD COLUMN runner_policy_revision bigint NOT NULL DEFAULT 1;
+
+ALTER TABLE github_provider_configuration_current
+    ALTER COLUMN runner_policy_revision DROP DEFAULT;
+
+ALTER TABLE github_provider_configuration_current
+    ADD CONSTRAINT github_provider_configuration_current_runner_policy_revision_positive
+    CHECK (runner_policy_revision > 0);

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -237,6 +237,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0058_required_check_event_isolation.sql",
         "ea67c5ce5f63d1fedffc66d92d7cf871cb0c0ec363f9312d3aebf12a015cd76a7c24c03c269558db395abbcc94390365",
     ),
+    (
+        "0059_provider_runner_policy_revision.sql",
+        "16f98a4cbb0b60b6145787bc5a38b8f37228b52cb7e6512a6738fcd24b483542adbadbf0fbf59bd0fd4ba7e53c3e6f76",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;
@@ -397,6 +401,22 @@ fn required_github_check_identity_is_event_isolated_and_never_skipped() {
         assert!(
             source.contains(required),
             "required-Check isolation migration lost contract: {required}"
+        );
+    }
+}
+
+#[test]
+fn provider_runner_policy_revision_is_independent_and_positive() {
+    let source = include_str!("../migrations/0059_provider_runner_policy_revision.sql");
+
+    for required in [
+        "ADD COLUMN runner_policy_revision bigint NOT NULL DEFAULT 1",
+        "ALTER COLUMN runner_policy_revision DROP DEFAULT",
+        "CHECK (runner_policy_revision > 0)",
+    ] {
+        assert!(
+            source.contains(required),
+            "provider runner-policy revision migration lost required contract: {required}"
         );
     }
 }

--- a/crates/automata-ci/src/server/github_provider_config.rs
+++ b/crates/automata-ci/src/server/github_provider_config.rs
@@ -242,6 +242,7 @@ impl GithubProviderConfig {
             configuration_revision,
             app_configuration_revision,
             webhook_verifier_revision,
+            runner_policy_revision,
             configuration,
             workspaces,
         ) = desired.into_parts();
@@ -287,6 +288,7 @@ impl GithubProviderConfig {
                 repositories.push(database_repository_config(
                     workspace_id,
                     projected_revision,
+                    runner_policy_revision,
                     selected,
                     &runner_policy,
                     &check_name,
@@ -422,6 +424,7 @@ impl fmt::Debug for DatabaseGithubProviderConfig {
 fn database_repository_config(
     workspace_id: WorkspaceId,
     projected_revision: u64,
+    runner_policy_revision: u64,
     selected: &GithubProviderRepositorySelection,
     runner_policy: &GithubRunnerPolicy,
     check_name: &GithubCheckName,
@@ -463,7 +466,7 @@ fn database_repository_config(
             .map_err(|_| GithubProviderConfigError)?;
     let manifest_revision = GithubProviderManifestRevision::new(projected_revision)
         .map_err(|_| GithubProviderConfigError)?;
-    let runtime_policy_revision = WorkflowRuntimePolicyRevision::new(projected_revision)
+    let runtime_policy_revision = WorkflowRuntimePolicyRevision::new(runner_policy_revision)
         .map_err(|_| GithubProviderConfigError)?;
     let visibility = selected.visibility();
     Ok(GithubProviderRepositoryConfig {

--- a/crates/automata-ci/src/server/github_provider_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_tests.rs
@@ -576,6 +576,7 @@ async fn duplicate_config_and_durable_manifest_selector_drift_fail_closed() {
 fn database_desired_state(
     configuration_revision: u64,
     workspace_revision: u64,
+    runner_policy_revision: u64,
 ) -> automata_ci_provisioning::GithubProviderDesiredState {
     use automata_ci_core::JobAuthorityProfile;
     use automata_ci_core::WorkspaceId;
@@ -623,6 +624,7 @@ fn database_desired_state(
             .expect("configuration revision"),
         3,
         4,
+        runner_policy_revision,
         configuration,
         vec![
             WorkspaceGithubRepositoriesDesiredState::new(
@@ -639,9 +641,9 @@ fn database_desired_state(
 
 #[test]
 fn database_desired_state_derives_stable_runtime_identities_and_revisions() {
-    let first = GithubProviderConfig::from_desired_state(database_desired_state(5, 5))
+    let first = GithubProviderConfig::from_desired_state(database_desired_state(5, 5, 2))
         .expect("database projection");
-    let second = GithubProviderConfig::from_desired_state(database_desired_state(5, 5))
+    let second = GithubProviderConfig::from_desired_state(database_desired_state(5, 5, 2))
         .expect("stable database projection");
     let first_repository = &first.config().repositories()[0];
     let second_repository = &second.config().repositories()[0];
@@ -652,7 +654,7 @@ fn database_desired_state_derives_stable_runtime_identities_and_revisions() {
     );
     assert_eq!(first_repository.manifest_revision().get(), 5);
     assert_eq!(first_repository.policy_revision().get(), 5);
-    assert_eq!(first_repository.runtime_policy_revision().get(), 5);
+    assert_eq!(first_repository.runtime_policy_revision().get(), 2);
     assert_eq!(
         first_repository.connection_id(),
         second_repository.connection_id()
@@ -675,5 +677,5 @@ fn database_desired_state_derives_stable_runtime_identities_and_revisions() {
 
 #[test]
 fn database_desired_state_rejects_mixed_runtime_generations() {
-    assert!(GithubProviderConfig::from_desired_state(database_desired_state(5, 4)).is_err());
+    assert!(GithubProviderConfig::from_desired_state(database_desired_state(5, 4, 2)).is_err());
 }


### PR DESCRIPTION
Fix provider desired-state reconciliation when a repository-only configuration change advances the shared generation.

- persist an independent runner-policy revision alongside App and webhook revisions
- advance it only when canonical runner-policy bytes change
- project manifests with that independent runtime-policy revision
- backfill existing installations to revision 1
- cover independent projection and migration invariants

This allows the production repository authority profile to move from credential-free to standard without manufacturing a duplicate runtime-policy revision.