### PR TITLE
Decouple provider installation binding revisions

### DIFF
--- a/crates/automata-ci-provisioning-postgres/src/github_provider.rs
+++ b/crates/automata-ci-provisioning-postgres/src/github_provider.rs
@@ -423,6 +423,13 @@ impl PostgresWorkspaceGithubRepositoriesApplier {
         .await
         .map_err(workspace_database_failure)?;
         for (ordinal, repository) in command.repositories().iter().enumerate() {
+            let installation_binding_generation = advance_installation_binding(
+                &mut transaction,
+                &workspace_text,
+                revision_i64,
+                repository,
+            )
+            .await?;
             insert_repository_selection(
                 &mut transaction,
                 &workspace_text,
@@ -430,6 +437,7 @@ impl PostgresWorkspaceGithubRepositoriesApplier {
                 revision_i64,
                 i32::try_from(ordinal).map_err(|_| workspace_internal())?,
                 repository,
+                installation_binding_generation,
             )
             .await?;
         }
@@ -537,6 +545,7 @@ impl PostgresGithubProviderDesiredStateReader {
             r"
             SELECT selections.workspace_id, selections.revision,
                    selections.provider_installation_id,
+                   selections.installation_binding_generation,
                    selections.provider_repository_id,
                    selections.provider_repository_owner_id,
                    selections.repository_name, selections.default_branch,
@@ -740,6 +749,7 @@ struct RepositorySelectionRow {
     workspace_id: String,
     revision: i64,
     provider_installation_id: i64,
+    installation_binding_generation: i64,
     provider_repository_id: i64,
     provider_repository_owner_id: i64,
     repository_name: String,
@@ -752,6 +762,7 @@ impl RepositorySelectionRow {
     fn decode(
         self,
     ) -> Result<GithubProviderRepositorySelection, GithubProviderDesiredStateFailure> {
+        let installation_binding_generation = positive_u64(self.installation_binding_generation)?;
         GithubProviderRepositorySelection::new(
             ProviderInstallationId::new(positive_u64(self.provider_installation_id)?)
                 .map_err(|_| desired_corrupt())?,
@@ -772,6 +783,9 @@ impl RepositorySelectionRow {
                 _ => return Err(desired_corrupt()),
             },
         )
+        .and_then(|selection| {
+            selection.with_installation_binding_generation(installation_binding_generation)
+        })
         .map_err(|_| desired_corrupt())
     }
 }
@@ -1148,6 +1162,7 @@ async fn insert_repository_selection(
     revision: i64,
     ordinal: i32,
     repository: &GithubProviderRepositorySelection,
+    installation_binding_generation: i64,
 ) -> Result<(), WorkspaceGithubRepositoriesFailure> {
     let visibility = match repository.visibility() {
         ProviderRepositoryVisibility::Public => "public",
@@ -1161,10 +1176,11 @@ async fn insert_repository_selection(
         r"
         INSERT INTO workspace_github_repository_selections (
             workspace_id, shard_id, revision, ordinal, provider_installation_id,
+            installation_binding_generation,
             provider_repository_id, provider_repository_owner_id,
             repository_name, default_branch, repository_visibility,
             authority_profile
-        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
         ",
     )
     .bind(workspace_id)
@@ -1172,6 +1188,7 @@ async fn insert_repository_selection(
     .bind(revision)
     .bind(ordinal)
     .bind(i64::try_from(repository.installation_id().get()).map_err(|_| workspace_internal())?)
+    .bind(installation_binding_generation)
     .bind(i64::try_from(repository.repository_id().get()).map_err(|_| workspace_internal())?)
     .bind(i64::try_from(repository.repository_owner_id().get()).map_err(|_| workspace_internal())?)
     .bind(repository.repository_name().as_str())
@@ -1182,6 +1199,88 @@ async fn insert_repository_selection(
     .await
     .map_err(workspace_database_failure)?;
     Ok(())
+}
+
+#[derive(FromRow)]
+struct InstallationBindingRow {
+    provider_installation_id: i64,
+    binding_generation: i64,
+}
+
+async fn advance_installation_binding(
+    transaction: &mut Transaction<'_, Postgres>,
+    workspace_id: &str,
+    workspace_revision: i64,
+    repository: &GithubProviderRepositorySelection,
+) -> Result<i64, WorkspaceGithubRepositoriesFailure> {
+    let repository_id =
+        i64::try_from(repository.repository_id().get()).map_err(|_| workspace_internal())?;
+    let installation_id =
+        i64::try_from(repository.installation_id().get()).map_err(|_| workspace_internal())?;
+    let current = sqlx::query_as::<_, InstallationBindingRow>(
+        r"
+        SELECT provider_installation_id, binding_generation
+        FROM workspace_github_repository_installation_bindings
+        WHERE workspace_id=$1 AND provider_repository_id=$2
+        FOR UPDATE
+        ",
+    )
+    .bind(workspace_id)
+    .bind(repository_id)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(workspace_database_failure)?;
+    let Some(current) = current else {
+        sqlx::query(
+            r"
+            INSERT INTO workspace_github_repository_installation_bindings (
+                workspace_id, provider_repository_id, provider_installation_id,
+                binding_generation, updated_at_revision
+            ) VALUES ($1,$2,$3,1,$4)
+            ",
+        )
+        .bind(workspace_id)
+        .bind(repository_id)
+        .bind(installation_id)
+        .bind(workspace_revision)
+        .execute(&mut **transaction)
+        .await
+        .map_err(workspace_database_failure)?;
+        return Ok(1);
+    };
+    if current.provider_installation_id == installation_id {
+        return Ok(current.binding_generation);
+    }
+    let next_generation = current
+        .binding_generation
+        .checked_add(1)
+        .ok_or_else(workspace_internal)?;
+    let updated = sqlx::query(
+        r"
+        UPDATE workspace_github_repository_installation_bindings
+        SET provider_installation_id=$3,
+            binding_generation=$4,
+            updated_at_revision=$5
+        WHERE workspace_id=$1
+          AND provider_repository_id=$2
+          AND provider_installation_id=$6
+          AND binding_generation=$7
+        ",
+    )
+    .bind(workspace_id)
+    .bind(repository_id)
+    .bind(installation_id)
+    .bind(next_generation)
+    .bind(workspace_revision)
+    .bind(current.provider_installation_id)
+    .bind(current.binding_generation)
+    .execute(&mut **transaction)
+    .await
+    .map_err(workspace_database_failure)?;
+    if updated.rows_affected() != 1 {
+        return Err(workspace_internal());
+    }
+    Ok(next_generation)
 }
 
 fn provider_configuration_digest(

--- a/crates/automata-ci-provisioning/src/github_provider.rs
+++ b/crates/automata-ci-provisioning/src/github_provider.rs
@@ -499,6 +499,7 @@ impl fmt::Debug for AuthorizedApplyGithubProviderConfiguration {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GithubProviderRepositorySelection {
     installation_id: ProviderInstallationId,
+    installation_binding_generation: u64,
     repository_id: ProviderRepositoryId,
     repository_owner_id: ProviderRepositoryOwnerId,
     repository_name: GithubRepositoryName,
@@ -537,6 +538,7 @@ impl GithubProviderRepositorySelection {
         }
         Ok(Self {
             installation_id,
+            installation_binding_generation: 1,
             repository_id,
             repository_owner_id,
             repository_name,
@@ -550,6 +552,28 @@ impl GithubProviderRepositorySelection {
     #[must_use]
     pub const fn installation_id(&self) -> ProviderInstallationId {
         self.installation_id
+    }
+
+    /// Restores the independently versioned installation binding.
+    ///
+    /// # Errors
+    ///
+    /// Rejects zero, which is outside the durable generation domain.
+    pub fn with_installation_binding_generation(
+        mut self,
+        generation: u64,
+    ) -> Result<Self, GithubProviderValueError> {
+        if generation == 0 {
+            return Err(GithubProviderValueError::InvalidRepository);
+        }
+        self.installation_binding_generation = generation;
+        Ok(self)
+    }
+
+    /// Returns the independent installation-binding generation.
+    #[must_use]
+    pub const fn installation_binding_generation(&self) -> u64 {
+        self.installation_binding_generation
     }
 
     /// Returns the stable numeric GitHub repository identity.

--- a/crates/automata-ci-store-postgres/migrations/0060_provider_installation_binding_generation.sql
+++ b/crates/automata-ci-store-postgres/migrations/0060_provider_installation_binding_generation.sql
@@ -1,0 +1,36 @@
+ALTER TABLE workspace_github_repository_selections
+    ADD COLUMN installation_binding_generation bigint NOT NULL DEFAULT 1;
+
+ALTER TABLE workspace_github_repository_selections
+    ALTER COLUMN installation_binding_generation DROP DEFAULT;
+
+ALTER TABLE workspace_github_repository_selections
+    ADD CONSTRAINT workspace_github_repository_installation_binding_generation_positive
+    CHECK (installation_binding_generation > 0);
+
+CREATE TABLE workspace_github_repository_installation_bindings (
+    workspace_id text NOT NULL,
+    provider_repository_id bigint NOT NULL,
+    provider_installation_id bigint NOT NULL,
+    binding_generation bigint NOT NULL,
+    updated_at_revision bigint NOT NULL,
+    PRIMARY KEY (workspace_id, provider_repository_id),
+    CONSTRAINT workspace_github_repository_installation_bindings_workspace
+        FOREIGN KEY (workspace_id)
+        REFERENCES workspace_management_bindings(workspace_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT workspace_github_repository_installation_bindings_positive CHECK (
+        provider_repository_id > 0
+        AND provider_installation_id > 0
+        AND binding_generation > 0
+        AND updated_at_revision > 0
+    )
+);
+
+INSERT INTO workspace_github_repository_installation_bindings (
+    workspace_id, provider_repository_id, provider_installation_id,
+    binding_generation, updated_at_revision
+)
+SELECT workspace_id, provider_repository_id, provider_installation_id,
+       installation_binding_generation, revision
+FROM workspace_github_repository_selections;

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -241,6 +241,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0059_provider_runner_policy_revision.sql",
         "16f98a4cbb0b60b6145787bc5a38b8f37228b52cb7e6512a6738fcd24b483542adbadbf0fbf59bd0fd4ba7e53c3e6f76",
     ),
+    (
+        "0060_provider_installation_binding_generation.sql",
+        "ce1b6174a6e19b1b67a090dbaeb3dfbd08b16bdd3c6253ec0be60a64ec9894f67cee662076ba3307a52f2ecc01b74573",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;
@@ -417,6 +421,23 @@ fn provider_runner_policy_revision_is_independent_and_positive() {
         assert!(
             source.contains(required),
             "provider runner-policy revision migration lost required contract: {required}"
+        );
+    }
+}
+
+#[test]
+fn provider_installation_binding_generation_is_independent_and_durable() {
+    let source = include_str!("../migrations/0060_provider_installation_binding_generation.sql");
+
+    for required in [
+        "ADD COLUMN installation_binding_generation bigint NOT NULL DEFAULT 1",
+        "ALTER COLUMN installation_binding_generation DROP DEFAULT",
+        "CREATE TABLE workspace_github_repository_installation_bindings",
+        "CHECK (installation_binding_generation > 0)",
+    ] {
+        assert!(
+            source.contains(required),
+            "provider installation-binding migration lost required contract: {required}"
         );
     }
 }

--- a/crates/automata-ci/src/server/github_provider_config.rs
+++ b/crates/automata-ci/src/server/github_provider_config.rs
@@ -462,7 +462,7 @@ fn database_repository_config(
     let workflow_git_ref = GithubProviderGitRef::new(cache_repository.default_branch_ref())
         .map_err(|_| GithubProviderConfigError)?;
     let installation_binding_generation =
-        GithubInstallationBindingGeneration::new(projected_revision)
+        GithubInstallationBindingGeneration::new(selected.installation_binding_generation())
             .map_err(|_| GithubProviderConfigError)?;
     let manifest_revision = GithubProviderManifestRevision::new(projected_revision)
         .map_err(|_| GithubProviderConfigError)?;

--- a/crates/automata-ci/src/server/github_provider_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_tests.rs
@@ -655,6 +655,7 @@ fn database_desired_state_derives_stable_runtime_identities_and_revisions() {
     assert_eq!(first_repository.manifest_revision().get(), 5);
     assert_eq!(first_repository.policy_revision().get(), 5);
     assert_eq!(first_repository.runtime_policy_revision().get(), 2);
+    assert_eq!(first_repository.installation_binding_generation().get(), 1);
     assert_eq!(
         first_repository.connection_id(),
         second_repository.connection_id()


### PR DESCRIPTION
Fix provider manifest activation when a repository policy changes without moving to a different GitHub App installation.

- persist an independent installation-binding generation
- advance it only when the installation identity changes
- retain the binding registry across repository removal/re-addition
- backfill existing selections at generation 1
- project manifests from the independent generation

Validated with affected workspace checks, 604 unit tests, migration lineage tests, formatting, and clippy with warnings denied.