### PR TITLE
Add macOS live integration gate

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           ./scripts/ci/install-zizmor.sh target/ci-tools
           ./scripts/ci/lint-workflows.sh
           ./scripts/ci/lint-ci-security.sh
+          python3 scripts/ci/tests/macos-integration-checks.test.py
           python3 scripts/ci/tests/windows-image-pipeline.test.py
           cargo clippy --workspace --lib --bins --all-features --locked -- -D warnings
           cargo test \

--- a/docs/development.md
+++ b/docs/development.md
@@ -148,6 +148,19 @@ cargo test -p automata-ci-runner --locked \
   --ignored --test-threads=1
 ```
 
+On Apple Silicon, `./scripts/ci/run-macos-integration-checks.sh` composes the
+six RustFS contracts above with the exact artifact/cache client real-store
+acceptance. In addition to the database and S3 variables, set the three pinned
+action roots and module paths named by
+`exact_client_real_store.rs`: `AUTOMATA_TEST_UPLOAD_ARTIFACT_ACTION_ROOT`,
+`AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE`,
+`AUTOMATA_TEST_DOWNLOAD_ARTIFACT_ACTION_ROOT`,
+`AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE`,
+`AUTOMATA_TEST_CACHE_ACTION_ROOT`, and
+`AUTOMATA_TEST_ACTIONS_CACHE_MODULE`. The gate checks the platform and pinned
+Node release, bounds every test to one thread, and always removes its complete
+PostgreSQL namespace. `--plan` prints the credential-free command matrix.
+
 The coverage runner checks the filtered runner probe listing against exact test
 identities in the policy and against every ignored function in its source file,
 so adding an ignored test outside the current module filter fails closed.

--- a/scripts/ci/run-macos-integration-checks.sh
+++ b/scripts/ci/run-macos-integration-checks.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  printf '%s\n' \
+    'error: macOS integration checks require Bash 4 or newer; install Homebrew bash and put /opt/homebrew/bin first in PATH' \
+    >&2
+  exit 2
+fi
+
+usage() {
+  printf 'usage: %s [--plan]\n' "$0" >&2
+}
+
+plan=false
+if (( $# > 0 )); then
+  if (( $# != 1 )) || [[ "$1" != --plan ]]; then
+    usage
+    exit 2
+  fi
+  plan=true
+fi
+
+repository_root="$(git rev-parse --show-toplevel)"
+cd "$repository_root"
+
+run_command() {
+  if [[ "$plan" == true ]]; then
+    printf 'RUN'
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+run_test() {
+  local label=$1
+  shift
+  printf 'macOS integration: %s\n' "$label" >&2
+  run_command "$@"
+}
+
+if [[ "$plan" != true ]]; then
+  if [[ "$(uname -s)" != Darwin || "$(uname -m)" != arm64 ]]; then
+    printf '%s\n' 'error: macOS integration checks require an Apple Silicon macOS host' >&2
+    exit 2
+  fi
+  if ! command -v node >/dev/null 2>&1 || [[ "$(node --version)" != v24.19.0 ]]; then
+    printf '%s\n' 'error: macOS integration checks require Node.js 24.19.0' >&2
+    exit 2
+  fi
+
+  required_environment=(
+    AUTOMATA_TEST_DATABASE_URL
+    AUTOMATA_TEST_S3_ENDPOINT
+    AUTOMATA_TEST_S3_BUCKET
+    AUTOMATA_TEST_S3_ACCESS_KEY
+    AUTOMATA_TEST_S3_SECRET_KEY
+    AUTOMATA_TEST_S3_KMS_KEY_ID
+    AUTOMATA_TEST_UPLOAD_ARTIFACT_ACTION_ROOT
+    AUTOMATA_TEST_ACTIONS_ARTIFACT_MODULE
+    AUTOMATA_TEST_DOWNLOAD_ARTIFACT_ACTION_ROOT
+    AUTOMATA_TEST_ACTIONS_DOWNLOAD_ARTIFACT_MODULE
+    AUTOMATA_TEST_CACHE_ACTION_ROOT
+    AUTOMATA_TEST_ACTIONS_CACHE_MODULE
+  )
+  for name in "${required_environment[@]}"; do
+    if [[ -z "${!name:-}" ]]; then
+      printf 'error: %s is required\n' "$name" >&2
+      exit 2
+    fi
+  done
+
+  # shellcheck source=scripts/ci/postgres-test-environment.sh
+  source "$repository_root/scripts/ci/postgres-test-environment.sh"
+  automata_configure_postgres_test_namespace
+  cleanup_macos_integration() {
+    local primary_status=$?
+    local cleanup_status=0
+    trap - EXIT
+    set +e
+    automata_cleanup_postgres_test_namespace
+    cleanup_status=$?
+    if (( cleanup_status != 0 )); then
+      printf 'error: macOS integration namespace cleanup failed with status %d\n' \
+        "$cleanup_status" >&2
+      if (( primary_status == 0 )); then
+        primary_status=$cleanup_status
+      fi
+    fi
+    exit "$primary_status"
+  }
+  trap cleanup_macos_integration EXIT
+fi
+
+run_test 'RustFS blob contract' \
+  cargo test -p automata-ci-blob-s3 --test blob_s3 --locked -- \
+  rustfs_contract:: --ignored --test-threads=1
+run_test 'GitHub action materialization through RustFS' \
+  cargo test -p automata-ci-action --test live_github_rustfs --locked -- \
+  --ignored --test-threads=1
+run_test 'checkout action pipeline through RustFS' \
+  cargo test -p automata-ci-action-actions --test live_checkout_pipeline --locked -- \
+  --ignored --test-threads=1
+run_test 'runner artifact results through RustFS' \
+  cargo test -p automata-ci-runner-results --test rustfs_results --locked -- \
+  --ignored --test-threads=1
+run_test 'runner cache results through RustFS' \
+  cargo test -p automata-ci-runner-results --test cache_rustfs --locked -- \
+  --ignored --test-threads=1
+run_test 'workflow admission through PostgreSQL and RustFS' \
+  cargo test -p automata-ci-workflow-service --test live_admission --locked -- \
+  --ignored --test-threads=1
+run_test 'exact artifact and cache clients through real stores' \
+  cargo test -p automata-ci-runner-results --test exact_client_real_store --locked \
+  exact_clients_cross_real_http_postgres_and_object_storage -- \
+  --ignored --test-threads=1

--- a/scripts/ci/tests/macos-integration-checks.test.py
+++ b/scripts/ci/tests/macos-integration-checks.test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import pathlib
+import subprocess
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+RUNNER = ROOT / "scripts" / "ci" / "run-macos-integration-checks.sh"
+
+
+class MacosIntegrationChecksTest(unittest.TestCase):
+    def run_script(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(RUNNER), *arguments],
+            cwd=ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_plan_is_complete_bounded_and_secret_safe(self) -> None:
+        result = self.run_script("--plan")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = [line for line in result.stdout.splitlines() if line.startswith("RUN ")]
+        self.assertEqual(len(commands), 7, result.stdout)
+        for identity in (
+            "automata-ci-blob-s3 --test blob_s3",
+            "automata-ci-action --test live_github_rustfs",
+            "automata-ci-action-actions --test live_checkout_pipeline",
+            "automata-ci-runner-results --test rustfs_results",
+            "automata-ci-runner-results --test cache_rustfs",
+            "automata-ci-workflow-service --test live_admission",
+            "automata-ci-runner-results --test exact_client_real_store",
+        ):
+            self.assertTrue(any(identity in command for command in commands), identity)
+        for command in commands:
+            self.assertIn("--test-threads=1", command)
+        self.assertNotIn("ACCESS_KEY=", result.stdout)
+        self.assertNotIn("SECRET_KEY=", result.stdout)
+
+    def test_unknown_arguments_fail_closed(self) -> None:
+        result = self.run_script("--unknown")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("usage:", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add one secret-safe Apple Silicon gate for all six live PostgreSQL/RustFS contracts plus the exact official artifact/cache client real-store acceptance
- validate the host, pinned Node release, required environment, one-thread bounds, and complete PostgreSQL namespace cleanup
- add a credential-free `--plan` contract and run its tests in hosted CI
- document the exact pinned action-root inputs

## Validation
- physical Apple Silicon macOS 26.5.1: all seven live integration targets passed against PostgreSQL 18.6, native RustFS 1.0.0-beta.11, Node 24.19.0, and the pinned upload-artifact 7.0.1, download-artifact 8.0.1, and cache 5.0.5 trees
- cleanup verified zero matching test databases
- `python3 scripts/ci/tests/macos-integration-checks.test.py`
- `bash -n scripts/ci/run-macos-integration-checks.sh`
- workflow lint with the repository resource-extension exception
- `git diff --check`

## Size
- fewer than 250 added lines