### PR TITLE
Fix sign-in finalization and merge-queue authority

### DIFF
--- a/crates/automata-ci-auth-postgres/src/sign_in.rs
+++ b/crates/automata-ci-auth-postgres/src/sign_in.rs
@@ -398,6 +398,27 @@ impl HumanSignInFinalizer for PostgresHumanSignInFinalizer {
                 }
             };
             let now_ms = consumed.observed_at_ms();
+            let admitted_at_ms = database_time_milliseconds(&mut transaction)
+                .await
+                .map_err(map_database_error)?;
+            let admitted_at = validate_caller_time(now, admitted_at_ms)
+                .map_err(|()| SignInFinalizerError::InvalidRequest)?;
+            // Database time is the admission authority. Reject authority that
+            // is already dead before token encryption or any durable write;
+            // the second check immediately before commit closes the time spent
+            // performing those operations.
+            if consumed.expires_at_ms() <= admitted_at_ms
+                || retry
+                    .provider_tokens()
+                    .metadata()
+                    .access_expires_at()
+                    .is_none_or(|expires_at| expires_at <= admitted_at)
+                || retry.membership().valid_until() <= admitted_at
+                || session.idle_expires_at() <= admitted_at
+                || session.expires_at() <= admitted_at
+            {
+                return Ok(FinalizeSignInOutcome::Expired);
+            }
             if let Some(conflict) = pending_session_conflict(&mut transaction, &session).await? {
                 return Ok(FinalizeSignInOutcome::SessionConflict {
                     conflict,
@@ -552,14 +573,11 @@ impl HumanSignInFinalizer for PostgresHumanSignInFinalizer {
             let completed_at_ms = database_time_milliseconds(&mut transaction)
                 .await
                 .map_err(map_database_error)?;
-            validate_caller_time(now, completed_at_ms)
-                .map_err(|()| SignInFinalizerError::InvalidRequest)?;
             let completed_at = timestamp_from_milliseconds(completed_at_ms)
                 .map_err(|()| SignInFinalizerError::IntegrityFailure)?;
-            // The request clock is only skew evidence. Provider and membership
-            // authority must still be live at fresh database time after the KMS
-            // and membership writes, immediately before the session transaction
-            // is allowed to commit.
+            // Provider and membership authority must remain live at fresh
+            // database time after the KMS and membership writes, immediately
+            // before the session transaction is allowed to commit.
             if consumed.expires_at_ms() <= completed_at_ms
                 || retry
                     .provider_tokens()

--- a/crates/automata-ci-core/src/trust.rs
+++ b/crates/automata-ci-core/src/trust.rs
@@ -819,10 +819,10 @@ impl TrustEvidence {
                 base && self.source_actor.is_some() && self.privileged_transition
             }
             TrustEventKind::MergeGroup => {
-                base && self
-                    .upstream
-                    .as_ref()
-                    .is_some_and(|upstream| upstream.evidence_complete && upstream.chain_depth <= 3)
+                base && self.token_recursion == TrustTokenRecursion::Suppressed
+                    && self.upstream.as_ref().is_none_or(|upstream| {
+                        upstream.evidence_complete && upstream.chain_depth <= 3
+                    })
             }
             TrustEventKind::RepositoryDispatch => {
                 base && (self.token_recursion == TrustTokenRecursion::External
@@ -855,6 +855,8 @@ pub enum TrustSourceClass {
     Dependabot,
     /// Complete evidence for another provider automation actor.
     Automation,
+    /// Complete provider-authenticated merge-queue evidence without constituent authority.
+    MergeQueue,
     /// Missing transitive or direct evidence; all authority is denied.
     Incomplete,
 }
@@ -1261,6 +1263,9 @@ fn source_classification(
     if let Some(upstream) = &evidence.upstream {
         return Ok(upstream.source);
     }
+    if evidence.event == TrustEventKind::MergeGroup {
+        return Ok(TrustSourceClass::MergeQueue);
+    }
     let other_automation =
         source_actor.is_some_and(|actor| actor.automation == TrustAutomationKind::Other);
     Ok(if dependabot {
@@ -1313,7 +1318,9 @@ fn authority_decision(
             outputs: TrustOutputAuthority::Untrusted,
             results: TrustResultsAuthority::Untrusted,
         },
-        TrustSourceClass::Dependabot | TrustSourceClass::Automation => TrustAuthorityDecision {
+        TrustSourceClass::Dependabot
+        | TrustSourceClass::Automation
+        | TrustSourceClass::MergeQueue => TrustAuthorityDecision {
             permissions: TrustPermissionAuthority::ReadOnly,
             secrets: TrustSecretAuthority::Denied,
             cache: TrustCacheAuthority::ReadOnly,

--- a/crates/automata-ci-core/tests/trust_snapshot.rs
+++ b/crates/automata-ci-core/tests/trust_snapshot.rs
@@ -58,6 +58,18 @@ fn fork_pull_request(automation: TrustAutomationKind) -> TrustEvidence {
     .with_source_actor(actor("101", automation))
 }
 
+fn merge_queue() -> TrustEvidence {
+    complete_evidence(
+        TrustOriginKind::ProviderWebhook,
+        TrustEventKind::MergeGroup,
+        repository("42", "7"),
+        repository("42", "7"),
+        false,
+        actor("100", TrustAutomationKind::None),
+    )
+    .with_token_recursion(TrustTokenRecursion::Suppressed)
+}
+
 #[derive(Clone, Copy)]
 struct ExpectedAuthority {
     permissions: TrustPermissionAuthority,
@@ -134,6 +146,19 @@ fn multidimensional_source_truth_table_reduces_every_consumer_coherently() {
         (
             same_repository_push(TrustAutomationKind::Other),
             TrustSourceClass::Automation,
+            ExpectedAuthority {
+                permissions: TrustPermissionAuthority::ReadOnly,
+                secrets: TrustSecretAuthority::Denied,
+                cache: TrustCacheAuthority::ReadOnly,
+                environment: TrustEnvironmentAuthority::Denied,
+                oidc: TrustOidcAuthority::Denied,
+                outputs: TrustOutputAuthority::Untrusted,
+                results: TrustResultsAuthority::Untrusted,
+            },
+        ),
+        (
+            merge_queue(),
+            TrustSourceClass::MergeQueue,
             ExpectedAuthority {
                 permissions: TrustPermissionAuthority::ReadOnly,
                 secrets: TrustSecretAuthority::Denied,
@@ -271,15 +296,18 @@ fn transitive_source_restrictions_survive_merge_group_and_workflow_run() {
         (TrustOriginKind::ProviderWebhook, TrustEventKind::MergeGroup),
         (TrustOriginKind::WorkflowRun, TrustEventKind::WorkflowRun),
     ] {
-        let evidence = complete_evidence(
+        let mut evidence = complete_evidence(
             origin,
             event,
             repository("42", "7"),
             repository("42", "7"),
             false,
             actor("100", TrustAutomationKind::None),
-        )
-        .with_upstream(
+        );
+        if event == TrustEventKind::MergeGroup {
+            evidence = evidence.with_token_recursion(TrustTokenRecursion::Suppressed);
+        }
+        let evidence = evidence.with_upstream(
             TrustUpstreamEvidence::new(
                 Sha256Digest::from_bytes([7; 32]),
                 2,

--- a/crates/automata-ci-postgres/tests/auth/sign_in.rs
+++ b/crates/automata-ci-postgres/tests/auth/sign_in.rs
@@ -704,7 +704,11 @@ async fn database_now_minus_sixty_cannot_commit_expired_provider_or_membership_a
             candidate,
             caller_now,
         )?;
-        let finalizer = PostgresHumanSignInFinalizer::new(pool.clone(), encryption);
+        // Expired database authority is terminal before token encryption. An
+        // unavailable key provider makes that ordering observable and prevents
+        // a regression from being hidden by a fast local finalization.
+        let finalizer =
+            PostgresHumanSignInFinalizer::new(pool.clone(), Arc::new(UnavailableKeyProvider));
         assert!(matches!(
             finalizer.finalize(request).await?,
             FinalizeSignInOutcome::Expired

--- a/crates/automata-ci-provider-github/src/event/registry.rs
+++ b/crates/automata-ci-provider-github/src/event/registry.rs
@@ -90,7 +90,7 @@ pub enum GithubEventSourceRule {
     EventRepository,
     /// Source is the pull-request head repository and target is the base repository.
     PullRequestHeadRepository,
-    /// The merge group is target-owned; constituent source repositories require later evidence.
+    /// The merge group is target-owned and remains read-only without constituent evidence.
     MergeGroupTargetWithUnresolvedConstituents,
 }
 

--- a/crates/automata-ci-provider-github/src/event/trust.rs
+++ b/crates/automata-ci-provider-github/src/event/trust.rs
@@ -57,9 +57,10 @@ impl GithubTrustDerivation {
 /// Derives one canonical trust snapshot from a sealed facts-only event envelope.
 ///
 /// The raw JSON body is neither accepted nor inspected. Missing actor
-/// classification, merge-group constituents, dispatch recursion, or resolved
-/// revision evidence produces a deny-all snapshot. Conflicting evidence is
-/// rejected.
+/// classification, dispatch recursion, or resolved revision evidence produces
+/// a deny-all snapshot. A provider-authenticated merge group without constituent
+/// evidence receives conservative merge-queue authority. Conflicting evidence
+/// is rejected.
 ///
 /// # Errors
 ///

--- a/crates/automata-ci-provider-github/tests/event_envelope.rs
+++ b/crates/automata-ci-provider-github/tests/event_envelope.rs
@@ -269,6 +269,25 @@ fn merge_group_inherits_exact_upstream_restrictions() {
 }
 
 #[test]
+fn merge_group_without_constituent_evidence_gets_read_only_queue_authority() {
+    let envelope = seal(&normalize(&merge_group_payload(), "merge_group"));
+    let snapshot = derive_github_trust_snapshot(
+        &envelope,
+        &TrustPolicy::current(),
+        &GithubTrustDerivation::new(),
+    )
+    .expect("merge-group trust");
+
+    assert!(snapshot.evidence_complete());
+    assert_eq!(snapshot.source_class(), TrustSourceClass::MergeQueue);
+    assert_eq!(
+        snapshot.authority().permissions(),
+        TrustPermissionAuthority::ReadOnly
+    );
+    assert_eq!(snapshot.authority().secrets(), TrustSecretAuthority::Denied);
+}
+
+#[test]
 fn repository_dispatch_keeps_arbitrary_payload_out_of_policy_facts() {
     let event = normalize(&repository_dispatch_payload(), "repository_dispatch");
     let envelope = seal(&event);

--- a/crates/automata-ci-provider/src/credential.rs
+++ b/crates/automata-ci-provider/src/credential.rs
@@ -968,6 +968,7 @@ const fn trust_class_code(value: TrustSourceClass) -> u8 {
         TrustSourceClass::Dependabot => 3,
         TrustSourceClass::Automation => 4,
         TrustSourceClass::Incomplete => 5,
+        TrustSourceClass::MergeQueue => 6,
     }
 }
 const fn profile_code(value: WorkloadCredentialProfile) -> u8 {

--- a/crates/automata-ci-workflow-service/src/orchestration.rs
+++ b/crates/automata-ci-workflow-service/src/orchestration.rs
@@ -1438,10 +1438,10 @@ const fn trust_gate_evidence(snapshot: &TrustSnapshot) -> (JobEventTrust, JobSou
         TrustSourceClass::Dependabot | TrustSourceClass::Automation => {
             (JobEventTrust::Untrusted, JobSourceKind::Dependabot)
         }
-        // The legacy gate has no `incomplete` variant. Snapshot authority is
+        // The durable job gate has no `incomplete` variant. Snapshot authority is
         // authoritative and denies environments/secrets; `fork` is retained
         // only as a conservative storage-compatible projection.
-        TrustSourceClass::Fork | TrustSourceClass::Incomplete => {
+        TrustSourceClass::Fork | TrustSourceClass::MergeQueue | TrustSourceClass::Incomplete => {
             (JobEventTrust::Untrusted, JobSourceKind::Fork)
         }
     }
@@ -1479,6 +1479,24 @@ mod source_evidence_tests {
             .expect("valid push trust")
     }
 
+    fn merge_queue() -> TrustSnapshot {
+        TrustPolicy::current()
+            .evaluate(
+                TrustEvidence::new(TrustOriginKind::ProviderWebhook, TrustEventKind::MergeGroup)
+                    .with_original_actor(actor(TrustAutomationKind::None))
+                    .with_repositories(repository("42"), repository("42"))
+                    .with_refs(
+                        "refs/heads/gh-readonly-queue/main/pr-7",
+                        "refs/heads/main",
+                        "refs/heads/gh-readonly-queue/main/pr-7",
+                    )
+                    .with_revisions("group", "target", "group")
+                    .with_fork(false)
+                    .with_token_recursion(TrustTokenRecursion::Suppressed),
+            )
+            .expect("valid merge-queue trust")
+    }
+
     #[test]
     fn exact_github_integer_limit_has_exact_boundaries() {
         assert_eq!(
@@ -1496,7 +1514,7 @@ mod source_evidence_tests {
     }
 
     #[test]
-    fn legacy_job_gate_is_only_a_projection_of_the_exact_snapshot() {
+    fn job_gate_is_only_a_projection_of_the_exact_snapshot() {
         let trusted = same_repository_push(TrustAutomationKind::None);
         assert_eq!(
             trust_gate_evidence(&trusted),
@@ -1508,6 +1526,13 @@ mod source_evidence_tests {
         assert_eq!(
             trust_gate_evidence(&automation),
             (JobEventTrust::Untrusted, JobSourceKind::Dependabot)
+        );
+
+        let merge_queue = merge_queue();
+        assert_eq!(merge_queue.source_class(), TrustSourceClass::MergeQueue);
+        assert_eq!(
+            trust_gate_evidence(&merge_queue),
+            (JobEventTrust::Untrusted, JobSourceKind::Fork)
         );
 
         let incomplete = TrustPolicy::current()

--- a/docs/github-actions-parity/trust-snapshots.md
+++ b/docs/github-actions-parity/trust-snapshots.md
@@ -122,7 +122,7 @@ filled from mutable repository state.
 | Push | full actor/repository/ref/revision tuple, non-fork relationship, and provider-suppressed token recursion |
 | Pull request | full tuple plus the distinct source actor; source and target stay independent |
 | Pull-request target | pull-request evidence plus an explicit privileged-transition marker; source restrictions survive base-context execution |
-| Merge group | full tuple plus complete upstream evidence with depth 1-3 |
+| Merge group | full target-owned tuple and provider-suppressed token recursion; exact constituent evidence with depth 1-3 may further restrict authority |
 | Repository dispatch | full tuple and authenticated external token origin, unless a pinned future policy explicitly permits recursion |
 | Workflow dispatch | full tuple, authenticated caller, stable manifest repository/owner IDs, and non-fork relationship |
 | Schedule | full tuple, scheduler identity, pinned repository evidence, and non-fork relationship |
@@ -144,6 +144,8 @@ Classification occurs only after completeness and consistency checks:
 - `dependabot`: complete same-repository evidence whose source authority is
   Dependabot.
 - `automation`: complete evidence from other restricted provider automation.
+- `merge_queue`: complete provider-authenticated merge-group evidence without
+  exact constituent authority.
 - `incomplete`: one or more event-required dimensions are absent or transitive
   evidence cannot authorize the event.
 
@@ -164,6 +166,7 @@ defaults may be guessed.
 | Fork, explicit future fork-write policy | Requested | Denied | Restore-only | Denied | Denied | Untrusted | Untrusted |
 | Dependabot | Read-only | Denied | Restore-only | Denied | Denied | Untrusted | Untrusted |
 | Other restricted automation | Read-only | Denied | Restore-only | Denied | Denied | Untrusted | Untrusted |
+| Merge queue without constituent evidence | Read-only | Denied | Restore-only | Denied | Denied | Untrusted | Untrusted |
 | Incomplete | Deny all | Denied | Denied | Denied | Denied | Untrusted | Denied |
 
 Fork-write permission, if explicitly enabled by a future pinned policy, changes
@@ -227,8 +230,8 @@ the snapshot's exact authority decision:
 
 Admission or execution fails closed for at least these conditions:
 
-- absent event-required actor, repository, ref, revision, fork, recursion, or
-  upstream evidence;
+- absent event-required actor, repository, ref, revision, fork, or recursion
+  evidence, or absent workflow-run upstream evidence;
 - source/target identity contradicting the fork bit;
 - Dependabot combined with a fork classification;
 - privileged event origin or transition inconsistent with the event kind;
@@ -252,8 +255,8 @@ formatting for actor evidence is intentionally redacted.
 
 The implementation is covered at several boundaries:
 
-- pure truth-table tests for event, fork, Dependabot, automation, incomplete,
-  recursion, privileged-transition, transitive, and policy combinations;
+- pure truth-table tests for event, fork, Dependabot, automation, merge queue,
+  incomplete, recursion, privileged-transition, transitive, and policy combinations;
 - canonical encoding, digest, unsupported-schema, altered-decision, and
   redacted-debug tests;
 - typed GitHub event-envelope tests proving derivation from authenticated


### PR DESCRIPTION
## Summary

- validate database-time sign-in authority before encryption or durable writes, then revalidate immediately before commit
- make the expired-authority regression deterministic with an unavailable key provider
- classify provider-authenticated merge-group heads as conservative `merge_queue` trust when exact constituent evidence is unavailable
- grant merge queues read-only repository authority while denying secrets, writes, environments, OIDC, and trusted outputs
- preserve stricter constituent source restrictions whenever authenticated upstream evidence is available

## Verification

- `cargo fmt --all -- --check`
- targeted expired database-time sign-in regression
- all 20 `automata-ci-auth-postgres` tests
- full `./scripts/ci/run-postgres-tests.sh`
- `cargo test -p automata-ci-core -p automata-ci-provider -p automata-ci-provider-github -p automata-ci-workflow-service --locked`
- `cargo clippy -p automata-ci-core -p automata-ci-provider -p automata-ci-provider-github -p automata-ci-workflow-service --all-targets --all-features --locked -- -D warnings`
