### PR TITLE
Support privately pinned macOS helper identities

### DIFF
--- a/crates/automata-ci-runner/src/product/config.rs
+++ b/crates/automata-ci-runner/src/product/config.rs
@@ -2449,38 +2449,51 @@ fn normalized_volume_uuid(value: &str) -> Option<String> {
 
 fn valid_helper_code_requirement(value: &str) -> bool {
     const PREFIX: &str = "identifier \"";
-    const MIDDLE: &str = "\" and anchor apple generic and certificate leaf[subject.OU] = \"";
+    const DEVELOPER_ID_MIDDLE: &str =
+        "\" and anchor apple generic and certificate leaf[subject.OU] = \"";
+    const PRIVATE_LEAF_MIDDLE: &str = "\" and certificate leaf = H\"";
     let Some(remainder) = value.strip_prefix(PREFIX) else {
         return false;
     };
-    let Some((identifier, team)) = remainder.split_once(MIDDLE) else {
-        return false;
+    let identifier_valid = |identifier: &str| {
+        identifier.len() <= 255
+            && identifier.split('.').count() >= 2
+            && identifier.split('.').all(|component| {
+                !component.is_empty()
+                    && component.len() <= 63
+                    && component
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+                    && component
+                        .as_bytes()
+                        .first()
+                        .is_some_and(u8::is_ascii_alphanumeric)
+                    && component
+                        .as_bytes()
+                        .last()
+                        .is_some_and(u8::is_ascii_alphanumeric)
+            })
     };
-    let Some(team) = team.strip_suffix('"') else {
-        return false;
-    };
-    let identifier_valid = identifier.len() <= 255
-        && identifier.split('.').count() >= 2
-        && identifier.split('.').all(|component| {
-            !component.is_empty()
-                && component.len() <= 63
-                && component
+    if let Some((identifier, team)) = remainder.split_once(DEVELOPER_ID_MIDDLE) {
+        return team.strip_suffix('"').is_some_and(|team| {
+            identifier_valid(identifier)
+                && team.len() == 10
+                && team
                     .bytes()
-                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
-                && component
-                    .as_bytes()
-                    .first()
-                    .is_some_and(u8::is_ascii_alphanumeric)
-                && component
-                    .as_bytes()
-                    .last()
-                    .is_some_and(u8::is_ascii_alphanumeric)
+                    .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
         });
-    identifier_valid
-        && team.len() == 10
-        && team
-            .bytes()
-            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+    }
+    remainder
+        .split_once(PRIVATE_LEAF_MIDDLE)
+        .is_some_and(|(identifier, certificate_hash)| {
+            certificate_hash.strip_suffix('"').is_some_and(|hash| {
+                identifier_valid(identifier)
+                    && hash.len() == 40
+                    && hash
+                        .bytes()
+                        .all(|byte| byte.is_ascii_digit() || matches!(byte, b'A'..=b'F'))
+            })
+        })
 }
 
 #[derive(Clone, Copy, Deserialize)]

--- a/crates/automata-ci-runner/tests/runner_product_config_macos.rs
+++ b/crates/automata-ci-runner/tests/runner_product_config_macos.rs
@@ -191,6 +191,8 @@ fn macos_template_and_state_boundaries_are_pinned_and_disjoint() {
     for weak_requirement in [
         "identifier \"dev.automata.macos-vm-helper\" and anchor apple generic",
         "identifier \"dev.automata.macos-vm-helper\" or anchor apple generic and certificate leaf[subject.OU] = \"ABCDEFGHIJ\"",
+        "identifier \"dev.automata.macos-vm-helper\" and certificate leaf = H\"0123456789abcdeffedcba98765432100a2bc5da\"",
+        "identifier \"dev.automata.macos-vm-helper\" or certificate leaf = H\"0123456789ABCDEFFEDCBA98765432100A2BC5DA\"",
     ] {
         let mut weak_helper = baseline();
         weak_helper["macos_virtualization"]["helper_code_requirement"] =
@@ -200,4 +202,10 @@ fn macos_template_and_state_boundaries_are_pinned_and_disjoint() {
             RunnerProductConfigError::InvalidProvider
         );
     }
+
+    let mut private_identity = baseline();
+    private_identity["macos_virtualization"]["helper_code_requirement"] = serde_json::json!(
+        "identifier \"dev.automata.macos-vm-helper\" and certificate leaf = H\"0123456789ABCDEFFEDCBA98765432100A2BC5DA\""
+    );
+    parse(&private_identity).expect("exact private signing leaf is accepted");
 }

--- a/crates/automata-ci-sandbox-macos/src/provider.rs
+++ b/crates/automata-ci-sandbox-macos/src/provider.rs
@@ -1349,38 +1349,51 @@ fn normalized_volume_uuid(value: &str) -> Option<String> {
 
 fn valid_helper_code_requirement(value: &str) -> bool {
     const PREFIX: &str = "identifier \"";
-    const MIDDLE: &str = "\" and anchor apple generic and certificate leaf[subject.OU] = \"";
+    const DEVELOPER_ID_MIDDLE: &str =
+        "\" and anchor apple generic and certificate leaf[subject.OU] = \"";
+    const PRIVATE_LEAF_MIDDLE: &str = "\" and certificate leaf = H\"";
     let Some(remainder) = value.strip_prefix(PREFIX) else {
         return false;
     };
-    let Some((identifier, team)) = remainder.split_once(MIDDLE) else {
-        return false;
+    let identifier_valid = |identifier: &str| {
+        identifier.len() <= 255
+            && identifier.split('.').count() >= 2
+            && identifier.split('.').all(|component| {
+                !component.is_empty()
+                    && component.len() <= 63
+                    && component
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+                    && component
+                        .as_bytes()
+                        .first()
+                        .is_some_and(u8::is_ascii_alphanumeric)
+                    && component
+                        .as_bytes()
+                        .last()
+                        .is_some_and(u8::is_ascii_alphanumeric)
+            })
     };
-    let Some(team) = team.strip_suffix('"') else {
-        return false;
-    };
-    let identifier_valid = identifier.len() <= 255
-        && identifier.split('.').count() >= 2
-        && identifier.split('.').all(|component| {
-            !component.is_empty()
-                && component.len() <= 63
-                && component
+    if let Some((identifier, team)) = remainder.split_once(DEVELOPER_ID_MIDDLE) {
+        return team.strip_suffix('"').is_some_and(|team| {
+            identifier_valid(identifier)
+                && team.len() == 10
+                && team
                     .bytes()
-                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
-                && component
-                    .as_bytes()
-                    .first()
-                    .is_some_and(u8::is_ascii_alphanumeric)
-                && component
-                    .as_bytes()
-                    .last()
-                    .is_some_and(u8::is_ascii_alphanumeric)
+                    .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
         });
-    identifier_valid
-        && team.len() == 10
-        && team
-            .bytes()
-            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+    }
+    remainder
+        .split_once(PRIVATE_LEAF_MIDDLE)
+        .is_some_and(|(identifier, certificate_hash)| {
+            certificate_hash.strip_suffix('"').is_some_and(|hash| {
+                identifier_valid(identifier)
+                    && hash.len() == 40
+                    && hash
+                        .bytes()
+                        .all(|byte| byte.is_ascii_digit() || matches!(byte, b'A'..=b'F'))
+            })
+        })
 }
 
 #[derive(serde::Deserialize)]
@@ -1753,15 +1766,21 @@ mod tests {
     }
 
     #[test]
-    fn helper_requirement_is_exactly_identifier_anchor_and_team() {
+    fn helper_requirement_is_an_exact_apple_or_private_identity() {
         assert!(valid_helper_code_requirement(
             "identifier \"dev.automata.macos-vm-helper\" and anchor apple generic and certificate leaf[subject.OU] = \"ABCDEFGHIJ\""
+        ));
+        assert!(valid_helper_code_requirement(
+            "identifier \"dev.automata.macos-vm-helper\" and certificate leaf = H\"0123456789ABCDEFFEDCBA98765432100A2BC5DA\""
         ));
         for invalid in [
             "identifier \"dev.automata.macos-vm-helper\" and anchor apple generic",
             "identifier \"dev.automata.macos-vm-helper\" or anchor apple generic and certificate leaf[subject.OU] = \"ABCDEFGHIJ\"",
             "identifier \"dev..helper\" and anchor apple generic and certificate leaf[subject.OU] = \"ABCDEFGHIJ\"",
             "identifier \"dev.automata.helper\" and anchor apple generic and certificate leaf[subject.OU] = \"teamid1234\"",
+            "identifier \"dev.automata.helper\" and certificate leaf = H\"0123456789abcdeffedcba98765432100a2bc5da\"",
+            "identifier \"dev.automata.helper\" or certificate leaf = H\"0123456789ABCDEFFEDCBA98765432100A2BC5DA\"",
+            "identifier \"dev.automata.helper\" and certificate leaf = H\"0123456789ABCDEFFEDCBA98765432100A2BC5D\"",
         ] {
             assert!(!valid_helper_code_requirement(invalid));
         }

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -99,9 +99,44 @@ and a strict designated requirement, for example
 `identifier "dev.automata.macos-vm-helper" and anchor apple generic and
 certificate leaf[subject.OU] = "ABCDEFGHIJ"`. Replace `ABCDEFGHIJ` with the
 exact ten-character signing Team ID; this conjunctive grammar is the only
-accepted configured requirement. Production must use a reviewed Developer ID
-signature. An ad-hoc signature may be used only to inspect build and entitlement
-shape and is intentionally rejected by product configuration.
+accepted Developer ID requirement.
+
+A private fleet may instead sign with a reviewed private code-signing identity
+and pin the exact leaf certificate SHA-1 used by Apple's
+[requirement language](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html):
+
+```text
+identifier "dev.automata.macos-vm-helper" and certificate leaf = H"0123456789ABCDEFFEDCBA98765432100A2BC5DA"
+```
+
+The hash is exactly 40 uppercase hexadecimal characters. It identifies the
+certificate, not the helper bytes; `helper_sha256` independently pins the
+complete executable. The private key must remain outside the runner service
+identity, and rotating the certificate requires an explicit configuration
+update. Apple trust-store installation is neither required nor consulted by
+this exact-leaf requirement. A signer that reads the private key directly can
+produce the Mach-O signature without adding that certificate to the host trust
+store. For example, `rcodesign` accepts a password file rather than exposing
+the PKCS#12 password in the process arguments:
+
+```console
+rcodesign sign \
+  --p12-file /offline/path/helper-signing.p12 \
+  --p12-password-file /offline/path/helper-signing.password \
+  --binary-identifier dev.automata.macos-vm-helper \
+  --code-signature-flags runtime \
+  --entitlements-xml-file crates/automata-ci-sandbox-macos/swift/virtualization.entitlements \
+  --timestamp-url none \
+  crates/automata-ci-sandbox-macos/swift/.build/release/automata-macos-vm-helper
+```
+
+`rcodesign` is an independently distributed tool, not an Automata runtime
+dependency. Pin and verify the reviewed release before using it. Developer ID
+remains the distribution profile for
+software delivered to third-party Macs because it supplies Apple/Gatekeeper
+identity and notarization. An ad-hoc signature may be used only to inspect
+build and entitlement shape and is intentionally rejected by both accepted
+product grammars.
 
 ## Provision bounded host storage
 


### PR DESCRIPTION
## Summary

- retain the exact Developer ID helper requirement
- accept an exact private leaf-certificate SHA-1 requirement for controlled runner fleets
- document private signing, key custody, certificate rotation, and independent helper-byte pinning

## Security model

The private grammar accepts only `identifier "…" and certificate leaf = H"…"`, with an exact 40-character uppercase hash. Ad-hoc signatures, lowercase or truncated hashes, and disjunctive requirements remain invalid. The existing `helper_sha256` pin independently authenticates the full helper executable.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p automata-ci-runner --test runner --locked --no-fail-fast` (105 passed)
- `cargo clippy -p automata-ci-runner -p automata-ci-sandbox-macos --lib --tests --all-features --locked -- -D warnings`
- physical Apple Silicon: private self-owned code-signing leaf, hardened runtime, exact virtualization entitlement, Apple `codesign --verify --strict=all` with the configured requirement
- physical Apple Silicon: allowlisted vsock runtime-proxy integration passed against the privately signed helper

The full shipped-runner acceptance is being repeated with this branch and the root-owned helper; results will be added here.