### PR TITLE
Allow first macOS attempt creation

### DIFF
--- a/crates/automata-ci-sandbox-macos/src/filesystem.rs
+++ b/crates/automata-ci-sandbox-macos/src/filesystem.rs
@@ -83,7 +83,11 @@ impl SecureRoot {
 
     pub(crate) fn remove_owned_tree(&self, target: &TargetPath) -> io::Result<()> {
         let components = self.relative_components(target)?;
-        let (parent, name) = self.open_parent(&components)?;
+        let (parent, name) = match self.open_parent(&components) {
+            Ok(parent) => parent,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
         let directory = match openat(&parent, &name, DIRECTORY_FLAGS, Mode::empty()) {
             Ok(directory) => directory,
             Err(Errno::NOENT) => return Ok(()),
@@ -208,4 +212,40 @@ fn component_name(component: Component<'_>) -> io::Result<OsString> {
 
 fn is_dot(name: &CStr) -> bool {
     matches!(name.to_bytes(), b"." | b"..")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, time::SystemTime};
+
+    use automata_ci_execution::TargetPath;
+
+    use super::SecureRoot;
+
+    #[test]
+    fn removing_an_absent_tree_with_an_absent_parent_is_idempotent() {
+        let parent = fs::canonicalize(std::env::temp_dir()).expect("canonical temporary root");
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system clock after Unix epoch")
+            .as_nanos();
+        let path = parent.join(format!(
+            "automata-macos-secure-root-{}-{unique}",
+            std::process::id()
+        ));
+        let root_target = TargetPath::posix(path.to_string_lossy().into_owned()).expect("root");
+        let attempt_path = path.join("attempts/first");
+        let attempt =
+            TargetPath::posix(attempt_path.to_string_lossy().into_owned()).expect("attempt");
+        let root = SecureRoot::open_or_create(&path, root_target).expect("secure root");
+
+        root.remove_owned_tree(&attempt)
+            .expect("an absent parent means the tree is already absent");
+        root.ensure_owned_directory(&attempt)
+            .expect("the following create makes the missing parent hierarchy");
+        assert!(attempt_path.is_dir());
+
+        drop(root);
+        fs::remove_dir_all(path).expect("remove test root");
+    }
 }


### PR DESCRIPTION
## Summary

- treat a missing parent as an already-absent tree in secure macOS cleanup
- preserve fail-closed behavior for symlinks, non-directories, ownership mismatches, and other errors
- cover the fresh-root remove-then-create sequence used by the provider

## Why

The macOS provider removes a possibly stale attempt before creating it. On a fresh provider root, the `attempts` parent does not exist. `remove_owned_tree` returned `NotFound` while opening that parent, so environment-profile admission failed before the first VM could be launched.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- physical Apple Silicon focused unit and full process acceptance will be attached after combining this isolated fix with #506 and #507 in a disposable worktree.