### PR TITLE
Shorten local snapshot fixture paths on macOS

### DIFF
--- a/crates/automata-ci-local/src/snapshot.rs
+++ b/crates/automata-ci-local/src/snapshot.rs
@@ -3445,7 +3445,7 @@ mod tests {
 
     impl Fixture {
         fn new() -> Self {
-            let root = std::env::temp_dir().join(format!("als-{}", Uuid::new_v4().simple()));
+            let root = Self::temporary_root("als-");
             fs::create_dir(&root).expect("create fixture root");
             let fixture = Self { root };
             fixture.git(&["init", "--quiet"]);
@@ -3455,7 +3455,7 @@ mod tests {
         }
 
         fn clone_from(source: &Path) -> Self {
-            let root = std::env::temp_dir().join(format!("als-clone-{}", Uuid::new_v4().simple()));
+            let root = Self::temporary_root("als-clone-");
             let output = Command::new("git")
                 .args(["clone", "--quiet"])
                 .arg(source)
@@ -3464,6 +3464,13 @@ mod tests {
                 .expect("clone fixture");
             assert!(output.status.success(), "git clone failed");
             Self { root }
+        }
+
+        fn temporary_root(prefix: &str) -> PathBuf {
+            let identifier = Uuid::new_v4().simple().to_string();
+            // One fixture creates a pathname Unix socket. Keep its randomized
+            // directory component short enough for Darwin's 103-byte limit.
+            std::env::temp_dir().join(format!("{prefix}{}", &identifier[..16]))
         }
 
         fn path(&self) -> &Path {


### PR DESCRIPTION
The macOS workspace gate failed before its intended special-file assertion because the randomized fixture directory made the Unix socket pathname exceed Darwin SUN_LEN. Keep the randomized fixture identity while shortening its directory token so the unchanged socket/snapshot contract runs on macOS.

Validated:
- cargo fmt --all -- --check
- cargo test -p automata-ci-local --lib --locked snapshot::tests::non_unicode_fifo_and_socket_entries_fail_closed (Linux)
- cargo clippy -p automata-ci-local --all-targets --all-features --locked -- -D warnings (Linux)
- cargo test -p automata-ci-local --lib --all-features --locked (physical Apple Silicon macOS: 59 passed, 1 intentionally ignored)
- ./scripts/ci/run-macos-checks.sh (physical Apple Silicon macOS; complete gate passed, including release builds of all three Swift executables)