### PR TITLE
Add a bounded macOS physical acceptance entrypoint

### DIFF
--- a/.ci/workflows/ci.yml
+++ b/.ci/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           ./scripts/ci/lint-workflows.sh
           ./scripts/ci/lint-ci-security.sh
           python3 scripts/ci/tests/macos-integration-checks.test.py
+          python3 scripts/ci/tests/macos-physical-checks.test.py
           python3 scripts/ci/tests/windows-image-pipeline.test.py
           cargo clippy --workspace --lib --bins --all-features --locked -- -D warnings
           cargo test \

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -1215,10 +1215,12 @@ current baseline.
 - [ ] Decide whether Intel/x64 is a later supported profile.
 - [x] Contain the whole process tree inside the disposable VM and enforce the
   sealed guest process ceiling.
-- [x] Add macOS Keychain custody and strict Developer ID helper verification.
+- [x] Add macOS Keychain custody and strict signed-helper verification for
+  either Developer ID distribution or an exact private-fleet leaf identity.
 - [ ] Add Xcode and toolchain profiles.
 - [ ] Add macOS acceptance jobs.
-- [ ] Add cleanup and recovery tests.
+- [x] Add physical clone cleanup, runner cancellation, and live-orphan startup
+  recovery tests.
 
 ### Architecture and image breadth
 

--- a/docs/github-actions-parity/github-actions-parity-09-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-09-platforms.md
@@ -284,11 +284,11 @@ Remaining tasks:
 
 Acceptance:
 
-- [ ] The shipped VM runner on Apple Silicon macOS 15 reports
+- [x] The shipped VM runner on Apple Silicon macOS 15 reports
   `runner.os=macOS` and `runner.arch=ARM64`, completes zero-resource Bash and
   `sh` jobs plus pinned Node 20/24 repository actions, and rejects services and
   containers before launch.
-- [ ] Self-hosted macOS 15 differential fixtures cover stable environment,
+- [x] Self-hosted macOS 15 differential fixtures cover stable environment,
   working-directory, command-file, output, timeout, cancellation, and
   conclusion behavior.
 - [ ] Physical Apple Silicon acceptance proves VM template identity,

--- a/docs/github-actions-parity/github-actions-parity-11c-integration-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-11c-integration-platforms.md
@@ -119,26 +119,28 @@ Acceptance:
 **Owner:** P with R and X review. **Size:** L. **Dependencies:** IT-01, IT-07,
 FND-02, PLAT-02.
 
-**Primary scope:** the accepted Apple Silicon macOS 15+ Bash/sh slice; actions,
-containers, Intel, signing jobs, and Xcode profiles stay outside this package.
+**Primary scope:** the accepted Apple Silicon macOS 15+ Bash/sh and configured
+Node-action slice; containers, Intel, signing jobs, and broader Xcode profiles
+stay outside this package.
 
 Tasks:
 
-- [ ] Implement the common adapter contract through the disposable macOS VM
+- [x] Implement the common adapter contract through the disposable macOS VM
   provider on a dedicated Apple Silicon macOS 15+ host.
-- [ ] Record exact OS/build, architecture, runner, shell, optional Python/pwsh,
+- [x] Record exact OS/build, architecture, runner, shell, optional Python/pwsh,
   identity, filesystem, network, and cleanup boundaries.
-- [ ] Run only the admitted VM-backed `run:` smoke without action/container
-  substitution.
-- [ ] Prove process-tree termination, workspace cleanup, restart handling, and
+- [x] Run the admitted VM-backed `run:` and configured Node 20/24 repository
+  action smoke without host or container substitution.
+- [x] Prove process-tree termination, workspace cleanup, restart handling, and
   no persistent keychain/developer credential access.
 
 Acceptance:
 
-- [ ] One ARM64 VM smoke passes through shipped processes and cleans all
+- [x] One ARM64 VM smoke passes through shipped processes and cleans all
   owned state.
-- [ ] Intel, actions, containers, signing, and Xcode are still rejected or
-  represented by later product packages.
+- [x] Intel, containers, signing, and broader Xcode profiles are still rejected
+  or represented by later product packages; configured Node actions are part
+  of the accepted slice.
 
 ### IT-12 — Multi-replica and fault topology adapter
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -7,12 +7,12 @@ no migration from a noncurrent schema, and no host-shared resource mode.
 
 | Field | Value |
 | --- | --- |
-| Status | Component complete; physical-host production qualification remains |
+| Status | Component complete for the advertised VM/action slice; a continuous physical-host gate remains |
 | Execution boundary | One cold-booted disposable VM per job |
 | Network | Disabled |
-| Available steps | Bash and `sh`; optional configured Python and PowerShell Core |
-| Unavailable | Actions, containers, services, GPUs, and ephemeral-disk claims |
-| Required acceptance | Sealed template, signed helper, dedicated APFS storage, and the opt-in physical-host suite |
+| Available steps | Bash and `sh`; composite, repository, and admitted local actions on configured Node generations; optional Python and PowerShell Core |
+| Unavailable | Docker actions, job/service containers, Intel, GPUs, ephemeral-disk claims, signing jobs, and broader Xcode profiles |
+| Required acceptance | Sealed template, signed helper, dedicated APFS storage, and the opt-in physical-host success, timeout, cancellation, proxy, and recovery suite |
 
 ## Why Virtualization.framework
 
@@ -432,11 +432,16 @@ runner must also execute the ignored
 `macos_vm_runner_process_e2e::shipped_runner_process_executes_a_claimed_isolated_job_with_action_runtimes`
 test with the eight `AUTOMATA_MACOS_VM_*` artifact and storage
 variables. That test verifies no Ethernet device, no host helper path,
-memory/vCPU sizing, the sealed process ceiling, configured Node 20 and Node 24
-admission and execution, shell/output behavior, and clone cleanup. Deployment
-qualification must additionally inject
-process-ceiling exhaustion, pipe loss, and helper crashes, reopen the journal,
-and run repeated clean jobs.
+memory/vCPU sizing, process-ceiling exhaustion, configured Node 20 and Node 24
+admission and execution, immutable repository-action materialization,
+shell/command-file/output behavior, timeout process-group termination, and
+clone cleanup. The companion cancellation test waits for two live `Running`
+heartbeats, delivers and acknowledges a durable cancellation command, and
+requires a bounded `Cancelled` result and slot release. The provider recovery
+test kills the process owning a live VM, reopens the journal, and requires
+startup reconciliation to remove the exact orphan. A continuous protected
+physical lane, an independent helper-crash-at-transition matrix, and a retained
+repeated-clean soak remain deployment work.
 
 Create `/Volumes/AutomataVM/e2e-state` as an empty `0700` directory owned by
 the physical runner service account before running the command below.
@@ -453,6 +458,14 @@ AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES=<exact-volume-quota-bytes> \
 cargo test --locked -p automata-ci-runner --test runner -- \
   macos_vm_runner_process_e2e::shipped_runner_process_executes_a_claimed_isolated_job_with_action_runtimes \
   --ignored --nocapture --test-threads=1
+
+cargo test --locked -p automata-ci-runner --test runner -- \
+  macos_vm_runner_process_e2e::shipped_runner_process_cancels_a_running_isolated_job \
+  --ignored --nocapture --test-threads=1
+
+cargo test --locked -p automata-ci-sandbox-macos --test macos_provider -- \
+  provider_reconciles_a_live_orphan_after_owner_process_loss \
+  --ignored --exact --nocapture
 ```
 
 The runtime proxy has a separate physical contract test. It starts a temporary

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -447,26 +447,22 @@ Create `/Volumes/AutomataVM/e2e-state` as an empty `0700` directory owned by
 the physical runner service account before running the command below.
 
 ```console
-AUTOMATA_MACOS_VM_HELPER=/Library/Automata/bin/automata-macos-vm-helper \
-AUTOMATA_MACOS_VM_HELPER_SHA256=<helper-sha256> \
-AUTOMATA_MACOS_VM_HELPER_REQUIREMENT='<strict-designated-requirement>' \
-AUTOMATA_MACOS_VM_TEMPLATE_MANIFEST=/Volumes/AutomataVM/templates/macos-15-arm64-v1/manifest.json \
-AUTOMATA_MACOS_VM_TEMPLATE_SHA256=<manifest-sha256> \
-AUTOMATA_MACOS_VM_STORAGE_ROOT=/Volumes/AutomataVM/e2e-state \
-AUTOMATA_MACOS_VM_STORAGE_VOLUME_UUID=<uppercase-volume-uuid> \
-AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES=<exact-volume-quota-bytes> \
-cargo test --locked -p automata-ci-runner --test runner -- \
-  macos_vm_runner_process_e2e::shipped_runner_process_executes_a_claimed_isolated_job_with_action_runtimes \
-  --ignored --nocapture --test-threads=1
-
-cargo test --locked -p automata-ci-runner --test runner -- \
-  macos_vm_runner_process_e2e::shipped_runner_process_cancels_a_running_isolated_job \
-  --ignored --nocapture --test-threads=1
-
-cargo test --locked -p automata-ci-sandbox-macos --test macos_provider -- \
-  provider_reconciles_a_live_orphan_after_owner_process_loss \
-  --ignored --exact --nocapture
+export AUTOMATA_MACOS_VM_HELPER=/Library/Automata/bin/automata-macos-vm-helper
+export AUTOMATA_MACOS_VM_HELPER_SHA256=<helper-sha256>
+export AUTOMATA_MACOS_VM_HELPER_REQUIREMENT='<strict-designated-requirement>'
+export AUTOMATA_MACOS_VM_TEMPLATE_MANIFEST=/Volumes/AutomataVM/templates/macos-15-arm64-v1/manifest.json
+export AUTOMATA_MACOS_VM_TEMPLATE_SHA256=<manifest-sha256>
+export AUTOMATA_MACOS_VM_STORAGE_ROOT=/Volumes/AutomataVM/e2e-state
+export AUTOMATA_MACOS_VM_STORAGE_VOLUME_UUID=<uppercase-volume-uuid>
+export AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES=<exact-volume-quota-bytes>
+./scripts/ci/run-macos-physical-checks.sh
 ```
+
+The entrypoint runs the shipped-runner success/timeout and cancellation matrix,
+live-orphan recovery, and the allowlisted runtime-proxy probe serially. Set
+`AUTOMATA_MACOS_PHYSICAL_REPETITIONS` from 1 through 10 for a bounded repeated
+runner soak. It refuses a `CARGO_TARGET_DIR` on the VM storage filesystem so
+build artifacts cannot consume the clone-capacity safety margin.
 
 The runtime proxy has a separate physical contract test. It starts a temporary
 loopback HTTP origin on the host, boots the sealed NIC-less guest through the

--- a/scripts/ci/run-macos-physical-checks.sh
+++ b/scripts/ci/run-macos-physical-checks.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  printf '%s\n' \
+    'error: physical macOS checks require Bash 4 or newer; install Homebrew bash and put /opt/homebrew/bin first in PATH' \
+    >&2
+  exit 2
+fi
+
+usage() {
+  printf 'usage: %s [--plan]\n' "$0" >&2
+}
+
+plan=false
+if (( $# > 0 )); then
+  if (( $# != 1 )) || [[ "$1" != --plan ]]; then
+    usage
+    exit 2
+  fi
+  plan=true
+fi
+
+repetitions=${AUTOMATA_MACOS_PHYSICAL_REPETITIONS:-1}
+if [[ ! "$repetitions" =~ ^[1-9][0-9]*$ ]] || (( repetitions > 10 )); then
+  printf '%s\n' 'error: AUTOMATA_MACOS_PHYSICAL_REPETITIONS must be an integer from 1 through 10' >&2
+  exit 2
+fi
+
+repository_root="$(git rev-parse --show-toplevel)"
+cd "$repository_root"
+
+run_command() {
+  if [[ "$plan" == true ]]; then
+    printf 'RUN'
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+run_test() {
+  local label=$1
+  shift
+  printf 'physical macOS: %s\n' "$label" >&2
+  run_command "$@"
+}
+
+assert_directory_empty() {
+  local label=$1
+  local directory=$2
+  if [[ ! -d "$directory" ]]; then
+    printf 'error: %s directory does not exist: %s\n' "$label" "$directory" >&2
+    exit 2
+  fi
+  if [[ -n "$(find "$directory" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    printf 'error: %s directory is not empty: %s\n' "$label" "$directory" >&2
+    exit 2
+  fi
+}
+
+if [[ "$plan" != true ]]; then
+  if [[ "$(uname -s)" != Darwin || "$(uname -m)" != arm64 ]]; then
+    printf '%s\n' 'error: physical macOS checks require an Apple Silicon macOS host' >&2
+    exit 2
+  fi
+
+  required_environment=(
+    AUTOMATA_MACOS_VM_HELPER
+    AUTOMATA_MACOS_VM_HELPER_SHA256
+    AUTOMATA_MACOS_VM_HELPER_REQUIREMENT
+    AUTOMATA_MACOS_VM_TEMPLATE_MANIFEST
+    AUTOMATA_MACOS_VM_TEMPLATE_SHA256
+    AUTOMATA_MACOS_VM_STORAGE_ROOT
+    AUTOMATA_MACOS_VM_STORAGE_VOLUME_UUID
+    AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES
+  )
+  for name in "${required_environment[@]}"; do
+    if [[ -z "${!name:-}" ]]; then
+      printf 'error: %s is required\n' "$name" >&2
+      exit 2
+    fi
+  done
+
+  export CARGO_INCREMENTAL=0
+  export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-$repository_root/target/macos-physical}
+  install -d -m 0700 "$CARGO_TARGET_DIR"
+  if [[ "$(stat -f %d "$CARGO_TARGET_DIR")" == \
+    "$(stat -f %d "$AUTOMATA_MACOS_VM_STORAGE_ROOT")" ]]; then
+    printf '%s\n' \
+      'error: CARGO_TARGET_DIR must not share the VM storage filesystem; build artifacts consume required clone headroom' \
+      >&2
+    exit 2
+  fi
+  available_kib=$(df -Pk "$CARGO_TARGET_DIR" | awk 'END {print $4}')
+  if (( available_kib < 8 * 1024 * 1024 )); then
+    printf 'error: CARGO_TARGET_DIR requires at least 8 GiB available; found %s KiB\n' \
+      "$available_kib" >&2
+    exit 2
+  fi
+
+  export AUTOMATA_MACOS_PHYSICAL_HELPER=$AUTOMATA_MACOS_VM_HELPER
+  export AUTOMATA_MACOS_PHYSICAL_MANIFEST=$AUTOMATA_MACOS_VM_TEMPLATE_MANIFEST
+  export AUTOMATA_MACOS_PHYSICAL_ATTEMPT_ROOT=${AUTOMATA_MACOS_PHYSICAL_ATTEMPT_ROOT:-$(dirname "$AUTOMATA_MACOS_VM_STORAGE_ROOT")/proxy-tests}
+  install -d -m 0700 "$AUTOMATA_MACOS_PHYSICAL_ATTEMPT_ROOT"
+  assert_directory_empty 'provider attempts' "$AUTOMATA_MACOS_VM_STORAGE_ROOT/attempts"
+  assert_directory_empty 'runtime proxy attempts' "$AUTOMATA_MACOS_PHYSICAL_ATTEMPT_ROOT"
+fi
+
+for ((iteration = 1; iteration <= repetitions; iteration++)); do
+  run_test "shipped runner success, timeout, and cancellation ($iteration/$repetitions)" \
+    cargo test -p automata-ci-runner --test runner --locked \
+    macos_vm_runner_process_e2e:: -- \
+    --ignored --nocapture --test-threads=1
+done
+run_test 'live VM orphan recovery after owner loss' \
+  cargo test -p automata-ci-sandbox-macos --test macos_provider --locked \
+  provider_reconciles_a_live_orphan_after_owner_process_loss -- \
+  --ignored --exact --nocapture --test-threads=1
+run_test 'allowlisted Virtio-socket runtime proxy' \
+  cargo test -p automata-ci-sandbox-macos --lib --locked \
+  runtime_proxy::tests::physical_guest_reaches_an_allowlisted_origin_through_the_vsock_proxy -- \
+  --ignored --exact --nocapture --test-threads=1
+
+if [[ "$plan" != true ]]; then
+  assert_directory_empty 'provider attempts' "$AUTOMATA_MACOS_VM_STORAGE_ROOT/attempts"
+  assert_directory_empty 'runtime proxy attempts' "$AUTOMATA_MACOS_PHYSICAL_ATTEMPT_ROOT"
+fi

--- a/scripts/ci/tests/macos-physical-checks.test.py
+++ b/scripts/ci/tests/macos-physical-checks.test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import os
+import pathlib
+import subprocess
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+RUNNER = ROOT / "scripts" / "ci" / "run-macos-physical-checks.sh"
+
+
+class MacosPhysicalChecksTest(unittest.TestCase):
+    def run_script(
+        self, *arguments: str, environment: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        merged_environment = os.environ.copy()
+        if environment is not None:
+            merged_environment.update(environment)
+        return subprocess.run(
+            [str(RUNNER), *arguments],
+            cwd=ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+            env=merged_environment,
+        )
+
+    def test_plan_is_complete_serial_and_secret_safe(self) -> None:
+        result = self.run_script("--plan")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = [line for line in result.stdout.splitlines() if line.startswith("RUN ")]
+        self.assertEqual(len(commands), 3, result.stdout)
+        for identity in (
+            "automata-ci-runner --test runner",
+            "automata-ci-sandbox-macos --test macos_provider",
+            "automata-ci-sandbox-macos --lib",
+        ):
+            self.assertTrue(any(identity in command for command in commands), identity)
+        for command in commands:
+            self.assertIn("--test-threads=1", command)
+        self.assertIn("macos_vm_runner_process_e2e::", commands[0])
+        self.assertIn("provider_reconciles_a_live_orphan", commands[1])
+        self.assertIn("physical_guest_reaches_an_allowlisted_origin", commands[2])
+        self.assertNotIn("HELPER_REQUIREMENT=", result.stdout)
+        self.assertNotIn("STORAGE_QUOTA_BYTES=", result.stdout)
+
+    def test_plan_repeats_only_the_shipped_runner_matrix(self) -> None:
+        result = self.run_script(
+            "--plan", environment={"AUTOMATA_MACOS_PHYSICAL_REPETITIONS": "2"}
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = [line for line in result.stdout.splitlines() if line.startswith("RUN ")]
+        self.assertEqual(len(commands), 4, result.stdout)
+        self.assertEqual(
+            sum("automata-ci-runner --test runner" in command for command in commands), 2
+        )
+        self.assertEqual(
+            sum("--test macos_provider" in command for command in commands), 1
+        )
+
+    def test_invalid_repetition_count_fails_closed(self) -> None:
+        result = self.run_script(
+            "--plan", environment={"AUTOMATA_MACOS_PHYSICAL_REPETITIONS": "0"}
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("integer from 1 through 10", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_unknown_arguments_fail_closed(self) -> None:
+        result = self.run_script("--unknown")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("usage:", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- align the macOS support and parity documentation with the physically qualified Bash/sh, configured Node-action, timeout, cancellation, proxy, and recovery slice
- add one bounded, serial physical-host entrypoint with storage-headroom and clean-state preflights
- add a secret-safe plan mode and exercise it in ordinary hosted CI

## Validation

- `bash -n scripts/ci/run-macos-physical-checks.sh`
- `python3 scripts/ci/tests/macos-physical-checks.test.py`
- `python3 scripts/ci/tests/macos-integration-checks.test.py`
- `git diff --check`
- physical Apple Silicon, exact commit `4589a8a872ec25b0eefc28501b62818dfbd0890b`: full entrypoint passed in 948.969s
  - shipped-runner success/timeout and cancellation: 2 passed in 488.86s
  - live-orphan recovery after owner loss: 1 passed in 404.71s
  - allowlisted Virtio-socket proxy: 1 passed in 8.55s
  - post-run: zero provider attempts, zero proxy attempts, and zero helper processes; VM volume restored to 72 GiB available
