### PR TITLE
Provider platform B4g: centralize configuration materialization

### DIFF
--- a/crates/automata-ci-provider-delivery/src/configuration.rs
+++ b/crates/automata-ci-provider-delivery/src/configuration.rs
@@ -1,0 +1,347 @@
+//! Provider-neutral configuration application through registered adapter factories.
+
+use std::{fmt, sync::Arc};
+
+use automata_ci_provider::{
+    ProviderConfigurationRevision, ProviderConnectionDraft, ProviderFactoryRegistry,
+    ProviderFactoryRegistryError, ProviderInstanceDraft, ProviderInstanceId,
+    ProviderManifestRepository, ProviderRepositoryError, ProviderSaveOutcome,
+};
+use thiserror::Error;
+
+/// Validates and atomically applies provider instance and connection revisions.
+pub struct ProviderConfigurationService {
+    factories: ProviderFactoryRegistry,
+    manifests: Arc<dyn ProviderManifestRepository>,
+}
+
+impl ProviderConfigurationService {
+    /// Composes the complete static adapter registry with canonical durable storage.
+    #[must_use]
+    pub fn new(
+        factories: ProviderFactoryRegistry,
+        manifests: Arc<dyn ProviderManifestRepository>,
+    ) -> Self {
+        Self {
+            factories,
+            manifests,
+        }
+    }
+
+    /// Validates and stores one first or contiguous provider-instance revision.
+    ///
+    /// The capability digest is derived exclusively from the selected adapter.
+    ///
+    /// # Errors
+    ///
+    /// Returns a closed factory or repository failure without provider secrets.
+    pub async fn apply_instance(
+        &self,
+        draft: ProviderInstanceDraft,
+    ) -> Result<ProviderSaveOutcome, ProviderConfigurationServiceError> {
+        let record = self
+            .factories
+            .materialize_instance(draft)
+            .map_err(ProviderConfigurationServiceError::Factory)?;
+        self.manifests
+            .save_instance(record)
+            .await
+            .map_err(ProviderConfigurationServiceError::Repository)
+    }
+
+    /// Loads the current provider revision, validates a connection draft, and stores it.
+    ///
+    /// Provider configuration and capability digests are copied from the
+    /// current decrypted manifest. The caller's expected revision must match
+    /// that pointer, preventing a new connection from selecting credentials
+    /// superseded by a provider rotation.
+    ///
+    /// # Errors
+    ///
+    /// Rejects absent provider evidence, adapter-policy drift, or repository failure.
+    pub async fn apply_connection(
+        &self,
+        instance_id: ProviderInstanceId,
+        provider_revision: ProviderConfigurationRevision,
+        draft: ProviderConnectionDraft,
+    ) -> Result<ProviderSaveOutcome, ProviderConfigurationServiceError> {
+        let record = self
+            .manifests
+            .current_instance(instance_id)
+            .await
+            .map_err(ProviderConfigurationServiceError::Repository)?
+            .ok_or(ProviderConfigurationServiceError::ProviderNotFound)?;
+        if record.manifest().revision() != provider_revision {
+            return Err(ProviderConfigurationServiceError::ProviderRevisionNotCurrent);
+        }
+        let descriptor = self
+            .factories
+            .build_descriptor(record.manifest().clone(), record.secrets())
+            .map_err(ProviderConfigurationServiceError::Factory)?;
+        let connection = self
+            .factories
+            .materialize_connection(&descriptor, draft)
+            .map_err(ProviderConfigurationServiceError::Factory)?;
+        self.manifests
+            .save_connection(connection)
+            .await
+            .map_err(ProviderConfigurationServiceError::Repository)
+    }
+}
+
+impl fmt::Debug for ProviderConfigurationService {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderConfigurationService")
+            .field("factories", &self.factories)
+            .field("manifests", &self.manifests)
+            .finish()
+    }
+}
+
+/// Sanitized provider-configuration application failure.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ProviderConfigurationServiceError {
+    /// Static adapter selection or validation rejected the draft.
+    #[error("provider configuration validation failed")]
+    Factory(#[source] ProviderFactoryRegistryError),
+    /// The exact provider revision required by a connection does not exist.
+    #[error("provider configuration revision was not found")]
+    ProviderNotFound,
+    /// The connection selected a provider revision superseded by current state.
+    #[error("provider configuration revision is not current")]
+    ProviderRevisionNotCurrent,
+    /// Durable manifest storage rejected or could not complete the operation.
+    #[error("provider configuration repository failed")]
+    Repository(#[source] ProviderRepositoryError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use automata_ci_core::{Sha256Digest, UnixMillis, WorkspaceId};
+    use automata_ci_provider::{
+        ExternalRepositoryId, ProviderArchiveLimits, ProviderCapabilities,
+        ProviderConfigurationDocument, ProviderConfigurationFactory,
+        ProviderConnectionFactoryRequest, ProviderConnectionId, ProviderConnectionManifest,
+        ProviderConnectionPolicyDocument, ProviderConnectionRevision, ProviderDefaultBranch,
+        ProviderFactoryRequest, ProviderFactoryValidationError, ProviderInstanceManifest,
+        ProviderInstanceRecord, ProviderLifecycleState, ProviderOrigins, ProviderRepositoryFuture,
+        ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderSchemaVersion, ProviderSecret,
+        ProviderTypeId, ProviderWorkflowSource, RepositoryVisibility,
+    };
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct RejectingFactory {
+        provider_type: ProviderTypeId,
+    }
+
+    impl ProviderConfigurationFactory for RejectingFactory {
+        fn provider_type(&self) -> &ProviderTypeId {
+            &self.provider_type
+        }
+
+        fn validate_instance(
+            &self,
+            _request: ProviderFactoryRequest<'_>,
+        ) -> Result<ProviderCapabilities, ProviderFactoryValidationError> {
+            Err(ProviderFactoryValidationError::InvalidConfiguration)
+        }
+
+        fn validate_connection(
+            &self,
+            _request: ProviderConnectionFactoryRequest<'_>,
+        ) -> Result<(), ProviderFactoryValidationError> {
+            unreachable!("an absent provider revision cannot reach adapter validation")
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingRepository {
+        instance_saves: AtomicUsize,
+        current_instance_loads: Mutex<Vec<ProviderInstanceId>>,
+        current_revision: Option<ProviderConfigurationRevision>,
+    }
+
+    impl ProviderManifestRepository for RecordingRepository {
+        fn save_instance(
+            &self,
+            _record: ProviderInstanceRecord,
+        ) -> ProviderRepositoryFuture<'_, ProviderSaveOutcome> {
+            self.instance_saves.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok(ProviderSaveOutcome::Inserted) })
+        }
+
+        fn load_instance(
+            &self,
+            _instance_id: ProviderInstanceId,
+            _revision: ProviderConfigurationRevision,
+        ) -> ProviderRepositoryFuture<'_, Option<ProviderInstanceRecord>> {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn current_instance(
+            &self,
+            instance_id: ProviderInstanceId,
+        ) -> ProviderRepositoryFuture<'_, Option<ProviderInstanceRecord>> {
+            self.current_instance_loads
+                .lock()
+                .expect("current instance loads")
+                .push(instance_id);
+            let record = self.current_revision.map(|revision| {
+                let manifest = ProviderInstanceManifest::new(
+                    instance_id,
+                    ProviderTypeId::new("github").expect("provider type"),
+                    revision,
+                    ProviderLifecycleState::Active,
+                    ProviderOrigins::new("https://github.com/", "https://api.github.com/")
+                        .expect("origins"),
+                    ProviderConfigurationDocument::new(
+                        ProviderSchemaVersion::new(1).expect("schema"),
+                        b"{}".to_vec(),
+                    )
+                    .expect("configuration"),
+                    automata_ci_provider::ProviderSecretBindings::empty(),
+                    Sha256Digest::from_bytes([1; 32]),
+                    UnixMillis::new(1_000),
+                    Some(UnixMillis::new(1_000)),
+                    None,
+                )
+                .expect("manifest");
+                ProviderInstanceRecord::new(
+                    manifest,
+                    automata_ci_provider::ProviderSecretSet::new(
+                        &automata_ci_provider::ProviderSecretBindings::empty(),
+                        [],
+                    )
+                    .expect("secrets"),
+                )
+                .expect("record")
+            });
+            Box::pin(async move { Ok(record) })
+        }
+
+        fn save_connection(
+            &self,
+            _manifest: ProviderConnectionManifest,
+        ) -> ProviderRepositoryFuture<'_, ProviderSaveOutcome> {
+            unreachable!("an absent provider revision cannot save a connection")
+        }
+
+        fn load_connection(
+            &self,
+            _connection_id: ProviderConnectionId,
+            _revision: ProviderConnectionRevision,
+        ) -> ProviderRepositoryFuture<'_, Option<ProviderConnectionManifest>> {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn current_connection(
+            &self,
+            _connection_id: ProviderConnectionId,
+        ) -> ProviderRepositoryFuture<'_, Option<ProviderConnectionManifest>> {
+            Box::pin(async { Ok(None) })
+        }
+    }
+
+    fn service(repository: Arc<RecordingRepository>) -> ProviderConfigurationService {
+        let factory = Arc::new(RejectingFactory {
+            provider_type: ProviderTypeId::new("github").expect("provider type"),
+        }) as Arc<dyn ProviderConfigurationFactory>;
+        ProviderConfigurationService::new(
+            ProviderFactoryRegistry::new([factory]).expect("factory registry"),
+            repository,
+        )
+    }
+
+    #[tokio::test]
+    async fn invalid_instance_never_reaches_persistence() {
+        let repository = Arc::new(RecordingRepository::default());
+        let draft = ProviderInstanceDraft::new(
+            ProviderInstanceId::new(),
+            ProviderTypeId::new("github").expect("provider type"),
+            ProviderConfigurationRevision::new(1).expect("revision"),
+            ProviderLifecycleState::Active,
+            ProviderOrigins::new("https://github.com/", "https://api.github.com/")
+                .expect("origins"),
+            ProviderConfigurationDocument::new(
+                ProviderSchemaVersion::new(1).expect("schema"),
+                b"{}".to_vec(),
+            )
+            .expect("configuration"),
+            Vec::<ProviderSecret>::new(),
+            UnixMillis::new(1_000),
+            Some(UnixMillis::new(1_000)),
+            None,
+        )
+        .expect("draft");
+
+        assert!(matches!(
+            service(Arc::clone(&repository)).apply_instance(draft).await,
+            Err(ProviderConfigurationServiceError::Factory(
+                ProviderFactoryRegistryError::Validation(
+                    ProviderFactoryValidationError::InvalidConfiguration
+                )
+            ))
+        ));
+        assert_eq!(repository.instance_saves.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn connection_rejects_a_superseded_provider_revision_before_adapter_work() {
+        let repository = Arc::new(RecordingRepository {
+            current_revision: Some(
+                ProviderConfigurationRevision::new(8).expect("current revision"),
+            ),
+            ..RecordingRepository::default()
+        });
+        let instance_id = ProviderInstanceId::new();
+        let provider_revision = ProviderConfigurationRevision::new(7).expect("revision");
+        let draft = ProviderConnectionDraft::new(
+            ProviderConnectionId::new(),
+            ProviderConnectionRevision::new(1).expect("connection revision"),
+            ProviderLifecycleState::Active,
+            WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+            ExternalRepositoryId::new("42").expect("repository ID"),
+            RepositoryVisibility::Private,
+            ProviderDefaultBranch::new("main").expect("branch"),
+            ProviderWorkflowSource::Directory(
+                ProviderRepositoryPath::new(".ci/workflows").expect("workflow path"),
+            ),
+            ProviderRunnerPolicyBinding::new(
+                ProviderSchemaVersion::new(1).expect("runner schema"),
+                Sha256Digest::from_bytes([7; 32]),
+            ),
+            ProviderArchiveLimits::new(1, 1, 1, 1, 1, 1).expect("archive limits"),
+            ProviderConnectionPolicyDocument::new(
+                ProviderSchemaVersion::new(1).expect("policy schema"),
+                b"{}".to_vec(),
+            )
+            .expect("policy"),
+            UnixMillis::new(1_000),
+            Some(UnixMillis::new(1_000)),
+            None,
+        )
+        .expect("connection draft");
+
+        assert_eq!(
+            service(Arc::clone(&repository))
+                .apply_connection(instance_id, provider_revision, draft)
+                .await,
+            Err(ProviderConfigurationServiceError::ProviderRevisionNotCurrent)
+        );
+        assert_eq!(
+            *repository
+                .current_instance_loads
+                .lock()
+                .expect("current instance loads"),
+            vec![instance_id]
+        );
+    }
+}

--- a/crates/automata-ci-provider-delivery/src/lib.rs
+++ b/crates/automata-ci-provider-delivery/src/lib.rs
@@ -4,6 +4,7 @@
 #![deny(missing_docs)]
 
 mod clock;
+mod configuration;
 mod ingress;
 mod result_worker;
 mod runtime;
@@ -11,6 +12,7 @@ mod trust;
 mod worker;
 
 pub use clock::{ProviderDeliveryClock, ProviderDeliveryClockError, SystemProviderDeliveryClock};
+pub use configuration::{ProviderConfigurationService, ProviderConfigurationServiceError};
 pub use ingress::{PreparedProviderWebhook, ProviderDeliveryIngress, ProviderDeliveryIngressError};
 pub use result_worker::{
     ProviderResultAdapter, ProviderResultAdapterRegistry, ProviderResultAdapterRegistryError,

--- a/crates/automata-ci-provider-github/src/factory.rs
+++ b/crates/automata-ci-provider-github/src/factory.rs
@@ -347,12 +347,15 @@ impl ProviderConfigurationFactory for GithubProviderFactory {
         request: ProviderFactoryRequest<'_>,
     ) -> Result<ProviderCapabilities, ProviderFactoryValidationError> {
         validate_instance_secrets(request).map_err(map_instance_validation_error)?;
-        let web = Url::parse(request.manifest().origins().web())
+        if request.provider_type() != &self.provider_type {
+            return Err(ProviderFactoryValidationError::InvalidConfiguration);
+        }
+        let web = Url::parse(request.origins().web())
             .map_err(|_| ProviderFactoryValidationError::InvalidOrigins)?;
-        let api = Url::parse(request.manifest().origins().api())
+        let api = Url::parse(request.origins().api())
             .map_err(|_| ProviderFactoryValidationError::InvalidOrigins)?;
-        let configuration = decode_instance(request.manifest().configuration())
-            .map_err(map_instance_validation_error)?;
+        let configuration =
+            decode_instance(request.configuration()).map_err(map_instance_validation_error)?;
         let trusted = GithubTrustedOrigins::new(
             web,
             api,
@@ -426,7 +429,7 @@ fn validate_instance_secrets(
             .map_err(|_| GithubFactoryError::InvalidSecrets)?;
     let webhook_name = automata_ci_provider::ProviderSecretName::new(GITHUB_WEBHOOK_SECRET_NAME)
         .map_err(|_| GithubFactoryError::InvalidSecrets)?;
-    let bindings = request.manifest().secrets();
+    let bindings = request.secret_bindings();
     if bindings.len() != 2
         || bindings.get(&app_key_name).is_none()
         || bindings.get(&webhook_name).is_none()

--- a/crates/automata-ci-provider-github/tests/factory.rs
+++ b/crates/automata-ci-provider-github/tests/factory.rs
@@ -7,18 +7,17 @@ use automata_ci_provider::{
     ProviderCapabilityKind, ProviderConfigurationDocument, ProviderConfigurationFactory,
     ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
     ProviderConnectionManifest, ProviderConnectionRevision, ProviderDefaultBranch,
-    ProviderFactoryRegistry, ProviderFactoryRegistryError, ProviderInstanceId,
-    ProviderInstanceManifest, ProviderLifecycleState, ProviderOrigins, ProviderRepositoryPath,
-    ProviderRunnerPolicyBinding, ProviderSchemaVersion, ProviderSecret, ProviderSecretBinding,
-    ProviderSecretBindings, ProviderSecretGeneration, ProviderSecretName, ProviderSecretSet,
-    ProviderTypeId, ProviderWorkflowSource, RepositoryVisibility, provider_capability_digest,
+    ProviderFactoryRegistry, ProviderFactoryRegistryError, ProviderInstanceDraft,
+    ProviderInstanceId, ProviderInstanceManifest, ProviderLifecycleState, ProviderOrigins,
+    ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderSchemaVersion, ProviderSecret,
+    ProviderSecretGeneration, ProviderSecretName, ProviderSecretSet, ProviderTypeId,
+    ProviderWorkflowSource, RepositoryVisibility,
 };
 use automata_ci_provider_github::{
     GITHUB_APP_PRIVATE_KEY_SECRET_NAME, GITHUB_WEBHOOK_SECRET_NAME, GithubConnectionPolicy,
     GithubHttpLimits, GithubInstanceConfiguration, GithubJwtIssuer, GithubProviderFactory,
 };
 use automata_ci_scm::RepositoryId;
-use sha2::{Digest as _, Sha256};
 
 const APP_PRIVATE_KEY: &[u8] = b"-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----";
 const WEBHOOK_SECRET: &[u8] = b"provider webhook secret";
@@ -37,8 +36,7 @@ fn capabilities_declare_native_rerun_without_requested_actions() {
 }
 
 fn instance(instance_id: &str, web: &str, api: &str, archive: &str) -> ProviderInstanceManifest {
-    let capabilities = GithubProviderFactory::capabilities().expect("GitHub capabilities");
-    ProviderInstanceManifest::new(
+    let draft = ProviderInstanceDraft::new(
         instance_id
             .parse::<ProviderInstanceId>()
             .expect("instance ID"),
@@ -55,29 +53,27 @@ fn instance(instance_id: &str, web: &str, api: &str, archive: &str) -> ProviderI
         .expect("instance configuration")
         .document()
         .expect("configuration document"),
-        secret_bindings(),
-        provider_capability_digest(&capabilities).expect("capability digest"),
+        [
+            ProviderSecret::new(
+                ProviderSecretName::new(GITHUB_APP_PRIVATE_KEY_SECRET_NAME).expect("app key name"),
+                ProviderSecretGeneration::new(1).expect("app key generation"),
+                SecretBytes::new(APP_PRIVATE_KEY.to_vec()).expect("app private key"),
+            ),
+            ProviderSecret::new(
+                ProviderSecretName::new(GITHUB_WEBHOOK_SECRET_NAME).expect("webhook name"),
+                ProviderSecretGeneration::new(1).expect("webhook generation"),
+                SecretBytes::new(WEBHOOK_SECRET.to_vec()).expect("webhook secret"),
+            ),
+        ],
         UnixMillis::new(1_000),
         Some(UnixMillis::new(1_000)),
         None,
     )
-    .expect("instance manifest")
-}
-
-fn secret_bindings() -> ProviderSecretBindings {
-    ProviderSecretBindings::new([
-        ProviderSecretBinding::new(
-            ProviderSecretName::new(GITHUB_APP_PRIVATE_KEY_SECRET_NAME).expect("app key name"),
-            ProviderSecretGeneration::new(1).expect("app key generation"),
-            Sha256Digest::from_bytes(Sha256::digest(APP_PRIVATE_KEY).into()),
-        ),
-        ProviderSecretBinding::new(
-            ProviderSecretName::new(GITHUB_WEBHOOK_SECRET_NAME).expect("webhook name"),
-            ProviderSecretGeneration::new(1).expect("webhook generation"),
-            Sha256Digest::from_bytes(Sha256::digest(WEBHOOK_SECRET).into()),
-        ),
-    ])
-    .expect("secret bindings")
+    .expect("instance draft");
+    let record = registry()
+        .materialize_instance(draft)
+        .expect("instance manifest");
+    record.into_parts().0
 }
 
 fn secret_set(manifest: &ProviderInstanceManifest) -> ProviderSecretSet {

--- a/crates/automata-ci-provider/src/configuration.rs
+++ b/crates/automata-ci-provider/src/configuration.rs
@@ -500,6 +500,131 @@ pub struct ProviderInstanceManifest {
     digest: Sha256Digest,
 }
 
+/// Complete provider-instance revision awaiting adapter capability validation.
+pub struct ProviderInstanceDraft {
+    instance_id: ProviderInstanceId,
+    provider_type: ProviderTypeId,
+    revision: ProviderConfigurationRevision,
+    state: ProviderLifecycleState,
+    origins: ProviderOrigins,
+    configuration: ProviderConfigurationDocument,
+    secret_bindings: ProviderSecretBindings,
+    secrets: ProviderSecretSet,
+    created_at: UnixMillis,
+    activated_at: Option<UnixMillis>,
+    retired_at: Option<UnixMillis>,
+}
+
+impl ProviderInstanceDraft {
+    /// Creates one complete revision without accepting a caller-supplied capability digest.
+    ///
+    /// Secret bindings are derived from the exact supplied plaintext values. The
+    /// registered adapter validates this draft and supplies the capability set
+    /// before a durable manifest can exist.
+    ///
+    /// # Errors
+    ///
+    /// Rejects inconsistent lifecycle evidence or invalid secret cardinality.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        instance_id: ProviderInstanceId,
+        provider_type: ProviderTypeId,
+        revision: ProviderConfigurationRevision,
+        state: ProviderLifecycleState,
+        origins: ProviderOrigins,
+        configuration: ProviderConfigurationDocument,
+        secrets: impl IntoIterator<Item = ProviderSecret>,
+        created_at: UnixMillis,
+        activated_at: Option<UnixMillis>,
+        retired_at: Option<UnixMillis>,
+    ) -> Result<Self, ProviderConfigurationError> {
+        validate_lifecycle(state, created_at, activated_at, retired_at)?;
+        let (secret_bindings, secrets) = ProviderSecretSet::bind(secrets)?;
+        Ok(Self {
+            instance_id,
+            provider_type,
+            revision,
+            state,
+            origins,
+            configuration,
+            secret_bindings,
+            secrets,
+            created_at,
+            activated_at,
+            retired_at,
+        })
+    }
+
+    /// Returns the provider type selecting one registered adapter.
+    #[must_use]
+    pub const fn provider_type(&self) -> &ProviderTypeId {
+        &self.provider_type
+    }
+
+    /// Returns the canonical provider origins.
+    #[must_use]
+    pub const fn origins(&self) -> &ProviderOrigins {
+        &self.origins
+    }
+
+    /// Returns the canonical adapter-owned configuration document.
+    #[must_use]
+    pub const fn configuration(&self) -> &ProviderConfigurationDocument {
+        &self.configuration
+    }
+
+    /// Returns bindings derived from the exact plaintext values.
+    #[must_use]
+    pub const fn secret_bindings(&self) -> &ProviderSecretBindings {
+        &self.secret_bindings
+    }
+
+    /// Returns the exact plaintext secret set at the adapter validation boundary.
+    #[must_use]
+    pub const fn secrets(&self) -> &ProviderSecretSet {
+        &self.secrets
+    }
+
+    pub(crate) fn into_manifest(
+        self,
+        capability_digest: Sha256Digest,
+    ) -> Result<(ProviderInstanceManifest, ProviderSecretSet), ProviderConfigurationError> {
+        let manifest = ProviderInstanceManifest::new(
+            self.instance_id,
+            self.provider_type,
+            self.revision,
+            self.state,
+            self.origins,
+            self.configuration,
+            self.secret_bindings,
+            capability_digest,
+            self.created_at,
+            self.activated_at,
+            self.retired_at,
+        )?;
+        Ok((manifest, self.secrets))
+    }
+}
+
+impl fmt::Debug for ProviderInstanceDraft {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderInstanceDraft")
+            .field("instance_id", &self.instance_id)
+            .field("provider_type", &self.provider_type)
+            .field("revision", &self.revision)
+            .field("state", &self.state)
+            .field("origins", &self.origins)
+            .field("configuration", &self.configuration)
+            .field("secret_bindings", &self.secret_bindings)
+            .field("secrets", &self.secrets)
+            .field("created_at", &self.created_at)
+            .field("activated_at", &self.activated_at)
+            .field("retired_at", &self.retired_at)
+            .finish()
+    }
+}
+
 impl ProviderInstanceManifest {
     /// Constructs one complete immutable manifest revision.
     ///
@@ -743,6 +868,33 @@ impl fmt::Debug for ProviderSecret {
 pub struct ProviderSecretSet(BTreeMap<ProviderSecretName, ProviderSecret>);
 
 impl ProviderSecretSet {
+    /// Derives exact bindings from plaintext values and takes custody of them.
+    ///
+    /// # Errors
+    ///
+    /// Rejects duplicate names or more than the common secret bound.
+    pub fn bind(
+        secrets: impl IntoIterator<Item = ProviderSecret>,
+    ) -> Result<(ProviderSecretBindings, Self), ProviderConfigurationError> {
+        let mut indexed = BTreeMap::new();
+        for secret in secrets {
+            if indexed.len() == MAX_PROVIDER_SECRET_BINDINGS {
+                return Err(ProviderConfigurationError::TooManySecrets);
+            }
+            if indexed.insert(secret.name.clone(), secret).is_some() {
+                return Err(ProviderConfigurationError::DuplicateSecret);
+            }
+        }
+        let bindings = ProviderSecretBindings::new(indexed.values().map(|secret| {
+            ProviderSecretBinding::new(
+                secret.name.clone(),
+                secret.generation,
+                Sha256Digest::from_bytes(Sha256::digest(secret.value.expose_secret()).into()),
+            )
+        }))?;
+        Ok((bindings, Self(indexed)))
+    }
+
     /// Validates exact names, generations, and plaintext digests.
     ///
     /// # Errors

--- a/crates/automata-ci-provider/src/connection.rs
+++ b/crates/automata-ci-provider/src/connection.rs
@@ -8,8 +8,9 @@ use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 
 use crate::{
-    ExternalRepositoryIdentity, ProviderConfigurationRevision, ProviderConnectionId,
-    ProviderLifecycleState, ProviderSchemaVersion, configuration::validate_lifecycle,
+    ExternalRepositoryId, ExternalRepositoryIdentity, ProviderConfigurationRevision,
+    ProviderConnectionId, ProviderInstanceManifest, ProviderLifecycleState, ProviderSchemaVersion,
+    configuration::validate_lifecycle,
 };
 
 /// Maximum bytes in a repository-relative workflow path.
@@ -600,6 +601,118 @@ impl ProviderConnectionConfiguration {
         }
         part(&mut hash, self.adapter_policy.digest().as_bytes());
         Sha256Digest::from_bytes(hash.finalize().into())
+    }
+}
+
+/// Complete repository-connection revision awaiting provider binding and adapter validation.
+pub struct ProviderConnectionDraft {
+    connection_id: ProviderConnectionId,
+    revision: ProviderConnectionRevision,
+    state: ProviderLifecycleState,
+    workspace_id: WorkspaceId,
+    external_repository_id: ExternalRepositoryId,
+    visibility: RepositoryVisibility,
+    default_branch: ProviderDefaultBranch,
+    workflow_source: ProviderWorkflowSource,
+    runner_policy: ProviderRunnerPolicyBinding,
+    archive_limits: ProviderArchiveLimits,
+    adapter_policy: ProviderConnectionPolicyDocument,
+    created_at: UnixMillis,
+    activated_at: Option<UnixMillis>,
+    retired_at: Option<UnixMillis>,
+}
+
+impl ProviderConnectionDraft {
+    /// Creates a connection revision without caller-supplied provider digests.
+    ///
+    /// # Errors
+    ///
+    /// Rejects inconsistent lifecycle timestamps.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        connection_id: ProviderConnectionId,
+        revision: ProviderConnectionRevision,
+        state: ProviderLifecycleState,
+        workspace_id: WorkspaceId,
+        external_repository_id: ExternalRepositoryId,
+        visibility: RepositoryVisibility,
+        default_branch: ProviderDefaultBranch,
+        workflow_source: ProviderWorkflowSource,
+        runner_policy: ProviderRunnerPolicyBinding,
+        archive_limits: ProviderArchiveLimits,
+        adapter_policy: ProviderConnectionPolicyDocument,
+        created_at: UnixMillis,
+        activated_at: Option<UnixMillis>,
+        retired_at: Option<UnixMillis>,
+    ) -> Result<Self, ProviderConnectionError> {
+        validate_lifecycle(state, created_at, activated_at, retired_at)
+            .map_err(|_| ProviderConnectionError::InvalidLifecycle)?;
+        Ok(Self {
+            connection_id,
+            revision,
+            state,
+            workspace_id,
+            external_repository_id,
+            visibility,
+            default_branch,
+            workflow_source,
+            runner_policy,
+            archive_limits,
+            adapter_policy,
+            created_at,
+            activated_at,
+            retired_at,
+        })
+    }
+
+    pub(crate) fn into_manifest(
+        self,
+        provider: &ProviderInstanceManifest,
+    ) -> Result<ProviderConnectionManifest, ProviderConnectionError> {
+        let configuration = ProviderConnectionConfiguration::new(
+            self.workspace_id,
+            ExternalRepositoryIdentity::new(provider.instance_id(), self.external_repository_id),
+            provider.revision(),
+            provider.configuration().digest(),
+            provider.capability_digest(),
+            self.visibility,
+            self.default_branch,
+            self.workflow_source,
+            self.runner_policy,
+            self.archive_limits,
+            self.adapter_policy,
+        );
+        ProviderConnectionManifest::new(
+            self.connection_id,
+            self.revision,
+            self.state,
+            configuration,
+            self.created_at,
+            self.activated_at,
+            self.retired_at,
+        )
+    }
+}
+
+impl fmt::Debug for ProviderConnectionDraft {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderConnectionDraft")
+            .field("connection_id", &self.connection_id)
+            .field("revision", &self.revision)
+            .field("state", &self.state)
+            .field("workspace_id", &self.workspace_id)
+            .field("external_repository_id", &self.external_repository_id)
+            .field("visibility", &self.visibility)
+            .field("default_branch", &self.default_branch)
+            .field("workflow_source", &self.workflow_source)
+            .field("runner_policy", &self.runner_policy)
+            .field("archive_limits", &self.archive_limits)
+            .field("adapter_policy", &self.adapter_policy)
+            .field("created_at", &self.created_at)
+            .field("activated_at", &self.activated_at)
+            .field("retired_at", &self.retired_at)
+            .finish()
     }
 }
 

--- a/crates/automata-ci-provider/src/factory.rs
+++ b/crates/automata-ci-provider/src/factory.rs
@@ -5,8 +5,10 @@ use std::{collections::BTreeMap, fmt, sync::Arc};
 use thiserror::Error;
 
 use crate::{
-    ProviderCapabilities, ProviderConnectionManifest, ProviderInstanceManifest, ProviderSecretSet,
-    ProviderTypeId, provider_capability_digest,
+    ProviderCapabilities, ProviderConfigurationDocument, ProviderConnectionDraft,
+    ProviderConnectionManifest, ProviderInstanceDraft, ProviderInstanceManifest,
+    ProviderInstanceRecord, ProviderLifecycleState, ProviderOrigins, ProviderSecretBindings,
+    ProviderSecretSet, ProviderTypeId, provider_capability_digest,
 };
 
 /// Maximum statically linked provider adapter types in one process.
@@ -15,24 +17,59 @@ pub const MAX_PROVIDER_FACTORIES: usize = 32;
 /// Exact configuration and secret evidence presented to one adapter factory.
 #[derive(Clone, Copy)]
 pub struct ProviderFactoryRequest<'a> {
-    manifest: &'a ProviderInstanceManifest,
+    provider_type: &'a ProviderTypeId,
+    origins: &'a ProviderOrigins,
+    configuration: &'a ProviderConfigurationDocument,
+    secret_bindings: &'a ProviderSecretBindings,
     secrets: &'a ProviderSecretSet,
 }
 
 impl<'a> ProviderFactoryRequest<'a> {
-    /// Binds one immutable manifest to its already verified plaintext secret set.
-    #[must_use]
-    pub const fn new(
+    const fn for_manifest(
         manifest: &'a ProviderInstanceManifest,
         secrets: &'a ProviderSecretSet,
     ) -> Self {
-        Self { manifest, secrets }
+        Self {
+            provider_type: manifest.provider_type(),
+            origins: manifest.origins(),
+            configuration: manifest.configuration(),
+            secret_bindings: manifest.secrets(),
+            secrets,
+        }
     }
 
-    /// Returns the immutable provider manifest.
+    const fn for_draft(draft: &'a ProviderInstanceDraft) -> Self {
+        Self {
+            provider_type: draft.provider_type(),
+            origins: draft.origins(),
+            configuration: draft.configuration(),
+            secret_bindings: draft.secret_bindings(),
+            secrets: draft.secrets(),
+        }
+    }
+
+    /// Returns the exact registered provider type.
     #[must_use]
-    pub const fn manifest(self) -> &'a ProviderInstanceManifest {
-        self.manifest
+    pub const fn provider_type(self) -> &'a ProviderTypeId {
+        self.provider_type
+    }
+
+    /// Returns canonical provider network origins.
+    #[must_use]
+    pub const fn origins(self) -> &'a ProviderOrigins {
+        self.origins
+    }
+
+    /// Returns the canonical adapter-owned configuration document.
+    #[must_use]
+    pub const fn configuration(self) -> &'a ProviderConfigurationDocument {
+        self.configuration
+    }
+
+    /// Returns bindings derived from the exact supplied secret values.
+    #[must_use]
+    pub const fn secret_bindings(self) -> &'a ProviderSecretBindings {
+        self.secret_bindings
     }
 
     /// Returns exact named plaintext values at the adapter boundary.
@@ -46,9 +83,10 @@ impl fmt::Debug for ProviderFactoryRequest<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ProviderFactoryRequest")
-            .field("instance_id", &self.manifest.instance_id())
-            .field("provider_type", self.manifest.provider_type())
-            .field("revision", &self.manifest.revision())
+            .field("provider_type", self.provider_type)
+            .field("origins", self.origins)
+            .field("configuration", self.configuration)
+            .field("secret_bindings", self.secret_bindings)
             .field("secret_names", &self.secrets.names().collect::<Vec<_>>())
             .finish()
     }
@@ -206,7 +244,7 @@ impl ProviderFactoryRegistry {
             return Err(ProviderFactoryRegistryError::FactoryIdentityMismatch);
         }
         let capabilities = factory
-            .validate_instance(ProviderFactoryRequest::new(&manifest, secrets))
+            .validate_instance(ProviderFactoryRequest::for_manifest(&manifest, secrets))
             .map_err(ProviderFactoryRegistryError::Validation)?;
         let digest = provider_capability_digest(&capabilities)
             .map_err(|_| ProviderFactoryRegistryError::CapabilityDigest)?;
@@ -217,6 +255,39 @@ impl ProviderFactoryRegistry {
             manifest,
             capabilities,
         })
+    }
+
+    /// Validates a complete draft and materializes its capability-bound durable record.
+    ///
+    /// The caller cannot provide a capability digest. The exact registered
+    /// adapter validates the configuration and secrets, and the registry
+    /// derives the digest from the returned typed capability set.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an unregistered type, adapter validation failure, capability
+    /// encoding failure, or inconsistent common instance evidence.
+    pub fn materialize_instance(
+        &self,
+        draft: ProviderInstanceDraft,
+    ) -> Result<ProviderInstanceRecord, ProviderFactoryRegistryError> {
+        let factory = self
+            .factories
+            .get(draft.provider_type())
+            .ok_or(ProviderFactoryRegistryError::UnknownProviderType)?;
+        if factory.provider_type() != draft.provider_type() {
+            return Err(ProviderFactoryRegistryError::FactoryIdentityMismatch);
+        }
+        let capabilities = factory
+            .validate_instance(ProviderFactoryRequest::for_draft(&draft))
+            .map_err(ProviderFactoryRegistryError::Validation)?;
+        let capability_digest = provider_capability_digest(&capabilities)
+            .map_err(|_| ProviderFactoryRegistryError::CapabilityDigest)?;
+        let (manifest, secrets) = draft
+            .into_manifest(capability_digest)
+            .map_err(|_| ProviderFactoryRegistryError::InstanceEvidence)?;
+        ProviderInstanceRecord::new(manifest, secrets)
+            .map_err(|_| ProviderFactoryRegistryError::SecretEvidence)
     }
 
     /// Validates exact provider evidence and adapter-owned connection policy.
@@ -247,6 +318,31 @@ impl ProviderFactoryRegistry {
         factory
             .validate_connection(ProviderConnectionFactoryRequest::new(provider, connection))
             .map_err(ProviderFactoryRegistryError::Validation)
+    }
+
+    /// Binds a connection draft to validated provider evidence and adapter policy.
+    ///
+    /// The provider configuration and capability digests are copied from the
+    /// descriptor. They are never accepted from the management caller.
+    ///
+    /// # Errors
+    ///
+    /// Rejects inconsistent common connection evidence or adapter-owned policy.
+    pub fn materialize_connection(
+        &self,
+        provider: &ProviderDescriptor,
+        draft: ProviderConnectionDraft,
+    ) -> Result<ProviderConnectionManifest, ProviderFactoryRegistryError> {
+        let connection = draft
+            .into_manifest(provider.manifest())
+            .map_err(|_| ProviderFactoryRegistryError::ConnectionEvidence)?;
+        if connection.state() == ProviderLifecycleState::Active
+            && provider.manifest().state() != ProviderLifecycleState::Active
+        {
+            return Err(ProviderFactoryRegistryError::ConnectionEvidence);
+        }
+        self.validate_connection(provider, &connection)?;
+        Ok(connection)
     }
 
     /// Iterates registered provider type IDs in canonical order.
@@ -314,4 +410,7 @@ pub enum ProviderFactoryRegistryError {
     /// A connection was pinned to different provider evidence.
     #[error("provider connection evidence is inconsistent")]
     ConnectionEvidence,
+    /// Common instance lifecycle or manifest evidence was inconsistent.
+    #[error("provider instance evidence is inconsistent")]
+    InstanceEvidence,
 }

--- a/crates/automata-ci-provider/src/lib.rs
+++ b/crates/automata-ci-provider/src/lib.rs
@@ -32,20 +32,20 @@ pub use capability::{
 pub use configuration::{
     MAX_PROVIDER_CONFIGURATION_BYTES, MAX_PROVIDER_ORIGIN_BYTES, MAX_PROVIDER_SCHEMA_VERSION,
     MAX_PROVIDER_SECRET_BINDINGS, MAX_PROVIDER_SECRET_NAME_BYTES, ProviderConfigurationDocument,
-    ProviderConfigurationError, ProviderConfigurationRevision, ProviderInstanceManifest,
-    ProviderLifecycleState, ProviderOrigins, ProviderSchemaVersion, ProviderSecret,
-    ProviderSecretBinding, ProviderSecretBindings, ProviderSecretGeneration, ProviderSecretName,
-    ProviderSecretSet, provider_capability_digest,
+    ProviderConfigurationError, ProviderConfigurationRevision, ProviderInstanceDraft,
+    ProviderInstanceManifest, ProviderLifecycleState, ProviderOrigins, ProviderSchemaVersion,
+    ProviderSecret, ProviderSecretBinding, ProviderSecretBindings, ProviderSecretGeneration,
+    ProviderSecretName, ProviderSecretSet, provider_capability_digest,
 };
 pub use connection::{
     MAX_PROVIDER_ARCHIVE_COMPRESSED_BYTES, MAX_PROVIDER_ARCHIVE_ENTRIES,
     MAX_PROVIDER_ARCHIVE_ENTRY_PATH_BYTES, MAX_PROVIDER_ARCHIVE_EXPANDED_BYTES,
     MAX_PROVIDER_ARCHIVE_WORKFLOWS, MAX_PROVIDER_CONNECTION_POLICY_BYTES,
     MAX_PROVIDER_REPOSITORY_PATH_BYTES, MAX_PROVIDER_WORKFLOW_BYTES, ProviderArchiveLimits,
-    ProviderConnectionConfiguration, ProviderConnectionError, ProviderConnectionManifest,
-    ProviderConnectionPolicyDocument, ProviderConnectionRevision, ProviderDefaultBranch,
-    ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderWorkflowSource,
-    RepositoryVisibility,
+    ProviderConnectionConfiguration, ProviderConnectionDraft, ProviderConnectionError,
+    ProviderConnectionManifest, ProviderConnectionPolicyDocument, ProviderConnectionRevision,
+    ProviderDefaultBranch, ProviderRepositoryPath, ProviderRunnerPolicyBinding,
+    ProviderWorkflowSource, RepositoryVisibility,
 };
 pub use control::{
     MAX_PROVIDER_CONTROL_DOCUMENT_BYTES, ProviderControl, ProviderControlDocument,

--- a/crates/automata-ci-provider/tests/configuration.rs
+++ b/crates/automata-ci-provider/tests/configuration.rs
@@ -6,15 +6,15 @@ use automata_ci_provider::{
     ExternalRepositoryId, ExternalRepositoryIdentity, MAX_PROVIDER_SCHEMA_VERSION,
     ProviderArchiveLimits, ProviderCapabilities, ProviderCapability, ProviderConfigurationDocument,
     ProviderConfigurationError, ProviderConfigurationFactory, ProviderConfigurationRevision,
-    ProviderConnectionConfiguration, ProviderConnectionFactoryRequest, ProviderConnectionId,
-    ProviderConnectionManifest, ProviderConnectionPolicyDocument, ProviderConnectionRevision,
-    ProviderDefaultBranch, ProviderFactoryRegistry, ProviderFactoryRegistryError,
-    ProviderFactoryRequest, ProviderFactoryValidationError, ProviderInstanceId,
-    ProviderInstanceManifest, ProviderLifecycleState, ProviderOrigins, ProviderRepositoryPath,
-    ProviderRunnerPolicyBinding, ProviderSchemaVersion, ProviderSecret, ProviderSecretBinding,
-    ProviderSecretBindings, ProviderSecretGeneration, ProviderSecretName, ProviderSecretSet,
-    ProviderTypeId, ProviderWorkflowSource, RepositoryVisibility, SourceReadCapability,
-    provider_capability_digest,
+    ProviderConnectionConfiguration, ProviderConnectionDraft, ProviderConnectionFactoryRequest,
+    ProviderConnectionId, ProviderConnectionManifest, ProviderConnectionPolicyDocument,
+    ProviderConnectionRevision, ProviderDefaultBranch, ProviderFactoryRegistry,
+    ProviderFactoryRegistryError, ProviderFactoryRequest, ProviderFactoryValidationError,
+    ProviderInstanceDraft, ProviderInstanceId, ProviderInstanceManifest, ProviderLifecycleState,
+    ProviderOrigins, ProviderRepositoryPath, ProviderRunnerPolicyBinding, ProviderSchemaVersion,
+    ProviderSecret, ProviderSecretBinding, ProviderSecretBindings, ProviderSecretGeneration,
+    ProviderSecretName, ProviderSecretSet, ProviderTypeId, ProviderWorkflowSource,
+    RepositoryVisibility, SourceReadCapability, provider_capability_digest,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
@@ -50,22 +50,22 @@ impl ProviderConfigurationFactory for FakeFactory {
         &self,
         request: ProviderFactoryRequest<'_>,
     ) -> Result<ProviderCapabilities, ProviderFactoryValidationError> {
-        if request.manifest().configuration().schema_version().get() != 1 {
+        if request.provider_type() != &self.provider_type {
+            return Err(ProviderFactoryValidationError::InvalidConfiguration);
+        }
+        if request.configuration().schema_version().get() != 1 {
             return Err(ProviderFactoryValidationError::UnsupportedSchema);
         }
-        let decoded =
-            serde_json::from_slice::<FakeConfiguration>(request.manifest().configuration().bytes())
-                .map_err(|_| ProviderFactoryValidationError::InvalidConfiguration)?;
+        let decoded = serde_json::from_slice::<FakeConfiguration>(request.configuration().bytes())
+            .map_err(|_| ProviderFactoryValidationError::InvalidConfiguration)?;
         let canonical = serde_json::to_vec(&decoded)
             .map_err(|_| ProviderFactoryValidationError::InvalidConfiguration)?;
-        if canonical != request.manifest().configuration().bytes()
-            || decoded.api_family != self.api_family
-        {
+        if canonical != request.configuration().bytes() || decoded.api_family != self.api_family {
             return Err(ProviderFactoryValidationError::InvalidConfiguration);
         }
 
         let token = ProviderSecretName::new("control-token").expect("secret name");
-        if request.manifest().secrets().len() != 1 || request.secrets().get(&token).is_none() {
+        if request.secret_bindings().len() != 1 || request.secrets().get(&token).is_none() {
             return Err(ProviderFactoryValidationError::InvalidSecrets);
         }
 
@@ -314,6 +314,95 @@ fn secret_sets_require_exact_names_generations_and_plaintext() {
         unexpected,
         Err(ProviderConfigurationError::UnexpectedSecret)
     ));
+}
+
+#[test]
+fn registry_materializes_capability_bound_records_without_caller_digest_authority() {
+    let configuration = ProviderConfigurationDocument::new(
+        ProviderSchemaVersion::new(1).expect("schema"),
+        serde_json::to_vec(&FakeConfiguration {
+            api_family: "forgejo".to_owned(),
+        })
+        .expect("configuration bytes"),
+    )
+    .expect("configuration");
+    let draft = ProviderInstanceDraft::new(
+        ProviderInstanceId::from_uuid(Uuid::from_u128(71)).expect("instance ID"),
+        ProviderTypeId::new("forgejo").expect("provider type"),
+        ProviderConfigurationRevision::new(1).expect("revision"),
+        ProviderLifecycleState::Active,
+        ProviderOrigins::new("https://code.example/", "https://code.example/api/v1/")
+            .expect("origins"),
+        configuration,
+        [ProviderSecret::new(
+            ProviderSecretName::new("control-token").expect("secret name"),
+            ProviderSecretGeneration::new(1).expect("secret generation"),
+            SecretBytes::new(b"plaintext-sentinel".to_vec()).expect("secret"),
+        )],
+        UnixMillis::new(1_000),
+        Some(UnixMillis::new(1_000)),
+        None,
+    )
+    .expect("draft");
+
+    let record = registry()
+        .materialize_instance(draft)
+        .expect("materialized record");
+    let capabilities = source_capabilities().expect("capabilities");
+    assert_eq!(
+        record.manifest().capability_digest(),
+        provider_capability_digest(&capabilities).expect("capability digest")
+    );
+    assert_eq!(record.manifest().provider_type().as_str(), "forgejo");
+    assert_eq!(record.secrets().names().count(), 1);
+    assert!(!format!("{record:?}").contains("plaintext-sentinel"));
+
+    let registry = registry();
+    let descriptor = registry
+        .build_descriptor(record.manifest().clone(), record.secrets())
+        .expect("descriptor");
+    let connection = registry
+        .materialize_connection(
+            &descriptor,
+            ProviderConnectionDraft::new(
+                ProviderConnectionId::from_uuid(Uuid::from_u128(72)).expect("connection ID"),
+                ProviderConnectionRevision::new(1).expect("connection revision"),
+                ProviderLifecycleState::Active,
+                WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+                ExternalRepositoryId::new("repository-42").expect("repository ID"),
+                RepositoryVisibility::Private,
+                ProviderDefaultBranch::new("main").expect("branch"),
+                ProviderWorkflowSource::Directory(
+                    ProviderRepositoryPath::new(".ci/workflows").expect("workflow source"),
+                ),
+                ProviderRunnerPolicyBinding::new(
+                    ProviderSchemaVersion::new(1).expect("runner schema"),
+                    Sha256Digest::from_bytes([7; 32]),
+                ),
+                ProviderArchiveLimits::new(1, 1, 1, 1, 1, 1).expect("archive limits"),
+                ProviderConnectionPolicyDocument::new(
+                    ProviderSchemaVersion::new(1).expect("adapter schema"),
+                    serde_json::to_vec(&FakeConfiguration {
+                        api_family: "forgejo".to_owned(),
+                    })
+                    .expect("adapter policy"),
+                )
+                .expect("adapter document"),
+                UnixMillis::new(1_000),
+                Some(UnixMillis::new(1_000)),
+                None,
+            )
+            .expect("connection draft"),
+        )
+        .expect("materialized connection");
+    assert_eq!(
+        connection.configuration().provider_configuration_digest(),
+        record.manifest().configuration().digest()
+    );
+    assert_eq!(
+        connection.configuration().capability_digest(),
+        record.manifest().capability_digest()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- move provider instance and connection materialization behind provider-owned factory contracts
- derive capability and configuration digests inside the registry instead of accepting caller authority
- keep GitHub as one strict adapter while preserving an extensible factory registry for Forgejo and future providers

## Validation

- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- strict clippy for provider, provider-github, and provider-delivery
- cargo test -p automata-ci-provider -p automata-ci-provider-github

## Staging

Depends on merged provider foundation PR #514. This PR is 874 additions and 73 deletions; later runtime and Forgejo work remains in separate stages.