### PR TITLE
Exercise macOS live helper loss recovery

### DIFF
--- a/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
+++ b/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
@@ -10,9 +10,11 @@ use std::{
 };
 
 use automata_ci_execution::{
-    EnvironmentProfile, EnvironmentProfileId, ExecutionEnvironment, NetworkPolicy, NeverCancelled,
+    DestroySandbox, EnvironmentProfile, EnvironmentProfileId, ExecutionArgv, ExecutionCommand,
+    ExecutionEnvironment, ExecutionErrorKind, ExecutionTermination, NetworkPolicy, NeverCancelled,
     OperationId, ProviderErrorKind, ResourceLimits, RootFilesystemPolicy, RunnerId, SandboxCustody,
-    SandboxEnvironment, SandboxGeneration, SandboxProvider, SandboxSpec, Sha256Digest, TargetPath,
+    SandboxEnvironment, SandboxGeneration, SandboxHandle, SandboxProvider, SandboxSpec,
+    Sha256Digest, TargetPath, discard_execution_output,
 };
 use automata_ci_sandbox_guest::GUEST_PROTOCOL_VERSION;
 use automata_ci_sandbox_macos::{MacosVirtualizationProvider, MacosVirtualizationProviderOptions};
@@ -185,10 +187,134 @@ fn provider_reconciles_a_live_orphan_after_owner_process_loss() {
     drop(recovered);
 }
 
-fn create_physical_orphan() {
+#[test]
+#[ignore = "requires a sealed VM template on a physical Apple Silicon runner"]
+fn provider_cleans_up_and_reuses_slot_after_live_helper_loss() {
     let root = required_path(VM_STORAGE_ROOT_ENV);
-    let provider = MacosVirtualizationProvider::open(physical_options(root))
+    assert_attempts_empty(&root);
+    let provider = MacosVirtualizationProvider::open(physical_options(root.clone()))
         .expect("open physical macOS provider");
+
+    let first_spec = physical_spec("helper-loss");
+    let first = provider
+        .create(&first_spec, &NeverCancelled)
+        .expect("create helper-loss VM");
+    let mut first_cleanup = PhysicalSandboxCleanup::new(
+        provider.clone(),
+        first.handle().clone(),
+        first_spec.generation(),
+        first_spec.custody(),
+    );
+    let endpoint = provider
+        .attach(first.handle(), &NeverCancelled)
+        .expect("attach helper-loss VM");
+    kill_attempt_helper(&root, first.handle());
+    let error = endpoint
+        .exec(
+            &probe_command(first_spec.workspace()),
+            &NeverCancelled,
+            discard_execution_output(),
+        )
+        .expect_err("a killed helper must close the guest endpoint");
+    assert_eq!(error.kind(), ExecutionErrorKind::BackendRejected);
+    drop(endpoint);
+    provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                first.handle().clone(),
+                first_spec.generation(),
+                first_spec.custody(),
+            ),
+            &NeverCancelled,
+        )
+        .expect("destroy VM after helper loss");
+    first_cleanup.disarm();
+    assert_attempts_empty(&root);
+
+    let second_spec = physical_spec("helper-loss-reuse");
+    let second = provider
+        .create(&second_spec, &NeverCancelled)
+        .expect("reuse provider slot after helper loss");
+    let mut second_cleanup = PhysicalSandboxCleanup::new(
+        provider.clone(),
+        second.handle().clone(),
+        second_spec.generation(),
+        second_spec.custody(),
+    );
+    let endpoint = provider
+        .attach(second.handle(), &NeverCancelled)
+        .expect("attach replacement VM");
+    let output = endpoint
+        .exec(
+            &probe_command(second_spec.workspace()),
+            &NeverCancelled,
+            discard_execution_output(),
+        )
+        .expect("execute in replacement VM");
+    assert_eq!(output.termination(), ExecutionTermination::Exited(0));
+    drop(endpoint);
+    provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                second.handle().clone(),
+                second_spec.generation(),
+                second_spec.custody(),
+            ),
+            &NeverCancelled,
+        )
+        .expect("destroy replacement VM");
+    second_cleanup.disarm();
+    assert_attempts_empty(&root);
+}
+
+struct PhysicalSandboxCleanup {
+    provider: MacosVirtualizationProvider,
+    handle: SandboxHandle,
+    generation: SandboxGeneration,
+    custody: SandboxCustody,
+    armed: bool,
+}
+
+impl PhysicalSandboxCleanup {
+    fn new(
+        provider: MacosVirtualizationProvider,
+        handle: SandboxHandle,
+        generation: SandboxGeneration,
+        custody: SandboxCustody,
+    ) -> Self {
+        Self {
+            provider,
+            handle,
+            generation,
+            custody,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PhysicalSandboxCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = self.provider.destroy(
+                &DestroySandbox::new(
+                    OperationId::new(),
+                    self.handle.clone(),
+                    self.generation,
+                    self.custody,
+                ),
+                &NeverCancelled,
+            );
+        }
+    }
+}
+
+fn physical_spec(name: &str) -> SandboxSpec {
     let manifest = required_digest(VM_TEMPLATE_SHA256_ENV);
     let profile = SandboxEnvironment::virtual_machine(
         EnvironmentProfile::new(
@@ -201,21 +327,75 @@ fn create_physical_orphan() {
         ExecutionEnvironment::empty(),
     )
     .expect("physical VM environment");
-    let spec = SandboxSpec::new(
+    SandboxSpec::new(
         OperationId::new(),
         SandboxGeneration::new(1).expect("sandbox generation"),
         SandboxCustody::ProfileAdmission {
             runner_id: RunnerId::new(),
         },
         profile,
-        TargetPath::posix("/Users/automata-job/workspaces/orphan-recovery").expect("job workspace"),
+        TargetPath::posix(format!("/Users/automata-job/workspaces/{name}")).expect("job workspace"),
         NetworkPolicy::Disabled,
         RootFilesystemPolicy::Writable,
         ResourceLimits::new(8 * 1024 * 1024 * 1024, 4_000, 512).expect("physical resources"),
     )
     .with_scratch(
-        TargetPath::posix("/Users/automata-job/runner/orphan-recovery").expect("job scratch"),
+        TargetPath::posix(format!("/Users/automata-job/runner/{name}")).expect("job scratch"),
+    )
+}
+
+fn probe_command(working_directory: &TargetPath) -> ExecutionCommand {
+    ExecutionCommand::new(
+        OperationId::new(),
+        ExecutionArgv::new(
+            TargetPath::posix("/usr/bin/true").expect("true path"),
+            Vec::new(),
+        )
+        .expect("probe argv"),
+        working_directory.clone(),
+        ExecutionEnvironment::empty(),
+        Duration::from_secs(5),
+        16 * 1024,
+    )
+    .expect("probe command")
+}
+
+fn kill_attempt_helper(root: &Path, handle: &SandboxHandle) {
+    let helper = required_path(VM_HELPER_ENV);
+    let lock = root.join("attempts").join(handle.opaque()).join(".vm.lock");
+    let expected = format!("{} run --lock {}", helper.display(), lock.display());
+    let output = Command::new("/bin/ps")
+        .args(["-axo", "pid=,command="])
+        .output()
+        .expect("list physical host processes");
+    assert!(output.status.success(), "physical host ps failed");
+    let pids: Vec<u32> = String::from_utf8(output.stdout)
+        .expect("physical host process list must be UTF-8")
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.trim_start().splitn(2, char::is_whitespace);
+            let pid = fields.next()?.parse().ok()?;
+            let command = fields.next()?.trim_start();
+            (command == expected).then_some(pid)
+        })
+        .collect();
+    assert_eq!(
+        pids.len(),
+        1,
+        "expected exactly one helper for the owned VM attempt"
     );
+    let status = Command::new("/bin/kill")
+        .args(["-KILL", &pids[0].to_string()])
+        .status()
+        .expect("kill physical VM helper");
+    assert!(status.success(), "physical VM helper kill failed");
+}
+
+fn create_physical_orphan() {
+    let root = required_path(VM_STORAGE_ROOT_ENV);
+    let provider = MacosVirtualizationProvider::open(physical_options(root))
+        .expect("open physical macOS provider");
+    let spec = physical_spec("orphan-recovery");
     provider
         .create(&spec, &NeverCancelled)
         .expect("create physical VM orphan fixture");

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -1219,8 +1219,8 @@ current baseline.
   either Developer ID distribution or an exact private-fleet leaf identity.
 - [ ] Add Xcode and toolchain profiles.
 - [ ] Add macOS acceptance jobs.
-- [x] Add physical clone cleanup, runner cancellation, and live-orphan startup
-  recovery tests.
+- [x] Add physical clone cleanup, runner cancellation, live-helper-loss slot
+  reuse, and live-orphan startup recovery tests.
 
 ### Architecture and image breadth
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -439,9 +439,11 @@ clone cleanup. The companion cancellation test waits for two live `Running`
 heartbeats, delivers and acknowledges a durable cancellation command, and
 requires a bounded `Cancelled` result and slot release. The provider recovery
 test kills the process owning a live VM, reopens the journal, and requires
-startup reconciliation to remove the exact orphan. A continuous protected
-physical lane, an independent helper-crash-at-transition matrix, and a retained
-repeated-clean soak remain deployment work.
+startup reconciliation to remove the exact orphan. The helper-loss test kills
+the exact helper bound to a running VM, requires a typed endpoint failure,
+destroys the clone, and proves the same provider slot can run and clean a fresh
+VM. A continuous protected physical lane, launch/destroy helper-crash
+transitions, and a retained repeated-clean soak remain deployment work.
 
 Create `/Volumes/AutomataVM/e2e-state` as an empty `0700` directory owned by
 the physical runner service account before running the command below.
@@ -459,7 +461,8 @@ export AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES=<exact-volume-quota-bytes>
 ```
 
 The entrypoint runs the shipped-runner success/timeout and cancellation matrix,
-live-orphan recovery, and the allowlisted runtime-proxy probe serially. Set
+live-helper-loss cleanup and slot reuse, live-orphan recovery, and the
+allowlisted runtime-proxy probe serially. Set
 `AUTOMATA_MACOS_PHYSICAL_REPETITIONS` from 1 through 10 for a bounded repeated
 runner soak. It refuses a `CARGO_TARGET_DIR` on the VM storage filesystem so
 build artifacts cannot consume the clone-capacity safety margin.

--- a/scripts/ci/run-macos-physical-checks.sh
+++ b/scripts/ci/run-macos-physical-checks.sh
@@ -114,6 +114,10 @@ for ((iteration = 1; iteration <= repetitions; iteration++)); do
     macos_vm_runner_process_e2e:: -- \
     --ignored --nocapture --test-threads=1
 done
+run_test 'live helper loss cleanup and slot reuse' \
+  cargo test -p automata-ci-sandbox-macos --test macos_provider --locked \
+  provider_cleans_up_and_reuses_slot_after_live_helper_loss -- \
+  --ignored --exact --nocapture --test-threads=1
 run_test 'live VM orphan recovery after owner loss' \
   cargo test -p automata-ci-sandbox-macos --test macos_provider --locked \
   provider_reconciles_a_live_orphan_after_owner_process_loss -- \

--- a/scripts/ci/tests/macos-physical-checks.test.py
+++ b/scripts/ci/tests/macos-physical-checks.test.py
@@ -30,7 +30,7 @@ class MacosPhysicalChecksTest(unittest.TestCase):
         result = self.run_script("--plan")
         self.assertEqual(result.returncode, 0, result.stderr)
         commands = [line for line in result.stdout.splitlines() if line.startswith("RUN ")]
-        self.assertEqual(len(commands), 3, result.stdout)
+        self.assertEqual(len(commands), 4, result.stdout)
         for identity in (
             "automata-ci-runner --test runner",
             "automata-ci-sandbox-macos --test macos_provider",
@@ -40,8 +40,9 @@ class MacosPhysicalChecksTest(unittest.TestCase):
         for command in commands:
             self.assertIn("--test-threads=1", command)
         self.assertIn("macos_vm_runner_process_e2e::", commands[0])
-        self.assertIn("provider_reconciles_a_live_orphan", commands[1])
-        self.assertIn("physical_guest_reaches_an_allowlisted_origin", commands[2])
+        self.assertIn("provider_cleans_up_and_reuses_slot_after_live_helper_loss", commands[1])
+        self.assertIn("provider_reconciles_a_live_orphan", commands[2])
+        self.assertIn("physical_guest_reaches_an_allowlisted_origin", commands[3])
         self.assertNotIn("HELPER_REQUIREMENT=", result.stdout)
         self.assertNotIn("STORAGE_QUOTA_BYTES=", result.stdout)
 
@@ -51,12 +52,12 @@ class MacosPhysicalChecksTest(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         commands = [line for line in result.stdout.splitlines() if line.startswith("RUN ")]
-        self.assertEqual(len(commands), 4, result.stdout)
+        self.assertEqual(len(commands), 5, result.stdout)
         self.assertEqual(
             sum("automata-ci-runner --test runner" in command for command in commands), 2
         )
         self.assertEqual(
-            sum("--test macos_provider" in command for command in commands), 1
+            sum("--test macos_provider" in command for command in commands), 2
         )
 
     def test_invalid_repetition_count_fails_closed(self) -> None:


### PR DESCRIPTION
## Summary

- add a physical provider contract that kills only the signed helper bound to a running VM
- require a typed endpoint failure, clone cleanup, slot release, and a successful clean replacement VM on the same provider
- include helper-loss recovery in the bounded serial physical entrypoint and narrow the remaining crash matrix to launch/destroy transitions

## Validation

- `cargo fmt --all -- --check`
- `bash -n scripts/ci/run-macos-physical-checks.sh`
- `python3 scripts/ci/tests/macos-physical-checks.test.py`
- native macOS: `cargo clippy -p automata-ci-sandbox-macos --test macos_provider --locked -- -D warnings`
- physical Apple Silicon, exact rebased commit `64d4c3f7d60625c05c56f20d6991baeb2881ce00`: full entrypoint passed in 1,156.784s
  - shipped runner success/timeout/cancellation: 2 passed in 484.21s
  - live-helper-loss cleanup and slot reuse: 1 passed in 215.29s
  - live-orphan recovery: 1 passed in 405.36s
  - allowlisted Virtio-socket proxy: 1 passed in 9.22s
  - post-run: zero provider attempts, zero proxy attempts, and zero helper processes; VM volume restored to 72 GiB available
