### PR TITLE
refactor(github): consolidate verified webhook identity

### DIFF
--- a/crates/automata-ci-provider-github/src/webhook.rs
+++ b/crates/automata-ci-provider-github/src/webhook.rs
@@ -1,16 +1,14 @@
 use std::{fmt, num::NonZeroU64};
 
-use automata_ci_core::GitObjectId;
 use bytes::{Bytes, BytesMut};
 use reqwest::header::{HeaderMap, HeaderValue};
 use ring::{digest, hmac};
-use serde::{Deserialize, Deserializer, Serialize, de};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{
-    event::GithubEventActor,
-    repository_path::{has_ascii_case_insensitive_suffix, is_valid_component},
-};
+use crate::repository_path::{has_ascii_case_insensitive_suffix, is_valid_component};
+
+pub use crate::webhook_event::push::{GithubWebhookEventMetadata, VerifiedGithubPush};
 
 /// Maximum exact webhook body accepted by workflow admission.
 pub const MAX_GITHUB_WEBHOOK_BODY_BYTES: usize = 26_214_400;
@@ -31,54 +29,34 @@ pub const X_GITHUB_DELIVERY: &str = "x-github-delivery";
 
 const MAX_DELIVERY_ID_BYTES: usize = 128;
 const MAX_GIT_REF_BYTES: usize = 1_024;
-const MAX_GITHUB_PATH_FILTER_COMMITS: usize = 1_000;
 const SHA256_SIGNATURE_PREFIX: &[u8] = b"sha256=";
-const ZERO_COMMIT_SHA: &str = "0000000000000000000000000000000000000000";
 const WEBHOOK_VERIFIER_FINGERPRINT_DOMAIN: &[u8] =
     b"automata.store.github-webhook-verifier-fingerprint.v1\0";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum GithubWebhookLimitRejection {
-    SecretBytes,
-    DeliveryIdBytes,
-    GitRefBytes,
-    PushCommitCount,
-    PathFilterCommitCount,
+    Secret,
+    DeliveryId,
+    GitRef,
 }
 
 const fn webhook_secret_byte_rejection(observed: usize) -> Option<GithubWebhookLimitRejection> {
     if observed > MAX_GITHUB_WEBHOOK_SECRET_BYTES {
-        return Some(GithubWebhookLimitRejection::SecretBytes);
+        return Some(GithubWebhookLimitRejection::Secret);
     }
     None
 }
 
 const fn delivery_id_byte_rejection(observed: usize) -> Option<GithubWebhookLimitRejection> {
     if observed > MAX_DELIVERY_ID_BYTES {
-        return Some(GithubWebhookLimitRejection::DeliveryIdBytes);
+        return Some(GithubWebhookLimitRejection::DeliveryId);
     }
     None
 }
 
 const fn git_ref_byte_rejection(observed: usize) -> Option<GithubWebhookLimitRejection> {
     if observed > MAX_GIT_REF_BYTES {
-        return Some(GithubWebhookLimitRejection::GitRefBytes);
-    }
-    None
-}
-
-const fn push_commit_count_rejection(observed: usize) -> Option<GithubWebhookLimitRejection> {
-    if observed > MAX_GITHUB_PUSH_COMMITS {
-        return Some(GithubWebhookLimitRejection::PushCommitCount);
-    }
-    None
-}
-
-const fn path_filter_commit_count_rejection(
-    observed: usize,
-) -> Option<GithubWebhookLimitRejection> {
-    if observed > MAX_GITHUB_PATH_FILTER_COMMITS {
-        return Some(GithubWebhookLimitRejection::PathFilterCommitCount);
+        return Some(GithubWebhookLimitRejection::GitRef);
     }
     None
 }
@@ -355,16 +333,7 @@ impl AuthenticatedGithubWebhook {
         if self.event_name.as_ref() != "push" {
             return Err(GithubWebhookError::UnsupportedEvent);
         }
-        let payload: PushPayload = serde_json::from_slice(&self.raw_body)
-            .map_err(|_| GithubWebhookError::MalformedPayload)?;
-        normalize_push(
-            PushRequestHeaders {
-                event_name: self.event_name,
-                delivery_id: self.delivery_id,
-            },
-            self.raw_body,
-            payload,
-        )
+        crate::webhook_event::push::decode_push(self)
     }
 }
 
@@ -504,8 +473,8 @@ impl GithubWebhookVerifier {
         hmac::verify(&self.key, &raw_body, &headers.signature)
             .map_err(|_| GithubWebhookError::AuthenticationFailed)?;
         Ok(AuthenticatedGithubWebhook {
-            delivery_id: headers.request.delivery_id,
-            event_name: headers.request.event_name,
+            delivery_id: headers.delivery_id,
+            event_name: headers.event_name,
             body_sha256: webhook_body_digest(&raw_body),
             raw_body,
         })
@@ -716,173 +685,6 @@ pub enum GithubRepositoryVisibility {
     Private,
 }
 
-/// Provider event-selection metadata retained without a compiler dependency.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GithubWebhookEventMetadata {
-    /// A push event and its exact provider flags.
-    Push {
-        /// Whether GitHub declared this reference newly created.
-        created: bool,
-        /// Whether GitHub declared this reference deleted.
-        deleted: bool,
-        /// Whether GitHub declared this a non-fast-forward update.
-        forced: bool,
-    },
-}
-
-/// Authenticated and strictly normalized GitHub push evidence.
-#[derive(Clone, Eq, PartialEq)]
-pub struct VerifiedGithubPush {
-    delivery_id: Box<str>,
-    event_name: Box<str>,
-    raw_body: Bytes,
-    body_sha256: GithubWebhookBodyDigest,
-    installation_id: NonZeroU64,
-    actor: Option<GithubEventActor>,
-    repository: GithubWebhookRepository,
-    git_ref: GithubWebhookRef,
-    before_commit_sha: Box<str>,
-    after_commit_sha: Box<str>,
-    metadata: GithubWebhookEventMetadata,
-    commit_count: usize,
-    complete_pushed_commit_revisions: Option<Box<[GitObjectId]>>,
-}
-
-impl VerifiedGithubPush {
-    /// Returns the exact singleton `X-GitHub-Delivery` value.
-    ///
-    /// This header is outside the body MAC and must be included separately in
-    /// any durable request or idempotency digest.
-    pub fn delivery_id(&self) -> &str {
-        &self.delivery_id
-    }
-
-    /// Returns the exact singleton `X-GitHub-Event` value.
-    ///
-    /// This header is outside the body MAC and must be included separately in
-    /// any durable request digest.
-    pub fn event_name(&self) -> &str {
-        &self.event_name
-    }
-
-    /// Returns the exact authenticated JSON bytes without reserialization.
-    pub fn raw_body(&self) -> &Bytes {
-        &self.raw_body
-    }
-
-    /// Returns SHA-256 of the exact authenticated body.
-    pub const fn body_sha256(&self) -> GithubWebhookBodyDigest {
-        self.body_sha256
-    }
-
-    /// Returns the nonzero GitHub App installation identifier.
-    pub const fn installation_id(&self) -> NonZeroU64 {
-        self.installation_id
-    }
-
-    /// Returns the authenticated sender facts when supplied by the webhook.
-    #[must_use]
-    pub const fn actor(&self) -> Option<&GithubEventActor> {
-        self.actor.as_ref()
-    }
-
-    /// Returns the internally consistent provider repository identity.
-    pub const fn repository(&self) -> &GithubWebhookRepository {
-        &self.repository
-    }
-
-    /// Returns the canonical full branch or tag reference.
-    pub const fn git_ref(&self) -> &GithubWebhookRef {
-        &self.git_ref
-    }
-
-    /// Returns the canonical lowercase 40-hex pre-push commit identifier.
-    pub fn before_commit_sha(&self) -> &str {
-        &self.before_commit_sha
-    }
-
-    /// Returns the canonical lowercase 40-hex post-push commit identifier.
-    pub fn after_commit_sha(&self) -> &str {
-        &self.after_commit_sha
-    }
-
-    /// Returns provider metadata required for later trigger selection.
-    pub const fn event_metadata(&self) -> GithubWebhookEventMetadata {
-        self.metadata
-    }
-
-    /// Returns the bounded number of commit summaries observed in the payload.
-    ///
-    /// GitHub caps the webhook array at [`MAX_GITHUB_PUSH_COMMITS`], so this is
-    /// not a claim about the total size of a larger truncated push.
-    pub const fn commit_count(&self) -> usize {
-        self.commit_count
-    }
-
-    /// Returns the complete canonical pushed-commit set when path filtering
-    /// requires a provider diff.
-    ///
-    /// The revisions are lexicographically sorted because provider array order
-    /// is not diff-base authority. `Some(empty)` is complete evidence for an
-    /// empty array. `None` means the payload contained more than 1,000 commits,
-    /// for which GitHub Actions bypasses path-filter diff generation.
-    pub fn complete_pushed_commit_revisions(&self) -> Option<&[GitObjectId]> {
-        self.complete_pushed_commit_revisions.as_deref()
-    }
-
-    /// Returns whether GitHub Actions' commit ceiling requires path filters to
-    /// match without generating a diff.
-    pub const fn path_filter_commit_limit_exceeded(&self) -> bool {
-        self.complete_pushed_commit_revisions.is_none()
-    }
-
-    /// Returns the exact provider deletion flag.
-    pub const fn deleted(&self) -> bool {
-        match self.metadata {
-            GithubWebhookEventMetadata::Push { deleted, .. } => deleted,
-        }
-    }
-
-    /// Returns the exact provider creation flag.
-    pub const fn created(&self) -> bool {
-        match self.metadata {
-            GithubWebhookEventMetadata::Push { created, .. } => created,
-        }
-    }
-
-    /// Returns the exact provider forced-update flag.
-    pub const fn forced(&self) -> bool {
-        match self.metadata {
-            GithubWebhookEventMetadata::Push { forced, .. } => forced,
-        }
-    }
-}
-
-impl fmt::Debug for VerifiedGithubPush {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("VerifiedGithubPush")
-            .field("delivery_id", &"[redacted]")
-            .field("event_name", &self.event_name)
-            .field("raw_body", &"[redacted]")
-            .field("body_len", &self.raw_body.len())
-            .field("body_sha256", &self.body_sha256)
-            .field("installation_id", &self.installation_id)
-            .field("actor", &self.actor)
-            .field("repository", &self.repository)
-            .field("git_ref", &self.git_ref)
-            .field("before_commit_sha", &"[redacted]")
-            .field("after_commit_sha", &"[redacted]")
-            .field("metadata", &self.metadata)
-            .field("commit_count", &self.commit_count)
-            .field(
-                "complete_pushed_commit_revisions",
-                &self.complete_pushed_commit_revisions.is_some(),
-            )
-            .finish()
-    }
-}
-
 /// Sanitized webhook verification and normalization failures.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub enum GithubWebhookError {
@@ -941,14 +743,10 @@ pub enum GithubStoredWebhookError {
     IdentityMismatch,
 }
 
-struct PushRequestHeaders {
-    event_name: Box<str>,
-    delivery_id: Box<str>,
-}
-
 struct VerifiedHeaders {
     signature: [u8; 32],
-    request: PushRequestHeaders,
+    event_name: Box<str>,
+    delivery_id: Box<str>,
 }
 
 impl VerifiedHeaders {
@@ -970,10 +768,8 @@ impl VerifiedHeaders {
             .into();
         Ok(Self {
             signature,
-            request: PushRequestHeaders {
-                event_name,
-                delivery_id,
-            },
+            event_name,
+            delivery_id,
         })
     }
 }
@@ -1030,183 +826,6 @@ const fn lower_hex_nibble(value: u8) -> Option<u8> {
         b'a'..=b'f' => Some(value - b'a' + 10),
         _ => None,
     }
-}
-
-#[derive(Deserialize)]
-struct PushPayload {
-    #[serde(rename = "ref")]
-    git_ref: String,
-    before: String,
-    after: String,
-    created: bool,
-    deleted: bool,
-    forced: bool,
-    repository: PushRepositoryPayload,
-    installation: PushInstallationPayload,
-    #[serde(default)]
-    sender: Option<PushActorPayload>,
-    commits: BoundedCommits,
-}
-
-#[derive(Deserialize)]
-struct PushActorPayload {
-    id: u64,
-    #[serde(default)]
-    login: Option<String>,
-    #[serde(rename = "type", default)]
-    kind: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct PushRepositoryPayload {
-    id: u64,
-    private: bool,
-    visibility: String,
-    name: String,
-    full_name: String,
-    owner: PushOwnerPayload,
-}
-
-#[derive(Deserialize)]
-struct PushOwnerPayload {
-    id: u64,
-    login: String,
-}
-
-#[derive(Deserialize)]
-struct PushInstallationPayload {
-    id: u64,
-}
-
-#[derive(Deserialize)]
-struct PushCommitPayload {
-    id: String,
-}
-
-#[derive(Default)]
-struct BoundedCommits(Vec<PushCommitPayload>);
-
-struct NormalizedPushedCommits {
-    count: usize,
-    complete_revisions: Option<Box<[GitObjectId]>>,
-}
-
-impl<'de> Deserialize<'de> for BoundedCommits {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(BoundedCommitVisitor)
-    }
-}
-
-struct BoundedCommitVisitor;
-
-impl<'de> de::Visitor<'de> for BoundedCommitVisitor {
-    type Value = BoundedCommits;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("a bounded GitHub push commit collection")
-    }
-
-    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
-    where
-        A: de::SeqAccess<'de>,
-    {
-        let mut commits = Vec::new();
-        while let Some(commit) = sequence.next_element::<PushCommitPayload>()? {
-            let projected = commits
-                .len()
-                .checked_add(1)
-                .ok_or_else(|| de::Error::custom("push commit count exceeds limit"))?;
-            if push_commit_count_rejection(projected).is_some() {
-                return Err(de::Error::custom("push commit count exceeds limit"));
-            }
-            commits.push(commit);
-        }
-        Ok(BoundedCommits(commits))
-    }
-}
-
-fn normalize_push(
-    headers: PushRequestHeaders,
-    raw_body: Bytes,
-    payload: PushPayload,
-) -> Result<VerifiedGithubPush, GithubWebhookError> {
-    let installation_id = durable_provider_id(payload.installation.id)?;
-    let actor = payload
-        .sender
-        .map(|actor| {
-            GithubEventActor::from_webhook_fields(actor.id, actor.login, actor.kind.as_deref())
-        })
-        .transpose()?;
-    let repository = GithubWebhookRepository::from_webhook_fields(
-        payload.repository.id,
-        payload.repository.owner.id,
-        payload.repository.private,
-        &payload.repository.visibility,
-        payload.repository.owner.login,
-        payload.repository.name,
-        payload.repository.full_name,
-    )?;
-
-    let git_ref = parse_git_ref(payload.git_ref)?;
-    validate_commit_range(
-        &payload.before,
-        &payload.after,
-        payload.created,
-        payload.deleted,
-    )?;
-    let pushed_commits = normalize_pushed_commits(payload.commits)?;
-    let body_sha256 = webhook_body_digest(&raw_body);
-
-    Ok(VerifiedGithubPush {
-        delivery_id: headers.delivery_id,
-        event_name: headers.event_name,
-        raw_body,
-        body_sha256,
-        installation_id,
-        actor,
-        repository,
-        git_ref,
-        before_commit_sha: payload.before.into_boxed_str(),
-        after_commit_sha: payload.after.into_boxed_str(),
-        metadata: GithubWebhookEventMetadata::Push {
-            created: payload.created,
-            deleted: payload.deleted,
-            forced: payload.forced,
-        },
-        commit_count: pushed_commits.count,
-        complete_pushed_commit_revisions: pushed_commits.complete_revisions,
-    })
-}
-
-fn normalize_pushed_commits(
-    commits: BoundedCommits,
-) -> Result<NormalizedPushedCommits, GithubWebhookError> {
-    let mut revisions = Vec::with_capacity(commits.0.len());
-    for commit in commits.0 {
-        if commit.id == ZERO_COMMIT_SHA {
-            return Err(GithubWebhookError::InvalidPayload);
-        }
-        revisions.push(
-            GitObjectId::from_provider_hex(commit.id)
-                .map_err(|_| GithubWebhookError::InvalidPayload)?,
-        );
-    }
-    revisions.sort_unstable();
-    if revisions.windows(2).any(|pair| pair[0] == pair[1]) {
-        return Err(GithubWebhookError::InvalidPayload);
-    }
-
-    let commit_count = revisions.len();
-    let complete = path_filter_commit_count_rejection(commit_count)
-        .is_none()
-        .then(|| revisions.into_boxed_slice());
-    Ok(NormalizedPushedCommits {
-        count: commit_count,
-        complete_revisions: complete,
-    })
 }
 
 pub(crate) fn durable_provider_id(value: u64) -> Result<NonZeroU64, GithubWebhookError> {
@@ -1318,34 +937,6 @@ fn valid_git_ref_name(short_name: &str) -> bool {
     !invalid
 }
 
-fn validate_commit_range(
-    before: &str,
-    after: &str,
-    created: bool,
-    deleted: bool,
-) -> Result<(), GithubWebhookError> {
-    if !is_commit_sha(before)
-        || !is_commit_sha(after)
-        || created != (before == ZERO_COMMIT_SHA)
-        || deleted != (after == ZERO_COMMIT_SHA)
-        || (created && deleted)
-    {
-        return Err(GithubWebhookError::InvalidPayload);
-    }
-    Ok(())
-}
-
-fn is_commit_sha(value: &str) -> bool {
-    if value.len() != 40
-        || !value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
-    {
-        return false;
-    }
-    true
-}
-
 #[cfg(test)]
 mod limit_contract_tests {
     use super::*;
@@ -1362,7 +953,7 @@ mod limit_contract_tests {
         );
         assert_eq!(
             webhook_secret_byte_rejection(MAX_GITHUB_WEBHOOK_SECRET_BYTES + 1),
-            Some(GithubWebhookLimitRejection::SecretBytes)
+            Some(GithubWebhookLimitRejection::Secret)
         );
     }
 
@@ -1372,7 +963,7 @@ mod limit_contract_tests {
         assert_eq!(delivery_id_byte_rejection(MAX_DELIVERY_ID_BYTES), None);
         assert_eq!(
             delivery_id_byte_rejection(MAX_DELIVERY_ID_BYTES + 1),
-            Some(GithubWebhookLimitRejection::DeliveryIdBytes)
+            Some(GithubWebhookLimitRejection::DeliveryId)
         );
     }
 
@@ -1382,36 +973,7 @@ mod limit_contract_tests {
         assert_eq!(git_ref_byte_rejection(MAX_GIT_REF_BYTES), None);
         assert_eq!(
             git_ref_byte_rejection(MAX_GIT_REF_BYTES + 1),
-            Some(GithubWebhookLimitRejection::GitRefBytes)
-        );
-    }
-
-    #[test]
-    fn push_commit_count_limit_has_exact_boundaries() {
-        assert_eq!(
-            push_commit_count_rejection(MAX_GITHUB_PUSH_COMMITS - 1),
-            None
-        );
-        assert_eq!(push_commit_count_rejection(MAX_GITHUB_PUSH_COMMITS), None);
-        assert_eq!(
-            push_commit_count_rejection(MAX_GITHUB_PUSH_COMMITS + 1),
-            Some(GithubWebhookLimitRejection::PushCommitCount)
-        );
-    }
-
-    #[test]
-    fn path_filter_commit_count_limit_has_exact_boundaries() {
-        assert_eq!(
-            path_filter_commit_count_rejection(MAX_GITHUB_PATH_FILTER_COMMITS - 1),
-            None
-        );
-        assert_eq!(
-            path_filter_commit_count_rejection(MAX_GITHUB_PATH_FILTER_COMMITS),
-            None
-        );
-        assert_eq!(
-            path_filter_commit_count_rejection(MAX_GITHUB_PATH_FILTER_COMMITS + 1),
-            Some(GithubWebhookLimitRejection::PathFilterCommitCount)
+            Some(GithubWebhookLimitRejection::GitRef)
         );
     }
 }

--- a/crates/automata-ci-provider-github/src/webhook_event.rs
+++ b/crates/automata-ci-provider-github/src/webhook_event.rs
@@ -11,9 +11,130 @@ use serde_json::{Map as JsonMap, Value as JsonValue};
 use crate::event::GithubEventActor;
 use crate::webhook::{
     AuthenticatedGithubWebhook, GithubWebhookBodyDigest, GithubWebhookError, GithubWebhookRef,
-    GithubWebhookRefKind, GithubWebhookRepository, VerifiedGithubPush, durable_provider_id,
-    normalize_branch_name, parse_git_ref,
+    GithubWebhookRefKind, GithubWebhookRepository, durable_provider_id, normalize_branch_name,
+    parse_git_ref,
 };
+
+macro_rules! verified_github_webhook_authenticated_accessors {
+    (push) => {
+        /// Returns the exact singleton `X-GitHub-Delivery` value.
+        ///
+        /// This header is outside the body MAC and must be included separately in
+        /// any durable request or idempotency digest.
+        pub fn delivery_id(&self) -> &str {
+            self.identity.authenticated.delivery_id()
+        }
+
+        /// Returns the exact singleton `X-GitHub-Event` value.
+        ///
+        /// This header is outside the body MAC and must be included separately in
+        /// any durable request digest.
+        pub fn event_name(&self) -> &str {
+            self.identity.authenticated.event_name()
+        }
+
+        /// Returns the exact authenticated JSON bytes without reserialization.
+        pub fn raw_body(&self) -> &Bytes {
+            self.identity.authenticated.raw_body()
+        }
+
+        /// Returns SHA-256 of the exact authenticated body.
+        pub const fn body_sha256(&self) -> GithubWebhookBodyDigest {
+            self.identity.authenticated.body_sha256()
+        }
+
+        /// Returns the nonzero GitHub App installation identifier.
+        pub const fn installation_id(&self) -> NonZeroU64 {
+            self.identity.installation_id
+        }
+    };
+    ($event_name:literal, $installation:literal) => {
+        /// Returns the exact singleton delivery header outside the body MAC.
+        #[must_use]
+        pub fn delivery_id(&self) -> &str {
+            self.identity.authenticated.delivery_id()
+        }
+
+        #[doc = $event_name]
+        #[must_use]
+        pub fn event_name(&self) -> &str {
+            self.identity.authenticated.event_name()
+        }
+
+        /// Returns the exact HMAC-authenticated body without reserialization.
+        #[must_use]
+        pub const fn raw_body(&self) -> &Bytes {
+            self.identity.authenticated.raw_body()
+        }
+
+        /// Returns SHA-256 of the exact authenticated body.
+        #[must_use]
+        pub const fn body_sha256(&self) -> GithubWebhookBodyDigest {
+            self.identity.authenticated.body_sha256()
+        }
+
+        #[doc = $installation]
+        #[must_use]
+        pub const fn installation_id(&self) -> NonZeroU64 {
+            self.identity.installation_id
+        }
+    };
+}
+
+macro_rules! verified_github_webhook_repository_accessor {
+    (push) => {
+        /// Returns the internally consistent provider repository identity.
+        pub const fn repository(&self) -> &GithubWebhookRepository {
+            &self.identity.repository
+        }
+    };
+    ($repository:literal) => {
+        #[doc = $repository]
+        #[must_use]
+        pub const fn repository(&self) -> &GithubWebhookRepository {
+            &self.identity.repository
+        }
+    };
+}
+
+macro_rules! verified_github_webhook_accessors {
+    (|$event:ident| $(
+        $(#[$attribute:meta])*
+        [$($constness:tt)*] fn $name:ident -> $return_type:ty = $body:expr;
+    )*) => {
+        $(
+            $(#[$attribute])*
+            pub $($constness)* fn $name(&self) -> $return_type {
+                let $event = self;
+                $body
+            }
+        )*
+    };
+}
+
+macro_rules! debug_verified_github_webhook_identity {
+    ($debug:ident, $identity:expr, workflow) => {
+        $debug
+            .field("delivery_id", &"[redacted]")
+            .field("event_name", &$identity.authenticated.event_name())
+            .field("raw_body", &"[redacted]")
+            .field("body_len", &$identity.authenticated.raw_body().len())
+            .field("body_sha256", &$identity.authenticated.body_sha256())
+            .field("installation_id", &$identity.installation_id);
+    };
+    ($debug:ident, $identity:expr, control) => {
+        $debug
+            .field("delivery_id", &"[redacted]")
+            .field("event_name", &$identity.authenticated.event_name())
+            .field("body_sha256", &$identity.authenticated.body_sha256())
+            .field("installation_id", &$identity.installation_id)
+            .field("repository", &$identity.repository);
+    };
+}
+
+pub(super) mod push;
+
+use push::VerifiedGithubPush;
 
 const ZERO_COMMIT_SHA: &str = "0000000000000000000000000000000000000000";
 const MAX_REPOSITORY_DISPATCH_EVENT_TYPE_CHARS: usize = 100;
@@ -52,6 +173,27 @@ const fn repository_dispatch_payload_character_rejection(
         return Some(GithubRepositoryDispatchLimitRejection::ClientPayloadCharacters);
     }
     None
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct VerifiedGithubWebhookIdentity {
+    authenticated: AuthenticatedGithubWebhook,
+    installation_id: NonZeroU64,
+    repository: GithubWebhookRepository,
+}
+
+impl VerifiedGithubWebhookIdentity {
+    const fn new(
+        authenticated: AuthenticatedGithubWebhook,
+        installation_id: NonZeroU64,
+        repository: GithubWebhookRepository,
+    ) -> Self {
+        Self {
+            authenticated,
+            installation_id,
+            repository,
+        }
+    }
 }
 
 /// A currently documented GitHub `pull_request` webhook activity.
@@ -203,82 +345,51 @@ pub enum VerifiedGithubWebhook {
 }
 
 impl VerifiedGithubWebhook {
+    const fn identity(&self) -> &VerifiedGithubWebhookIdentity {
+        match self {
+            Self::Push(event) => &event.identity,
+            Self::PullRequest(event) => &event.identity,
+            Self::MergeGroup(event) => &event.identity,
+            Self::RepositoryDispatch(event) => &event.identity,
+            Self::CheckRun(event) => &event.identity,
+            Self::CheckSuite(event) => &event.identity,
+        }
+    }
+
     /// Returns the exact singleton delivery header outside the body MAC.
     #[must_use]
     pub fn delivery_id(&self) -> &str {
-        match self {
-            Self::Push(event) => event.delivery_id(),
-            Self::PullRequest(event) => event.delivery_id(),
-            Self::MergeGroup(event) => event.delivery_id(),
-            Self::RepositoryDispatch(event) => event.delivery_id(),
-            Self::CheckRun(event) => event.delivery_id(),
-            Self::CheckSuite(event) => event.delivery_id(),
-        }
+        self.identity().authenticated.delivery_id()
     }
 
     /// Returns the exact singleton event-name header outside the body MAC.
     #[must_use]
     pub fn event_name(&self) -> &str {
-        match self {
-            Self::Push(event) => event.event_name(),
-            Self::PullRequest(event) => event.event_name(),
-            Self::MergeGroup(event) => event.event_name(),
-            Self::RepositoryDispatch(event) => event.event_name(),
-            Self::CheckRun(event) => event.event_name(),
-            Self::CheckSuite(event) => event.event_name(),
-        }
+        self.identity().authenticated.event_name()
     }
 
     /// Returns the exact HMAC-authenticated body without reserialization.
     #[must_use]
     pub fn raw_body(&self) -> &Bytes {
-        match self {
-            Self::Push(event) => event.raw_body(),
-            Self::PullRequest(event) => event.raw_body(),
-            Self::MergeGroup(event) => event.raw_body(),
-            Self::RepositoryDispatch(event) => event.raw_body(),
-            Self::CheckRun(event) => event.raw_body(),
-            Self::CheckSuite(event) => event.raw_body(),
-        }
+        self.identity().authenticated.raw_body()
     }
 
     /// Returns SHA-256 of the exact authenticated body.
     #[must_use]
     pub const fn body_sha256(&self) -> GithubWebhookBodyDigest {
-        match self {
-            Self::Push(event) => event.body_sha256(),
-            Self::PullRequest(event) => event.body_sha256(),
-            Self::MergeGroup(event) => event.body_sha256(),
-            Self::RepositoryDispatch(event) => event.body_sha256(),
-            Self::CheckRun(event) => event.body_sha256(),
-            Self::CheckSuite(event) => event.body_sha256(),
-        }
+        self.identity().authenticated.body_sha256()
     }
 
     /// Returns the nonzero GitHub App installation identifier.
     #[must_use]
     pub const fn installation_id(&self) -> NonZeroU64 {
-        match self {
-            Self::Push(event) => event.installation_id(),
-            Self::PullRequest(event) => event.installation_id(),
-            Self::MergeGroup(event) => event.installation_id(),
-            Self::RepositoryDispatch(event) => event.installation_id(),
-            Self::CheckRun(event) => event.installation_id(),
-            Self::CheckSuite(event) => event.installation_id(),
-        }
+        self.identity().installation_id
     }
 
     /// Returns the internally consistent event repository identity.
     #[must_use]
     pub const fn repository(&self) -> &GithubWebhookRepository {
-        match self {
-            Self::Push(event) => event.repository(),
-            Self::PullRequest(event) => event.repository(),
-            Self::MergeGroup(event) => event.repository(),
-            Self::RepositoryDispatch(event) => event.repository(),
-            Self::CheckRun(event) => event.repository(),
-            Self::CheckSuite(event) => event.repository(),
-        }
+        &self.identity().repository
     }
 }
 
@@ -301,9 +412,7 @@ impl fmt::Debug for VerifiedGithubWebhook {
 /// Authenticated identity for one native Check Run rerun control.
 #[derive(Clone, Eq, PartialEq)]
 pub struct VerifiedGithubCheckRun {
-    authenticated: AuthenticatedGithubWebhook,
-    installation_id: NonZeroU64,
-    repository: GithubWebhookRepository,
+    identity: VerifiedGithubWebhookIdentity,
     actor: GithubEventActor,
     app_id: NonZeroU64,
     run_id: NonZeroU64,
@@ -314,82 +423,43 @@ pub struct VerifiedGithubCheckRun {
 }
 
 impl VerifiedGithubCheckRun {
-    /// Returns the exact singleton delivery header outside the body MAC.
-    #[must_use]
-    pub fn delivery_id(&self) -> &str {
-        self.authenticated.delivery_id()
-    }
-    /// Returns the exact `check_run` event-name header.
-    #[must_use]
-    pub fn event_name(&self) -> &str {
-        self.authenticated.event_name()
-    }
-    /// Returns the exact HMAC-authenticated body without reserialization.
-    #[must_use]
-    pub const fn raw_body(&self) -> &Bytes {
-        self.authenticated.raw_body()
-    }
-    /// Returns SHA-256 of the exact authenticated body.
-    #[must_use]
-    pub const fn body_sha256(&self) -> GithubWebhookBodyDigest {
-        self.authenticated.body_sha256()
-    }
-    /// Returns the nonzero App installation identifier.
-    #[must_use]
-    pub const fn installation_id(&self) -> NonZeroU64 {
-        self.installation_id
-    }
-    /// Returns the exact repository from the signed payload.
-    #[must_use]
-    pub const fn repository(&self) -> &GithubWebhookRepository {
-        &self.repository
-    }
-    /// Returns the authenticated GitHub sender facts to reauthorize.
-    #[must_use]
-    pub const fn actor(&self) -> &GithubEventActor {
-        &self.actor
-    }
-    /// Returns the GitHub App that owns the Check Run.
-    #[must_use]
-    pub const fn app_id(&self) -> NonZeroU64 {
-        self.app_id
-    }
-    /// Returns the exact Check Run identifier.
-    #[must_use]
-    pub const fn run_id(&self) -> NonZeroU64 {
-        self.run_id
-    }
-    /// Returns the exact Check Suite identifier.
-    #[must_use]
-    pub const fn suite_id(&self) -> NonZeroU64 {
-        self.suite_id
-    }
-    /// Returns the exact checked commit.
-    #[must_use]
-    pub const fn head_revision(&self) -> &GitObjectId {
-        &self.head_revision
-    }
-    /// Returns Automata's bounded external Check identity.
-    #[must_use]
-    pub fn external_id(&self) -> &str {
-        &self.external_id
-    }
-    /// Returns the requested rerun operation.
-    #[must_use]
-    pub const fn action(&self) -> GithubCheckRunAction {
-        self.action
+    verified_github_webhook_authenticated_accessors!(
+        "Returns the exact `check_run` event-name header.",
+        "Returns the nonzero App installation identifier."
+    );
+    verified_github_webhook_repository_accessor!(
+        "Returns the exact repository from the signed payload."
+    );
+    verified_github_webhook_accessors! { |event|
+        /// Returns the authenticated GitHub sender facts to reauthorize.
+        #[must_use]
+        [const] fn actor -> &GithubEventActor = &event.actor;
+        /// Returns the GitHub App that owns the Check Run.
+        #[must_use]
+        [const] fn app_id -> NonZeroU64 = event.app_id;
+        /// Returns the exact Check Run identifier.
+        #[must_use]
+        [const] fn run_id -> NonZeroU64 = event.run_id;
+        /// Returns the exact Check Suite identifier.
+        #[must_use]
+        [const] fn suite_id -> NonZeroU64 = event.suite_id;
+        /// Returns the exact checked commit.
+        #[must_use]
+        [const] fn head_revision -> &GitObjectId = &event.head_revision;
+        /// Returns Automata's bounded external Check identity.
+        #[must_use]
+        [] fn external_id -> &str = &event.external_id;
+        /// Returns the requested rerun operation.
+        #[must_use]
+        [const] fn action -> GithubCheckRunAction = event.action;
     }
 }
 
 impl fmt::Debug for VerifiedGithubCheckRun {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("VerifiedGithubCheckRun")
-            .field("delivery_id", &"[redacted]")
-            .field("event_name", &self.authenticated.event_name())
-            .field("body_sha256", &self.authenticated.body_sha256())
-            .field("installation_id", &self.installation_id)
-            .field("repository", &self.repository)
+        let mut debug = formatter.debug_struct("VerifiedGithubCheckRun");
+        debug_verified_github_webhook_identity!(debug, self.identity, control);
+        debug
             .field("actor", &self.actor)
             .field("app_id", &self.app_id)
             .field("run_id", &self.run_id)
@@ -404,9 +474,7 @@ impl fmt::Debug for VerifiedGithubCheckRun {
 /// Authenticated identity for one native Check Suite re-request.
 #[derive(Clone, Eq, PartialEq)]
 pub struct VerifiedGithubCheckSuite {
-    authenticated: AuthenticatedGithubWebhook,
-    installation_id: NonZeroU64,
-    repository: GithubWebhookRepository,
+    identity: VerifiedGithubWebhookIdentity,
     actor: GithubEventActor,
     app_id: NonZeroU64,
     suite_id: NonZeroU64,
@@ -414,67 +482,34 @@ pub struct VerifiedGithubCheckSuite {
 }
 
 impl VerifiedGithubCheckSuite {
-    /// Returns the exact singleton delivery header outside the body MAC.
-    #[must_use]
-    pub fn delivery_id(&self) -> &str {
-        self.authenticated.delivery_id()
-    }
-    /// Returns the exact `check_suite` event-name header.
-    #[must_use]
-    pub fn event_name(&self) -> &str {
-        self.authenticated.event_name()
-    }
-    /// Returns the exact HMAC-authenticated body without reserialization.
-    #[must_use]
-    pub const fn raw_body(&self) -> &Bytes {
-        self.authenticated.raw_body()
-    }
-    /// Returns SHA-256 of the exact authenticated body.
-    #[must_use]
-    pub const fn body_sha256(&self) -> GithubWebhookBodyDigest {
-        self.authenticated.body_sha256()
-    }
-    /// Returns the nonzero App installation identifier.
-    #[must_use]
-    pub const fn installation_id(&self) -> NonZeroU64 {
-        self.installation_id
-    }
-    /// Returns the exact repository from the signed payload.
-    #[must_use]
-    pub const fn repository(&self) -> &GithubWebhookRepository {
-        &self.repository
-    }
-    /// Returns the authenticated GitHub sender facts to reauthorize.
-    #[must_use]
-    pub const fn actor(&self) -> &GithubEventActor {
-        &self.actor
-    }
-    /// Returns the GitHub App that owns the Check Suite.
-    #[must_use]
-    pub const fn app_id(&self) -> NonZeroU64 {
-        self.app_id
-    }
-    /// Returns the exact Check Suite identifier.
-    #[must_use]
-    pub const fn suite_id(&self) -> NonZeroU64 {
-        self.suite_id
-    }
-    /// Returns the exact checked commit.
-    #[must_use]
-    pub const fn head_revision(&self) -> &GitObjectId {
-        &self.head_revision
+    verified_github_webhook_authenticated_accessors!(
+        "Returns the exact `check_suite` event-name header.",
+        "Returns the nonzero App installation identifier."
+    );
+    verified_github_webhook_repository_accessor!(
+        "Returns the exact repository from the signed payload."
+    );
+    verified_github_webhook_accessors! { |event|
+        /// Returns the authenticated GitHub sender facts to reauthorize.
+        #[must_use]
+        [const] fn actor -> &GithubEventActor = &event.actor;
+        /// Returns the GitHub App that owns the Check Suite.
+        #[must_use]
+        [const] fn app_id -> NonZeroU64 = event.app_id;
+        /// Returns the exact Check Suite identifier.
+        #[must_use]
+        [const] fn suite_id -> NonZeroU64 = event.suite_id;
+        /// Returns the exact checked commit.
+        #[must_use]
+        [const] fn head_revision -> &GitObjectId = &event.head_revision;
     }
 }
 
 impl fmt::Debug for VerifiedGithubCheckSuite {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("VerifiedGithubCheckSuite")
-            .field("delivery_id", &"[redacted]")
-            .field("event_name", &self.authenticated.event_name())
-            .field("body_sha256", &self.authenticated.body_sha256())
-            .field("installation_id", &self.installation_id)
-            .field("repository", &self.repository)
+        let mut debug = formatter.debug_struct("VerifiedGithubCheckSuite");
+        debug_verified_github_webhook_identity!(debug, self.identity, control);
+        debug
             .field("actor", &self.actor)
             .field("app_id", &self.app_id)
             .field("suite_id", &self.suite_id)
@@ -489,10 +524,8 @@ impl fmt::Debug for VerifiedGithubCheckSuite {
 /// body and this typed view, but is always redacted from `Debug` output.
 #[derive(Clone, Eq, PartialEq)]
 pub struct VerifiedGithubRepositoryDispatch {
-    authenticated: AuthenticatedGithubWebhook,
-    installation_id: NonZeroU64,
+    identity: VerifiedGithubWebhookIdentity,
     actor: Option<GithubEventActor>,
-    repository: GithubWebhookRepository,
     event_type: Box<str>,
     branch: Box<str>,
     git_ref: Box<str>,
@@ -500,85 +533,44 @@ pub struct VerifiedGithubRepositoryDispatch {
 }
 
 impl VerifiedGithubRepositoryDispatch {
-    /// Returns the exact singleton delivery header outside the body MAC.
-    #[must_use]
-    pub fn delivery_id(&self) -> &str {
-        self.authenticated.delivery_id()
+    verified_github_webhook_authenticated_accessors!(
+        "Returns the exact `repository_dispatch` event-name header.",
+        "Returns the nonzero GitHub App installation identifier."
+    );
+
+    verified_github_webhook_accessors! { |event|
+        /// Returns the authenticated sender facts when supplied by the webhook.
+        #[must_use]
+        [const] fn actor -> Option<&GithubEventActor> = event.actor.as_ref();
     }
 
-    /// Returns the exact `repository_dispatch` event-name header.
-    #[must_use]
-    pub fn event_name(&self) -> &str {
-        self.authenticated.event_name()
-    }
+    verified_github_webhook_repository_accessor!(
+        "Returns the repository that received the custom dispatch."
+    );
 
-    /// Returns the exact HMAC-authenticated body without reserialization.
-    #[must_use]
-    pub const fn raw_body(&self) -> &Bytes {
-        self.authenticated.raw_body()
-    }
-
-    /// Returns SHA-256 of the exact authenticated body.
-    #[must_use]
-    pub const fn body_sha256(&self) -> GithubWebhookBodyDigest {
-        self.authenticated.body_sha256()
-    }
-
-    /// Returns the nonzero GitHub App installation identifier.
-    #[must_use]
-    pub const fn installation_id(&self) -> NonZeroU64 {
-        self.installation_id
-    }
-
-    /// Returns the authenticated sender facts when supplied by the webhook.
-    #[must_use]
-    pub const fn actor(&self) -> Option<&GithubEventActor> {
-        self.actor.as_ref()
-    }
-
-    /// Returns the repository that received the custom dispatch.
-    #[must_use]
-    pub const fn repository(&self) -> &GithubWebhookRepository {
-        &self.repository
-    }
-
-    /// Returns the bounded custom event type used by `on.repository_dispatch.types`.
-    #[must_use]
-    pub fn event_type(&self) -> &str {
-        &self.event_type
-    }
-
-    /// Returns the validated unqualified default-branch name.
-    #[must_use]
-    pub fn branch(&self) -> &str {
-        &self.branch
-    }
-
-    /// Returns the full default-branch reference used by the workflow run.
-    #[must_use]
-    pub fn git_ref(&self) -> &str {
-        &self.git_ref
-    }
-
-    /// Returns the bounded custom client payload, or `None` for JSON `null`.
-    #[must_use]
-    pub const fn client_payload(&self) -> Option<&JsonMap<String, JsonValue>> {
-        self.client_payload.as_ref()
+    verified_github_webhook_accessors! { |event|
+        /// Returns the bounded custom event type used by `on.repository_dispatch.types`.
+        #[must_use]
+        [] fn event_type -> &str = &event.event_type;
+        /// Returns the validated unqualified default-branch name.
+        #[must_use]
+        [] fn branch -> &str = &event.branch;
+        /// Returns the full default-branch reference used by the workflow run.
+        #[must_use]
+        [] fn git_ref -> &str = &event.git_ref;
+        /// Returns the bounded custom client payload, or `None` for JSON `null`.
+        #[must_use]
+        [const] fn client_payload -> Option<&JsonMap<String, JsonValue>> = event.client_payload.as_ref();
     }
 }
 
 impl fmt::Debug for VerifiedGithubRepositoryDispatch {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("VerifiedGithubRepositoryDispatch")
-            .field("delivery_id", &"[redacted]")
-            .field("event_name", &self.authenticated.event_name())
-            .field("raw_body", &"[redacted]")
-            .field("body_len", &self.authenticated.raw_body().len())
-            .field("body_sha256", &self.authenticated.body_sha256())
-            .field("installation_id", &self.installation_id)
+        let mut debug = formatter.debug_struct("VerifiedGithubRepositoryDispatch");
+        debug_verified_github_webhook_identity!(debug, self.identity, workflow);
+        debug
             .field("actor", &self.actor)
-            .field("repository", &self.repository)
+            .field("repository", &self.identity.repository)
             .field("event_type", &"[redacted]")
             .field("branch", &"[redacted]")
             .field("git_ref", &"[redacted]")
@@ -590,11 +582,9 @@ impl fmt::Debug for VerifiedGithubRepositoryDispatch {
 /// Authenticated and strictly normalized pull-request webhook evidence.
 #[derive(Clone, Eq, PartialEq)]
 pub struct VerifiedGithubPullRequest {
-    authenticated: AuthenticatedGithubWebhook,
-    installation_id: NonZeroU64,
+    identity: VerifiedGithubWebhookIdentity,
     actor: Option<GithubEventActor>,
     source_actor: Option<GithubEventActor>,
-    repository: GithubWebhookRepository,
     head_repository: GithubWebhookRepository,
     number: NonZeroU64,
     action: GithubPullRequestAction,
@@ -609,138 +599,73 @@ pub struct VerifiedGithubPullRequest {
 }
 
 impl VerifiedGithubPullRequest {
-    /// Returns the exact singleton delivery header outside the body MAC.
-    #[must_use]
-    pub fn delivery_id(&self) -> &str {
-        self.authenticated.delivery_id()
+    verified_github_webhook_authenticated_accessors!(
+        "Returns the exact `pull_request` event-name header.",
+        "Returns the nonzero GitHub App installation identifier."
+    );
+
+    verified_github_webhook_accessors! { |event|
+        /// Returns the authenticated event sender facts when supplied by GitHub.
+        #[must_use]
+        [const] fn actor -> Option<&GithubEventActor> = event.actor.as_ref();
+        /// Returns the pull-request author's authenticated identity facts when
+        /// supplied by GitHub.
+        #[must_use]
+        [const] fn source_actor -> Option<&GithubEventActor> = event.source_actor.as_ref();
     }
 
-    /// Returns the exact `pull_request` event-name header.
-    #[must_use]
-    pub fn event_name(&self) -> &str {
-        self.authenticated.event_name()
-    }
+    verified_github_webhook_repository_accessor!(
+        "Returns the base repository where the pull request occurred."
+    );
 
-    /// Returns the exact HMAC-authenticated body without reserialization.
-    #[must_use]
-    pub const fn raw_body(&self) -> &Bytes {
-        self.authenticated.raw_body()
-    }
-
-    /// Returns SHA-256 of the exact authenticated body.
-    #[must_use]
-    pub const fn body_sha256(&self) -> GithubWebhookBodyDigest {
-        self.authenticated.body_sha256()
-    }
-
-    /// Returns the nonzero GitHub App installation identifier.
-    #[must_use]
-    pub const fn installation_id(&self) -> NonZeroU64 {
-        self.installation_id
-    }
-
-    /// Returns the authenticated event sender facts when supplied by GitHub.
-    #[must_use]
-    pub const fn actor(&self) -> Option<&GithubEventActor> {
-        self.actor.as_ref()
-    }
-
-    /// Returns the pull-request author's authenticated identity facts when
-    /// supplied by GitHub.
-    #[must_use]
-    pub const fn source_actor(&self) -> Option<&GithubEventActor> {
-        self.source_actor.as_ref()
-    }
-
-    /// Returns the base repository where the pull request occurred.
-    #[must_use]
-    pub const fn repository(&self) -> &GithubWebhookRepository {
-        &self.repository
-    }
-
-    /// Returns the exact source repository for the pull-request head.
-    #[must_use]
-    pub const fn head_repository(&self) -> &GithubWebhookRepository {
-        &self.head_repository
-    }
-
-    /// Returns the positive pull-request number within the base repository.
-    #[must_use]
-    pub const fn number(&self) -> NonZeroU64 {
-        self.number
-    }
-
-    /// Returns the validated provider activity.
-    #[must_use]
-    pub const fn action(&self) -> GithubPullRequestAction {
-        self.action
-    }
-
-    /// Returns whether this event describes a pull request that was merged.
-    #[must_use]
-    pub const fn merged(&self) -> bool {
-        self.merged
-    }
-
-    /// Returns whether the pull request is currently a draft.
-    #[must_use]
-    pub const fn draft(&self) -> bool {
-        self.draft
-    }
-
-    /// Returns the canonical pull-request head commit.
-    #[must_use]
-    pub const fn head_revision(&self) -> &GitObjectId {
-        &self.head_revision
-    }
-
-    /// Returns the canonical base-branch commit observed by the payload.
-    #[must_use]
-    pub const fn base_revision(&self) -> &GitObjectId {
-        &self.base_revision
-    }
-
-    /// Returns the merge-branch commit used as `GITHUB_SHA` for this event.
-    ///
-    /// GitHub may send `null` before it has materialized the pull-request merge
-    /// commit; absence remains explicit rather than inventing an object identity.
-    #[must_use]
-    pub const fn merge_revision(&self) -> Option<GitObjectId> {
-        self.merge_revision
-    }
-
-    /// Returns the validated unqualified pull-request head branch.
-    #[must_use]
-    pub fn head_ref(&self) -> &str {
-        &self.head_ref
-    }
-
-    /// Returns the validated unqualified target branch used by trigger filters.
-    #[must_use]
-    pub fn base_ref(&self) -> &str {
-        &self.base_ref
-    }
-
-    /// Returns the full ref GitHub assigns to the workflow run.
-    #[must_use]
-    pub fn git_ref(&self) -> &str {
-        &self.git_ref
+    verified_github_webhook_accessors! { |event|
+        /// Returns the exact source repository for the pull-request head.
+        #[must_use]
+        [const] fn head_repository -> &GithubWebhookRepository = &event.head_repository;
+        /// Returns the positive pull-request number within the base repository.
+        #[must_use]
+        [const] fn number -> NonZeroU64 = event.number;
+        /// Returns the validated provider activity.
+        #[must_use]
+        [const] fn action -> GithubPullRequestAction = event.action;
+        /// Returns whether this event describes a pull request that was merged.
+        #[must_use]
+        [const] fn merged -> bool = event.merged;
+        /// Returns whether the pull request is currently a draft.
+        #[must_use]
+        [const] fn draft -> bool = event.draft;
+        /// Returns the canonical pull-request head commit.
+        #[must_use]
+        [const] fn head_revision -> &GitObjectId = &event.head_revision;
+        /// Returns the canonical base-branch commit observed by the payload.
+        #[must_use]
+        [const] fn base_revision -> &GitObjectId = &event.base_revision;
+        /// Returns the merge-branch commit used as `GITHUB_SHA` for this event.
+        ///
+        /// GitHub may send `null` before it has materialized the pull-request merge
+        /// commit; absence remains explicit rather than inventing an object identity.
+        #[must_use]
+        [const] fn merge_revision -> Option<GitObjectId> = event.merge_revision;
+        /// Returns the validated unqualified pull-request head branch.
+        #[must_use]
+        [] fn head_ref -> &str = &event.head_ref;
+        /// Returns the validated unqualified target branch used by trigger filters.
+        #[must_use]
+        [] fn base_ref -> &str = &event.base_ref;
+        /// Returns the full ref GitHub assigns to the workflow run.
+        #[must_use]
+        [] fn git_ref -> &str = &event.git_ref;
     }
 }
 
 impl fmt::Debug for VerifiedGithubPullRequest {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("VerifiedGithubPullRequest")
-            .field("delivery_id", &"[redacted]")
-            .field("event_name", &self.authenticated.event_name())
-            .field("raw_body", &"[redacted]")
-            .field("body_len", &self.authenticated.raw_body().len())
-            .field("body_sha256", &self.authenticated.body_sha256())
-            .field("installation_id", &self.installation_id)
+        let mut debug = formatter.debug_struct("VerifiedGithubPullRequest");
+        debug_verified_github_webhook_identity!(debug, self.identity, workflow);
+        debug
             .field("actor", &self.actor)
             .field("source_actor", &self.source_actor)
-            .field("repository", &self.repository)
+            .field("repository", &self.identity.repository)
             .field("head_repository", &self.head_repository)
             .field("number", &self.number)
             .field("action", &self.action)
@@ -759,10 +684,8 @@ impl fmt::Debug for VerifiedGithubPullRequest {
 /// Authenticated and strictly normalized merge-queue group webhook evidence.
 #[derive(Clone, Eq, PartialEq)]
 pub struct VerifiedGithubMergeGroup {
-    authenticated: AuthenticatedGithubWebhook,
-    installation_id: NonZeroU64,
+    identity: VerifiedGithubWebhookIdentity,
     actor: Option<GithubEventActor>,
-    repository: GithubWebhookRepository,
     action: GithubMergeGroupAction,
     head_revision: GitObjectId,
     base_revision: GitObjectId,
@@ -771,91 +694,47 @@ pub struct VerifiedGithubMergeGroup {
 }
 
 impl VerifiedGithubMergeGroup {
-    /// Returns the exact singleton delivery header outside the body MAC.
-    #[must_use]
-    pub fn delivery_id(&self) -> &str {
-        self.authenticated.delivery_id()
+    verified_github_webhook_authenticated_accessors!(
+        "Returns the exact `merge_group` event-name header.",
+        "Returns the nonzero GitHub App installation identifier."
+    );
+
+    verified_github_webhook_accessors! { |event|
+        /// Returns the authenticated sender facts when supplied by the webhook.
+        #[must_use]
+        [const] fn actor -> Option<&GithubEventActor> = event.actor.as_ref();
     }
 
-    /// Returns the exact `merge_group` event-name header.
-    #[must_use]
-    pub fn event_name(&self) -> &str {
-        self.authenticated.event_name()
-    }
+    verified_github_webhook_repository_accessor!(
+        "Returns the repository whose merge queue created the group."
+    );
 
-    /// Returns the exact HMAC-authenticated body without reserialization.
-    #[must_use]
-    pub const fn raw_body(&self) -> &Bytes {
-        self.authenticated.raw_body()
-    }
-
-    /// Returns SHA-256 of the exact authenticated body.
-    #[must_use]
-    pub const fn body_sha256(&self) -> GithubWebhookBodyDigest {
-        self.authenticated.body_sha256()
-    }
-
-    /// Returns the nonzero GitHub App installation identifier.
-    #[must_use]
-    pub const fn installation_id(&self) -> NonZeroU64 {
-        self.installation_id
-    }
-
-    /// Returns the authenticated sender facts when supplied by the webhook.
-    #[must_use]
-    pub const fn actor(&self) -> Option<&GithubEventActor> {
-        self.actor.as_ref()
-    }
-
-    /// Returns the repository whose merge queue created the group.
-    #[must_use]
-    pub const fn repository(&self) -> &GithubWebhookRepository {
-        &self.repository
-    }
-
-    /// Returns the validated provider activity.
-    #[must_use]
-    pub const fn action(&self) -> GithubMergeGroupAction {
-        self.action
-    }
-
-    /// Returns the canonical merge-group head commit to check.
-    #[must_use]
-    pub const fn head_revision(&self) -> &GitObjectId {
-        &self.head_revision
-    }
-
-    /// Returns the canonical parent commit of the merge group.
-    #[must_use]
-    pub const fn base_revision(&self) -> &GitObjectId {
-        &self.base_revision
-    }
-
-    /// Returns the canonical full merge-group branch reference.
-    #[must_use]
-    pub const fn head_ref(&self) -> &GithubWebhookRef {
-        &self.head_ref
-    }
-
-    /// Returns the canonical full target-branch reference.
-    #[must_use]
-    pub const fn base_ref(&self) -> &GithubWebhookRef {
-        &self.base_ref
+    verified_github_webhook_accessors! { |event|
+        /// Returns the validated provider activity.
+        #[must_use]
+        [const] fn action -> GithubMergeGroupAction = event.action;
+        /// Returns the canonical merge-group head commit to check.
+        #[must_use]
+        [const] fn head_revision -> &GitObjectId = &event.head_revision;
+        /// Returns the canonical parent commit of the merge group.
+        #[must_use]
+        [const] fn base_revision -> &GitObjectId = &event.base_revision;
+        /// Returns the canonical full merge-group branch reference.
+        #[must_use]
+        [const] fn head_ref -> &GithubWebhookRef = &event.head_ref;
+        /// Returns the canonical full target-branch reference.
+        #[must_use]
+        [const] fn base_ref -> &GithubWebhookRef = &event.base_ref;
     }
 }
 
 impl fmt::Debug for VerifiedGithubMergeGroup {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("VerifiedGithubMergeGroup")
-            .field("delivery_id", &"[redacted]")
-            .field("event_name", &self.authenticated.event_name())
-            .field("raw_body", &"[redacted]")
-            .field("body_len", &self.authenticated.raw_body().len())
-            .field("body_sha256", &self.authenticated.body_sha256())
-            .field("installation_id", &self.installation_id)
+        let mut debug = formatter.debug_struct("VerifiedGithubMergeGroup");
+        debug_verified_github_webhook_identity!(debug, self.identity, workflow);
+        debug
             .field("actor", &self.actor)
-            .field("repository", &self.repository)
+            .field("repository", &self.identity.repository)
             .field("action", &self.action)
             .field("head_revision", &"[redacted]")
             .field("base_revision", &"[redacted]")
@@ -1091,14 +970,17 @@ pub(crate) fn normalize_check_run(
         return Err(GithubWebhookError::InvalidPayload);
     }
     let actor = payload.sender.normalize()?;
+    let installation_id = durable_provider_id(payload.installation.id)?;
+    let repository = payload.repository.normalize()?;
+    let app_id = durable_provider_id(payload.check_run.app.id)?;
+    let run_id = durable_provider_id(payload.check_run.id)?;
+    let suite_id = durable_provider_id(payload.check_run.check_suite.id)?;
     Ok(VerifiedGithubCheckRun {
-        authenticated,
-        installation_id: durable_provider_id(payload.installation.id)?,
-        repository: payload.repository.normalize()?,
+        identity: VerifiedGithubWebhookIdentity::new(authenticated, installation_id, repository),
         actor,
-        app_id: durable_provider_id(payload.check_run.app.id)?,
-        run_id: durable_provider_id(payload.check_run.id)?,
-        suite_id: durable_provider_id(payload.check_run.check_suite.id)?,
+        app_id,
+        run_id,
+        suite_id,
         head_revision,
         external_id: payload.check_run.external_id.into_boxed_str(),
         action,
@@ -1117,14 +999,17 @@ pub(crate) fn normalize_check_suite(
         return Err(GithubWebhookError::InvalidPayload);
     }
     let actor = payload.sender.normalize()?;
+    let installation_id = durable_provider_id(payload.installation.id)?;
+    let repository = payload.repository.normalize()?;
+    let app_id = durable_provider_id(payload.check_suite.app.id)?;
+    let suite_id = durable_provider_id(payload.check_suite.id)?;
+    let head_revision = exact_revision(payload.check_suite.head_sha)?;
     Ok(VerifiedGithubCheckSuite {
-        authenticated,
-        installation_id: durable_provider_id(payload.installation.id)?,
-        repository: payload.repository.normalize()?,
+        identity: VerifiedGithubWebhookIdentity::new(authenticated, installation_id, repository),
         actor,
-        app_id: durable_provider_id(payload.check_suite.app.id)?,
-        suite_id: durable_provider_id(payload.check_suite.id)?,
-        head_revision: exact_revision(payload.check_suite.head_sha)?,
+        app_id,
+        suite_id,
+        head_revision,
     })
 }
 
@@ -1173,11 +1058,9 @@ pub(crate) fn normalize_pull_request(
         .transpose()?;
 
     Ok(VerifiedGithubPullRequest {
-        authenticated,
-        installation_id,
+        identity: VerifiedGithubWebhookIdentity::new(authenticated, installation_id, repository),
         actor,
         source_actor,
-        repository,
         head_repository,
         number,
         action,
@@ -1207,10 +1090,8 @@ pub(crate) fn normalize_merge_group(
     let actor = payload.sender.map(SenderPayload::normalize).transpose()?;
 
     Ok(VerifiedGithubMergeGroup {
-        authenticated,
-        installation_id,
+        identity: VerifiedGithubWebhookIdentity::new(authenticated, installation_id, repository),
         actor,
-        repository,
         action,
         head_revision,
         base_revision,
@@ -1236,10 +1117,8 @@ pub(crate) fn normalize_repository_dispatch(
     let actor = payload.sender.map(SenderPayload::normalize).transpose()?;
 
     Ok(VerifiedGithubRepositoryDispatch {
-        authenticated,
-        installation_id,
+        identity: VerifiedGithubWebhookIdentity::new(authenticated, installation_id, repository),
         actor,
-        repository,
         event_type,
         branch,
         git_ref,

--- a/crates/automata-ci-provider-github/src/webhook_event/push.rs
+++ b/crates/automata-ci-provider-github/src/webhook_event/push.rs
@@ -1,0 +1,330 @@
+use std::{fmt, num::NonZeroU64};
+
+use automata_ci_core::GitObjectId;
+use bytes::Bytes;
+use serde::{Deserialize, Deserializer, de};
+
+use super::{
+    InstallationPayload, RepositoryOwnerPayload, SenderPayload, VerifiedGithubWebhookIdentity,
+};
+use crate::{
+    event::GithubEventActor,
+    webhook::{
+        AuthenticatedGithubWebhook, GithubWebhookBodyDigest, GithubWebhookError, GithubWebhookRef,
+        GithubWebhookRepository, MAX_GITHUB_PUSH_COMMITS, durable_provider_id, parse_git_ref,
+    },
+};
+
+const MAX_GITHUB_PATH_FILTER_COMMITS: usize = 1_000;
+const ZERO_COMMIT_SHA: &str = "0000000000000000000000000000000000000000";
+
+const fn push_commit_count_rejected(observed: usize) -> bool {
+    observed > MAX_GITHUB_PUSH_COMMITS
+}
+
+const fn path_filter_commit_count_rejected(observed: usize) -> bool {
+    observed > MAX_GITHUB_PATH_FILTER_COMMITS
+}
+
+/// Provider event-selection metadata retained without a compiler dependency.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GithubWebhookEventMetadata {
+    /// A push event and its exact provider flags.
+    Push {
+        /// Whether GitHub declared this reference newly created.
+        created: bool,
+        /// Whether GitHub declared this reference deleted.
+        deleted: bool,
+        /// Whether GitHub declared this a non-fast-forward update.
+        forced: bool,
+    },
+}
+
+/// Authenticated and strictly normalized GitHub push evidence.
+#[derive(Clone, Eq, PartialEq)]
+pub struct VerifiedGithubPush {
+    pub(super) identity: VerifiedGithubWebhookIdentity,
+    actor: Option<GithubEventActor>,
+    git_ref: GithubWebhookRef,
+    before_commit_sha: Box<str>,
+    after_commit_sha: Box<str>,
+    metadata: GithubWebhookEventMetadata,
+    commit_count: usize,
+    complete_pushed_commit_revisions: Option<Box<[GitObjectId]>>,
+}
+
+impl VerifiedGithubPush {
+    verified_github_webhook_authenticated_accessors!(push);
+
+    verified_github_webhook_accessors! { |event|
+        /// Returns the authenticated sender facts when supplied by the webhook.
+        #[must_use]
+        [const] fn actor -> Option<&GithubEventActor> = event.actor.as_ref();
+    }
+
+    verified_github_webhook_repository_accessor!(push);
+
+    verified_github_webhook_accessors! { |event|
+        /// Returns the canonical full branch or tag reference.
+        [const] fn git_ref -> &GithubWebhookRef = &event.git_ref;
+        /// Returns the canonical lowercase 40-hex pre-push commit identifier.
+        [] fn before_commit_sha -> &str = &event.before_commit_sha;
+        /// Returns the canonical lowercase 40-hex post-push commit identifier.
+        [] fn after_commit_sha -> &str = &event.after_commit_sha;
+        /// Returns provider metadata required for later trigger selection.
+        [const] fn event_metadata -> GithubWebhookEventMetadata = event.metadata;
+        /// Returns the bounded number of commit summaries observed in the payload.
+        ///
+        /// GitHub caps the webhook array at [`MAX_GITHUB_PUSH_COMMITS`], so this is
+        /// not a claim about the total size of a larger truncated push.
+        [const] fn commit_count -> usize = event.commit_count;
+        /// Returns the complete canonical pushed-commit set when path filtering
+        /// requires a provider diff.
+        ///
+        /// The revisions are lexicographically sorted because provider array order
+        /// is not diff-base authority. `Some(empty)` is complete evidence for an
+        /// empty array. `None` means the payload contained more than 1,000 commits,
+        /// for which GitHub Actions bypasses path-filter diff generation.
+        [] fn complete_pushed_commit_revisions -> Option<&[GitObjectId]> = event.complete_pushed_commit_revisions.as_deref();
+        /// Returns whether GitHub Actions' commit ceiling requires path filters to
+        /// match without generating a diff.
+        [const] fn path_filter_commit_limit_exceeded -> bool = event.complete_pushed_commit_revisions.is_none();
+        /// Returns the exact provider deletion flag.
+        [const] fn deleted -> bool = match event.metadata {
+            GithubWebhookEventMetadata::Push { deleted, .. } => deleted,
+        };
+        /// Returns the exact provider creation flag.
+        [const] fn created -> bool = match event.metadata {
+            GithubWebhookEventMetadata::Push { created, .. } => created,
+        };
+        /// Returns the exact provider forced-update flag.
+        [const] fn forced -> bool = match event.metadata {
+            GithubWebhookEventMetadata::Push { forced, .. } => forced,
+        };
+    }
+}
+
+impl fmt::Debug for VerifiedGithubPush {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = formatter.debug_struct("VerifiedGithubPush");
+        debug_verified_github_webhook_identity!(debug, self.identity, workflow);
+        debug
+            .field("actor", &self.actor)
+            .field("repository", &self.identity.repository)
+            .field("git_ref", &self.git_ref)
+            .field("before_commit_sha", &"[redacted]")
+            .field("after_commit_sha", &"[redacted]")
+            .field("metadata", &self.metadata)
+            .field("commit_count", &self.commit_count)
+            .field(
+                "complete_pushed_commit_revisions",
+                &self.complete_pushed_commit_revisions.is_some(),
+            )
+            .finish()
+    }
+}
+
+#[derive(Deserialize)]
+struct PushPayload {
+    #[serde(rename = "ref")]
+    git_ref: String,
+    before: String,
+    after: String,
+    created: bool,
+    deleted: bool,
+    forced: bool,
+    repository: PushRepositoryPayload,
+    installation: InstallationPayload,
+    #[serde(default)]
+    sender: Option<SenderPayload>,
+    commits: BoundedCommits,
+}
+
+#[derive(Deserialize)]
+struct PushRepositoryPayload {
+    id: u64,
+    private: bool,
+    visibility: String,
+    name: String,
+    full_name: String,
+    owner: RepositoryOwnerPayload,
+}
+
+#[derive(Deserialize)]
+struct PushCommitPayload {
+    id: String,
+}
+
+#[derive(Default)]
+struct BoundedCommits(Vec<PushCommitPayload>);
+
+struct NormalizedPushedCommits {
+    count: usize,
+    complete_revisions: Option<Box<[GitObjectId]>>,
+}
+
+impl<'de> Deserialize<'de> for BoundedCommits {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(BoundedCommitVisitor)
+    }
+}
+
+struct BoundedCommitVisitor;
+
+impl<'de> de::Visitor<'de> for BoundedCommitVisitor {
+    type Value = BoundedCommits;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a bounded GitHub push commit collection")
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let mut commits = Vec::new();
+        while let Some(commit) = sequence.next_element::<PushCommitPayload>()? {
+            let projected = commits
+                .len()
+                .checked_add(1)
+                .ok_or_else(|| de::Error::custom("push commit count exceeds limit"))?;
+            if push_commit_count_rejected(projected) {
+                return Err(de::Error::custom("push commit count exceeds limit"));
+            }
+            commits.push(commit);
+        }
+        Ok(BoundedCommits(commits))
+    }
+}
+
+pub(crate) fn decode_push(
+    authenticated: AuthenticatedGithubWebhook,
+) -> Result<VerifiedGithubPush, GithubWebhookError> {
+    let payload: PushPayload = serde_json::from_slice(authenticated.raw_body())
+        .map_err(|_| GithubWebhookError::MalformedPayload)?;
+    normalize_push(authenticated, payload)
+}
+
+fn normalize_push(
+    authenticated: AuthenticatedGithubWebhook,
+    payload: PushPayload,
+) -> Result<VerifiedGithubPush, GithubWebhookError> {
+    let installation_id = durable_provider_id(payload.installation.id)?;
+    let actor = payload.sender.map(SenderPayload::normalize).transpose()?;
+    let repository = GithubWebhookRepository::from_webhook_fields(
+        payload.repository.id,
+        payload.repository.owner.id,
+        payload.repository.private,
+        &payload.repository.visibility,
+        payload.repository.owner.login,
+        payload.repository.name,
+        payload.repository.full_name,
+    )?;
+
+    let git_ref = parse_git_ref(payload.git_ref)?;
+    validate_commit_range(
+        &payload.before,
+        &payload.after,
+        payload.created,
+        payload.deleted,
+    )?;
+    let pushed_commits = normalize_pushed_commits(payload.commits)?;
+
+    Ok(VerifiedGithubPush {
+        identity: VerifiedGithubWebhookIdentity::new(authenticated, installation_id, repository),
+        actor,
+        git_ref,
+        before_commit_sha: payload.before.into_boxed_str(),
+        after_commit_sha: payload.after.into_boxed_str(),
+        metadata: GithubWebhookEventMetadata::Push {
+            created: payload.created,
+            deleted: payload.deleted,
+            forced: payload.forced,
+        },
+        commit_count: pushed_commits.count,
+        complete_pushed_commit_revisions: pushed_commits.complete_revisions,
+    })
+}
+
+fn normalize_pushed_commits(
+    commits: BoundedCommits,
+) -> Result<NormalizedPushedCommits, GithubWebhookError> {
+    let mut revisions = Vec::with_capacity(commits.0.len());
+    for commit in commits.0 {
+        if commit.id == ZERO_COMMIT_SHA {
+            return Err(GithubWebhookError::InvalidPayload);
+        }
+        revisions.push(
+            GitObjectId::from_provider_hex(commit.id)
+                .map_err(|_| GithubWebhookError::InvalidPayload)?,
+        );
+    }
+    revisions.sort_unstable();
+    if revisions.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(GithubWebhookError::InvalidPayload);
+    }
+
+    let commit_count = revisions.len();
+    let complete =
+        (!path_filter_commit_count_rejected(commit_count)).then(|| revisions.into_boxed_slice());
+    Ok(NormalizedPushedCommits {
+        count: commit_count,
+        complete_revisions: complete,
+    })
+}
+
+fn validate_commit_range(
+    before: &str,
+    after: &str,
+    created: bool,
+    deleted: bool,
+) -> Result<(), GithubWebhookError> {
+    if !is_commit_sha(before)
+        || !is_commit_sha(after)
+        || created != (before == ZERO_COMMIT_SHA)
+        || deleted != (after == ZERO_COMMIT_SHA)
+        || (created && deleted)
+    {
+        return Err(GithubWebhookError::InvalidPayload);
+    }
+    Ok(())
+}
+
+fn is_commit_sha(value: &str) -> bool {
+    if value.len() != 40
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod limit_contract_tests {
+    use super::*;
+
+    #[test]
+    fn push_commit_count_limit_has_exact_boundaries() {
+        assert!(!push_commit_count_rejected(MAX_GITHUB_PUSH_COMMITS - 1));
+        assert!(!push_commit_count_rejected(MAX_GITHUB_PUSH_COMMITS));
+        assert!(push_commit_count_rejected(MAX_GITHUB_PUSH_COMMITS + 1));
+    }
+
+    #[test]
+    fn path_filter_commit_count_limit_has_exact_boundaries() {
+        assert!(!path_filter_commit_count_rejected(
+            MAX_GITHUB_PATH_FILTER_COMMITS - 1
+        ));
+        assert!(!path_filter_commit_count_rejected(
+            MAX_GITHUB_PATH_FILTER_COMMITS
+        ));
+        assert!(path_filter_commit_count_rejected(
+            MAX_GITHUB_PATH_FILTER_COMMITS + 1
+        ));
+    }
+}

--- a/crates/automata-ci-provider-github/tests/webhook_event_normalization.rs
+++ b/crates/automata-ci-provider-github/tests/webhook_event_normalization.rs
@@ -3,6 +3,7 @@ use crate::support::{
     signed_webhook_headers, webhook_body_digest,
 };
 
+use automata_ci_core::GitObjectAlgorithm;
 use automata_ci_provider_github::{
     GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE, GithubCheckRunAction, GithubMergeGroupAction,
     GithubPullRequestAction, GithubRepositoryVisibility, GithubStoredWebhookError,
@@ -15,6 +16,7 @@ use ring::digest;
 use serde_json::{Value, json};
 
 const SECRET: &[u8] = b"independent synthetic webhook secret";
+const SHA256_REVISION: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 #[test]
 fn check_run_controls_retain_exact_signed_identity() {
@@ -80,6 +82,20 @@ fn check_suite_rerequest_retains_suite_app_sender_and_revision() {
     assert_eq!(event.app_id().get(), 17);
     assert_eq!(event.suite_id().get(), 23);
     assert_eq!(event.head_revision().to_string(), HEAD_SHA);
+    assert_eq!(event.head_revision().algorithm(), GitObjectAlgorithm::Sha1);
+
+    let mut payload = check_suite_payload();
+    payload["check_suite"]["head_sha"] = json!(SHA256_REVISION);
+    let VerifiedGithubWebhook::CheckSuite(event) =
+        normalize_payload(&payload, "check_suite").expect("SHA-256 check suite")
+    else {
+        panic!("expected check-suite evidence");
+    };
+    assert_eq!(
+        event.head_revision().algorithm(),
+        GitObjectAlgorithm::Sha256
+    );
+    assert_eq!(event.head_revision().to_string(), SHA256_REVISION);
 }
 
 #[test]
@@ -122,6 +138,7 @@ fn pull_request_normalization_retains_exact_dispatch_evidence() {
         event.merge_revision().expect("merge revision").to_string(),
         MERGE_SHA
     );
+    assert_eq!(event.head_revision().algorithm(), GitObjectAlgorithm::Sha1);
     assert_eq!(event.head_ref(), "feature/topic");
     assert_eq!(event.base_ref(), "main");
     assert_eq!(event.git_ref(), "refs/pull/7/merge");
@@ -483,14 +500,32 @@ fn durable_event_v1_rehydrates_each_supported_kind_without_reserialization() {
             "repository_dispatch",
             "durable-custom-3",
         ),
+        (
+            check_run_payload("rerequested", None),
+            "check_run",
+            "durable-run-41",
+        ),
+        (check_suite_payload(), "check_suite", "durable-suite-23"),
     ] {
-        let body = json_body(&payload);
-        let stored = stored_event_v1(&body, event_name, delivery_id);
+        let mut invalid_identity = payload.clone();
+        invalid_identity["installation"]["id"] = json!(0);
+        assert_payload_error(
+            &invalid_identity,
+            event_name,
+            GithubWebhookError::InvalidPayload,
+        );
+
+        let body = Bytes::from(json_body(&payload));
+        let body_pointer = body.as_ptr();
+        let body_sha256 = webhook_body_digest(&body);
+        let stored = stored_event_v1(body, event_name, delivery_id);
         let event = rehydrate_stored_authenticated_github_webhook(stored)
             .expect("rehydrated authenticated event");
         assert_eq!(event.event_name(), event_name);
         assert_eq!(event.delivery_id(), delivery_id);
-        assert_eq!(event.raw_body().as_ref(), body);
+        assert_eq!(event.installation_id().get(), 71);
+        assert_eq!(event.raw_body().as_ptr(), body_pointer);
+        assert_eq!(event.body_sha256(), body_sha256);
         assert_eq!(event.repository().full_name(), "example/base-repository");
     }
 }
@@ -502,7 +537,7 @@ fn durable_event_v1_rejects_envelope_drift_and_duplicate_json() {
         "application/vnd.automata.github-authenticated-event+json"
     );
     let body = json_body(&pull_request_payload());
-    let wrong_event = stored_event_v1(&body, "merge_group", "durable-pr-7");
+    let wrong_event = stored_event_v1(Bytes::from(body.clone()), "merge_group", "durable-pr-7");
     assert_eq!(
         rehydrate_stored_authenticated_github_webhook(wrong_event)
             .expect_err("event-name drift must fail"),
@@ -517,7 +552,7 @@ fn durable_event_v1_rejects_envelope_drift_and_duplicate_json() {
             1,
         )
         .into_bytes();
-    let stored = stored_event_v1(&duplicate, "pull_request", "durable-pr-7");
+    let stored = stored_event_v1(Bytes::from(duplicate), "pull_request", "durable-pr-7");
     assert_eq!(
         rehydrate_stored_authenticated_github_webhook(stored)
             .expect_err("duplicate JSON must fail"),
@@ -670,14 +705,16 @@ fn assert_bytes_error(body: &[u8], event_name: &str, expected: GithubWebhookErro
 }
 
 fn stored_event_v1(
-    body: &[u8],
+    body: Bytes,
     event_name: &str,
     delivery_id: &str,
 ) -> StoredAuthenticatedGithubWebhook {
+    let body_sha256 = webhook_body_digest(&body);
+    let encoded_size = u64::try_from(body.len()).expect("fixture size");
     StoredAuthenticatedGithubWebhook::from_durable_coordinates(
-        Bytes::copy_from_slice(body),
-        webhook_body_digest(body),
-        u64::try_from(body.len()).expect("fixture size"),
+        body,
+        body_sha256,
+        encoded_size,
         GITHUB_AUTHENTICATED_EVENT_MEDIA_TYPE,
         event_name,
         delivery_id,


### PR DESCRIPTION
## Summary

- consolidate the authenticated request, installation ID, and repository identity shared by all six normalized GitHub webhook kinds into one private `VerifiedGithubWebhookIdentity`
- move push decoding, bounded commit parsing, and push-only validation into private `webhook_event/push.rs`
- reuse the verifier's authenticated body digest and move the original `Bytes` allocation through normalization without copying
- preserve the public event variants, accessors and constness, typed validation order, durable rehydration checks, and redacted debug contract
- extend six-kind durable replay coverage to Check Run and Check Suite, SHA-1/SHA-256 revision identity, invalid installation identity, exact digest/body evidence, and allocation preservation

The patch changes exactly four files: 765 additions, 957 deletions, and 192 net lines removed. Stable patch ID: `9e112e5310fa33d639a57854b73a9e3b6e6d978b`.

## Validation

Passed on exact base `cce16b884beca287def5fa322ddc3eb4d907db7b`:

- `cargo fmt --all -- --check`
- `cargo check --locked -p automata-ci-provider-github --all-targets --all-features`
- `cargo clippy --locked -p automata-ci-provider-github --all-targets --all-features -- -D warnings`
- `cargo test --locked -p automata-ci-provider-github --all-targets --all-features` — 24 unit + 145 integration passed; the pre-existing public-network snapshot test remained ignored
- `cargo test --locked -p automata-ci-provider-github --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p automata-ci-provider-github --all-features --no-deps`
- downstream all-target/all-feature check for `automata-ci-github-delivery`, `automata-ci-provisioning`, `automata-ci-runner`, `automata-ci-provider-delivery`, `automata-ci-provider-postgres`, and `automata-ci`
- `cargo test --locked -p automata-ci-github-delivery --all-targets --all-features` — 51 unit + 104 integration passed

Additional repository checks passed before the final provider-result-only main advance: workspace doc-tests, warning-denied workspace rustdoc, `cargo run --locked --bin automata -- --help`, the 35-test CLI integration suite, and the macOS integration/physical plus Windows image policy tests.

The exact-final all-target workspace baseline exposes two unrelated current-main failures outside this patch:

- strict workspace clippy: `crates/automata-ci-postgres/tests/store/execution/runner_control.rs:363` is 104 lines against the 100-line `too_many_lines` limit
- workspace tests: `crates/automata-ci/tests/results_metrics.rs:86` expects 5,894 preinitialized series while current code produces 5,958

The live PostgreSQL lane was not run locally because no dedicated test service/namespace was provisioned; the hosted PostgreSQL check remains required on the PR head.

Closes #455
