### PR TITLE
refactor(api): retire definition-only runtime conveniences

### DIFF
--- a/crates/automata-ci-control/src/lease/runnable.rs
+++ b/crates/automata-ci-control/src/lease/runnable.rs
@@ -451,12 +451,6 @@ impl RunnableScanPage {
         &self.candidates
     }
 
-    /// Returns the cursor version expected by the page.
-    #[must_use]
-    pub const fn expected_cursor_version(&self) -> u64 {
-        self.cursor.expected_version
-    }
-
     /// Produces a compact proof that advances through one selected candidate.
     ///
     /// # Errors

--- a/crates/automata-ci-store/src/logical_activation.rs
+++ b/crates/automata-ci-store/src/logical_activation.rs
@@ -1203,14 +1203,6 @@ impl ActivatedLogicalInstanceDescriptor {
         })
     }
 
-    /// Replaces the value-free evidence while constructing a divergent test or
-    /// retry candidate. A descriptor can never transition back to no evidence.
-    #[must_use]
-    pub fn with_environment_gate(mut self, evidence: JobEnvironmentActivationEvidence) -> Self {
-        self.environment_gate = Some(evidence);
-        self
-    }
-
     /// Decodes either a current instance or retained pre-evidence history.
     ///
     /// `None` is accepted only on this internal durable path so terminal records

--- a/crates/automata-ci/src/server/github_provider_config.rs
+++ b/crates/automata-ci/src/server/github_provider_config.rs
@@ -573,15 +573,6 @@ impl GithubProviderTransport {
         }
     }
 
-    /// Returns the isolated emulator API base, when selected.
-    #[must_use]
-    pub const fn loopback_api_base(&self) -> Option<&Url> {
-        match self {
-            Self::GithubDotCom => None,
-            Self::LoopbackEmulator { api_base, .. } => Some(api_base),
-        }
-    }
-
     /// Returns the exact container-mapped origin carried by repository job
     /// authorities for isolated emulation.
     #[must_use]

--- a/crates/automata-ci/src/server/github_provider_runtime.rs
+++ b/crates/automata-ci/src/server/github_provider_runtime.rs
@@ -510,13 +510,6 @@ impl GithubProviderRuntimeBuilder {
         self
     }
 
-    /// Replaces the bounded idle and release policy.
-    #[must_use]
-    pub fn with_policy(mut self, policy: GithubProviderRuntimePolicy) -> Self {
-        self.policy = policy;
-        self
-    }
-
     /// Converges bootstrap state and builds the live aggregate.
     ///
     /// The App PEM and webhook bytes are consumed by this builder and dropped


### PR DESCRIPTION
## Summary

- remove `RunnableScanPage::expected_cursor_version`
- remove `ActivatedLogicalInstanceDescriptor::with_environment_gate`
- remove `GithubProviderRuntimeBuilder::with_policy`
- remove `GithubProviderTransport::loopback_api_base`

These four public convenience methods had no workspace source, test, documentation, or generated-code callers. Their backing state, validation, defaults, constructors, and runtime behavior are unchanged. No compatibility aliases or replacement paths are added.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features -p automata-ci-control -p automata-ci-store -p automata-ci`
- `cargo clippy --locked --all-targets --all-features -p automata-ci-control -p automata-ci-store -p automata-ci -- -D warnings`
- `cargo test --locked --all-targets --all-features -p automata-ci-control -p automata-ci-store` (157 control and 247 store tests passed)
- `cargo test --locked --all-features -p automata-ci --lib` (522 passed)
- `cargo test --locked -p automata-ci --test cli` (35 passed)
- `cargo run --locked --bin automata -- --help`
- `cargo test --locked --doc --all-features -p automata-ci-control -p automata-ci-store -p automata-ci`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps -p automata-ci-control -p automata-ci-store -p automata-ci`

Closes #528
