### PR TITLE
refactor(store): consolidate runtime-authority receipt replay

### DIFF
--- a/crates/automata-ci-store-postgres/src/runtime_authority.rs
+++ b/crates/automata-ci-store-postgres/src/runtime_authority.rs
@@ -741,24 +741,19 @@ impl GithubRuntimeAuthorityRepository for PostgresStore {
         if !lock_exact_mint_claim(&mut transaction, request.claim()).await? {
             return Err(GithubRuntimeAuthorityStoreError::MintClaimRejected);
         }
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             MINT_COMMIT_OPERATION,
             pg_bigint(fence.get()),
             operation_digest,
             Some(owner.as_uuid()),
+            GithubRuntimeAuthorityStoreError::IdentityConflict,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::IdentityConflict);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         let durable = load_row_for_update(&mut transaction, key)
             .await?
@@ -766,24 +761,19 @@ impl GithubRuntimeAuthorityRepository for PostgresStore {
         if decode_identity(&durable)? != *identity {
             return Err(GithubRuntimeAuthorityStoreError::MintClaimRejected);
         }
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             MINT_COMMIT_OPERATION,
             pg_bigint(fence.get()),
             operation_digest,
             Some(owner.as_uuid()),
+            GithubRuntimeAuthorityStoreError::IdentityConflict,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::IdentityConflict);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         if worker_column(&durable, "mint_claim_owner_id")? != owner
             || claim_fence_column(&durable, "mint_claim_fence")? != fence
@@ -1128,46 +1118,36 @@ impl GithubRuntimeAuthorityRepository for PostgresStore {
         {
             return Err(GithubRuntimeAuthorityStoreError::QuarantineRejected);
         }
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             QUARANTINE_OPERATION,
             0,
             operation_digest,
             None,
+            GithubRuntimeAuthorityStoreError::QuarantineRejected,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::QuarantineRejected);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         let durable = load_row_for_update(&mut transaction, key)
             .await?
             .ok_or(GithubRuntimeAuthorityStoreError::QuarantineRejected)?;
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             QUARANTINE_OPERATION,
             0,
             operation_digest,
             None,
+            GithubRuntimeAuthorityStoreError::QuarantineRejected,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::QuarantineRejected);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         let state = decode_state(&durable)?;
         if state == GithubRuntimeAuthorityState::Revoked
@@ -1664,46 +1644,36 @@ impl GithubRuntimeAuthorityRepository for PostgresStore {
         {
             return Err(GithubRuntimeAuthorityStoreError::RevocationClaimRejected);
         }
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             REVOCATION_OUTCOME_OPERATION,
             pg_bigint(request.fence().get()),
             operation_digest,
             Some(request.owner().as_uuid()),
+            GithubRuntimeAuthorityStoreError::RevocationClaimRejected,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::RevocationClaimRejected);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         let durable = load_row_for_update(&mut transaction, key)
             .await?
             .ok_or(GithubRuntimeAuthorityStoreError::RevocationClaimRejected)?;
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             REVOCATION_OUTCOME_OPERATION,
             pg_bigint(request.fence().get()),
             operation_digest,
             Some(request.owner().as_uuid()),
+            GithubRuntimeAuthorityStoreError::RevocationClaimRejected,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::RevocationClaimRejected);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         let claimed_at = request.claimed_at();
         let expires_at = request.expires_at();
@@ -1868,46 +1838,36 @@ impl GithubRuntimeAuthorityRepository for PostgresStore {
         {
             return Err(GithubRuntimeAuthorityStoreError::RevocationClaimRejected);
         }
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             REVOCATION_OUTCOME_OPERATION,
             pg_bigint(request.fence().get()),
             operation_digest,
             Some(request.owner().as_uuid()),
+            GithubRuntimeAuthorityStoreError::RevocationClaimRejected,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::RevocationClaimRejected);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         let durable = load_row_for_update(&mut transaction, key)
             .await?
             .ok_or(GithubRuntimeAuthorityStoreError::RevocationClaimRejected)?;
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             REVOCATION_OUTCOME_OPERATION,
             pg_bigint(request.fence().get()),
             operation_digest,
             Some(request.owner().as_uuid()),
+            GithubRuntimeAuthorityStoreError::RevocationClaimRejected,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::RevocationClaimRejected);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         let claimed_at = request.claimed_at();
         let expires_at = request.expires_at();
@@ -2035,46 +1995,36 @@ impl GithubRuntimeAuthorityRepository for PostgresStore {
         {
             return Err(GithubRuntimeAuthorityStoreError::RevocationClaimRejected);
         }
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             REVOCATION_OUTCOME_OPERATION,
             pg_bigint(request.fence().get()),
             operation_digest,
             Some(request.owner().as_uuid()),
+            GithubRuntimeAuthorityStoreError::RevocationClaimRejected,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::RevocationClaimRejected);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         let durable = load_row_for_update(&mut transaction, key)
             .await?
             .ok_or(GithubRuntimeAuthorityStoreError::RevocationClaimRejected)?;
-        match operation_receipt_matches(
+        if let Some(receipt) = load_exact_operation_receipt(
             &mut transaction,
             key,
             REVOCATION_OUTCOME_OPERATION,
             pg_bigint(request.fence().get()),
             operation_digest,
             Some(request.owner().as_uuid()),
+            GithubRuntimeAuthorityStoreError::RevocationClaimRejected,
         )
         .await?
         {
-            Some(OperationReceiptMatch::Exact(receipt)) => {
-                transaction.commit().await.map_err(operation_error)?;
-                return Ok(receipt);
-            }
-            Some(OperationReceiptMatch::Conflict) => {
-                return Err(GithubRuntimeAuthorityStoreError::RevocationClaimRejected);
-            }
-            None => {}
+            transaction.commit().await.map_err(operation_error)?;
+            return Ok(receipt);
         }
         let claimed_at = request.claimed_at();
         let expires_at = request.expires_at();
@@ -2596,6 +2546,31 @@ async fn operation_receipt_matches(
     )
     .map_err(|_| GithubRuntimeAuthorityStoreError::CorruptData)?;
     Ok(Some(OperationReceiptMatch::Exact(receipt)))
+}
+
+async fn load_exact_operation_receipt(
+    transaction: &mut Transaction<'_, Postgres>,
+    key: GithubRuntimeAuthorityKey,
+    operation_kind: &str,
+    claim_fence: i64,
+    operation_digest: Sha256Digest,
+    expected_owner: Option<Uuid>,
+    conflict_error: GithubRuntimeAuthorityStoreError,
+) -> Result<Option<GithubRuntimeAuthorityReceipt>, GithubRuntimeAuthorityStoreError> {
+    match operation_receipt_matches(
+        transaction,
+        key,
+        operation_kind,
+        claim_fence,
+        operation_digest,
+        expected_owner,
+    )
+    .await?
+    {
+        Some(OperationReceiptMatch::Exact(receipt)) => Ok(Some(receipt)),
+        Some(OperationReceiptMatch::Conflict) => Err(conflict_error),
+        None => Ok(None),
+    }
 }
 
 async fn record_current_mint_claim(


### PR DESCRIPTION
## Summary

- consolidate ten repeated runtime-authority operation-receipt replay checks behind one private helper
- preserve the two-phase receipt lookup around the issuance-row lock
- keep transaction commits at each replaying call site
- retain the exact operation-specific conflict mapping for mint commit, quarantine, and revocation outcomes

This is an internal control-flow consolidation only. It changes no public API, SQL, migration, schema, dependency, durable coordinate, lock order, or runtime outcome. The one-file diff removes 25 net lines.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `cargo check --locked -p automata-ci-store-postgres --all-targets --all-features`
- `cargo clippy --locked -p automata-ci-store-postgres --all-targets --all-features -- -D warnings`
- `cargo test --locked -p automata-ci-store-postgres --all-targets --all-features` (76 passed)
- `cargo test --locked -p automata-ci-store-postgres --doc --all-features` (0 doc-tests; the first invocation did not run because the isolated `TMPDIR` was absent, then passed after provisioning it)
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p automata-ci-store-postgres --all-features --no-deps`
- `cargo test --workspace --doc --all-features --locked`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --locked`
- `cargo run --locked --bin automata -- --help`
- the workspace CLI integration binary passed all 35 tests before the later baseline failure

Repository baseline exceptions, both outside this diff:

- workspace strict Clippy stops at the pre-existing 104-line test function in `crates/automata-ci-postgres/tests/store/execution/runner_control.rs:363`
- workspace all-target tests stop at the pre-existing state-metrics cardinality mismatch in `crates/automata-ci/tests/results_metrics.rs:86` (5958 actual vs 5894 expected)
- the initial long-`TMPDIR` workspace run hit a Unix socket path-length failure; the exact failed test passed when rerun with a short `mktemp` path, and the workspace rerun with `TMPDIR=/tmp` progressed to the metrics failure above
- `scripts/ci/run-postgres-tests.sh` was not run locally because `AUTOMATA_TEST_DATABASE_URL` is unset; the hosted PostgreSQL lane remains required

Closes #531
