### PR TITLE
test(macos): recover interrupted VM launch

### DIFF
--- a/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
+++ b/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
@@ -12,9 +12,10 @@ use std::{
 use automata_ci_execution::{
     DestroySandbox, EnvironmentProfile, EnvironmentProfileId, ExecutionArgv, ExecutionCommand,
     ExecutionEnvironment, ExecutionErrorKind, ExecutionTermination, NetworkPolicy, NeverCancelled,
-    OperationId, ProviderErrorKind, ResourceLimits, RootFilesystemPolicy, RunnerId, SandboxCustody,
-    SandboxEnvironment, SandboxGeneration, SandboxHandle, SandboxProvider, SandboxSpec,
-    Sha256Digest, TargetPath, discard_execution_output,
+    OperationId, OperationOutcome, ProviderErrorKind, ProviderStage, ResourceLimits,
+    RootFilesystemPolicy, RunnerId, SandboxCustody, SandboxEnvironment, SandboxGeneration,
+    SandboxHandle, SandboxProvider, SandboxSpec, Sha256Digest, TargetPath,
+    discard_execution_output,
 };
 use automata_ci_sandbox_guest::GUEST_PROTOCOL_VERSION;
 use automata_ci_sandbox_macos::{MacosVirtualizationProvider, MacosVirtualizationProviderOptions};
@@ -269,6 +270,51 @@ fn provider_cleans_up_and_reuses_slot_after_live_helper_loss() {
     assert_attempts_empty(&root);
 }
 
+#[test]
+#[ignore = "requires a sealed VM template on a physical Apple Silicon runner"]
+fn provider_recovers_an_interrupted_launch_and_reuses_the_slot() {
+    let root = required_path(VM_STORAGE_ROOT_ENV);
+    assert_attempts_empty(&root);
+    let provider = MacosVirtualizationProvider::open(physical_options(root.clone()))
+        .expect("open physical macOS provider");
+
+    let interrupted_spec = physical_spec("launch-helper-loss");
+    let (attempt, result) = thread::scope(|scope| {
+        let create = scope.spawn(|| provider.create(&interrupted_spec, &NeverCancelled));
+        let attempt = wait_for_single_attempt(&root, Duration::from_secs(30));
+        kill_helper_for_attempt(&root, &attempt, Duration::from_secs(30));
+        let result = create.join().expect("join interrupted VM create");
+        (attempt, result)
+    });
+    let error = result.expect_err("killing the helper must interrupt VM launch");
+    assert_eq!(error.kind(), ProviderErrorKind::AdapterUnavailable);
+    assert_eq!(error.stage(), ProviderStage::CreateSandbox);
+    assert_eq!(error.outcome(), OperationOutcome::Uncertain);
+    let handle = error
+        .recovery_handle()
+        .expect("interrupted launch must return its exact recovery handle");
+    assert_eq!(handle.opaque(), attempt);
+    provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                handle.clone(),
+                interrupted_spec.generation(),
+                interrupted_spec.custody(),
+            ),
+            &NeverCancelled,
+        )
+        .expect("reconcile interrupted VM launch");
+    assert_attempts_empty(&root);
+
+    create_probe_and_destroy(
+        &provider,
+        &physical_spec("launch-helper-loss-reuse"),
+        "reuse provider slot after interrupted launch",
+    );
+    assert_attempts_empty(&root);
+}
+
 struct PhysicalSandboxCleanup {
     provider: MacosVirtualizationProvider,
     handle: SandboxHandle,
@@ -360,16 +406,97 @@ fn probe_command(working_directory: &TargetPath) -> ExecutionCommand {
     .expect("probe command")
 }
 
-fn kill_attempt_helper(root: &Path, handle: &SandboxHandle) {
+fn create_probe_and_destroy(
+    provider: &MacosVirtualizationProvider,
+    spec: &SandboxSpec,
+    create_label: &str,
+) {
+    let created = provider
+        .create(spec, &NeverCancelled)
+        .unwrap_or_else(|error| panic!("{create_label}: {error}"));
+    let mut cleanup = PhysicalSandboxCleanup::new(
+        provider.clone(),
+        created.handle().clone(),
+        spec.generation(),
+        spec.custody(),
+    );
+    let endpoint = provider
+        .attach(created.handle(), &NeverCancelled)
+        .expect("attach replacement VM");
+    let output = endpoint
+        .exec(
+            &probe_command(spec.workspace()),
+            &NeverCancelled,
+            discard_execution_output(),
+        )
+        .expect("execute in replacement VM");
+    assert_eq!(output.termination(), ExecutionTermination::Exited(0));
+    drop(endpoint);
+    provider
+        .destroy(
+            &DestroySandbox::new(
+                OperationId::new(),
+                created.handle().clone(),
+                spec.generation(),
+                spec.custody(),
+            ),
+            &NeverCancelled,
+        )
+        .expect("destroy replacement VM");
+    cleanup.disarm();
+}
+
+fn wait_for_single_attempt(root: &Path, timeout: Duration) -> String {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let attempts: Vec<_> = fs::read_dir(root.join("attempts"))
+            .expect("read physical provider attempts")
+            .map(|entry| entry.expect("read physical provider attempt entry"))
+            .collect();
+        match attempts.as_slice() {
+            [attempt] => {
+                return attempt
+                    .file_name()
+                    .into_string()
+                    .expect("physical attempt name must be UTF-8");
+            }
+            [] if Instant::now() < deadline => thread::sleep(Duration::from_millis(10)),
+            [] => panic!("provider did not create one VM attempt before the deadline"),
+            _ => panic!("provider created more than one physical VM attempt"),
+        }
+    }
+}
+
+fn kill_helper_for_attempt(root: &Path, attempt: &str, timeout: Duration) {
+    let lock = root.join("attempts").join(attempt).join(".vm.lock");
+    let deadline = Instant::now() + timeout;
+    loop {
+        let pids = helper_pids_for_lock(&lock);
+        match pids.as_slice() {
+            [pid] => {
+                let status = Command::new("/bin/kill")
+                    .args(["-KILL", &pid.to_string()])
+                    .status()
+                    .expect("kill physical VM helper");
+                assert!(status.success(), "physical VM helper kill failed");
+                return;
+            }
+            [] if Instant::now() < deadline => thread::sleep(Duration::from_millis(10)),
+            [] => panic!("physical VM helper did not start before the deadline"),
+            _ => panic!("more than one helper owns the physical VM attempt"),
+        }
+    }
+}
+
+fn helper_pids_for_lock(lock: &Path) -> Vec<u32> {
     let helper = required_path(VM_HELPER_ENV);
-    let lock = root.join("attempts").join(handle.opaque()).join(".vm.lock");
     let expected = format!("{} run --lock {}", helper.display(), lock.display());
     let output = Command::new("/bin/ps")
         .args(["-axo", "pid=,command="])
         .output()
         .expect("list physical host processes");
     assert!(output.status.success(), "physical host ps failed");
-    let pids: Vec<u32> = String::from_utf8(output.stdout)
+    String::from_utf8(output.stdout)
         .expect("physical host process list must be UTF-8")
         .lines()
         .filter_map(|line| {
@@ -378,7 +505,12 @@ fn kill_attempt_helper(root: &Path, handle: &SandboxHandle) {
             let command = fields.next()?.trim_start();
             (command == expected).then_some(pid)
         })
-        .collect();
+        .collect()
+}
+
+fn kill_attempt_helper(root: &Path, handle: &SandboxHandle) {
+    let lock = root.join("attempts").join(handle.opaque()).join(".vm.lock");
+    let pids = helper_pids_for_lock(&lock);
     assert_eq!(
         pids.len(),
         1,

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -1219,8 +1219,8 @@ current baseline.
   either Developer ID distribution or an exact private-fleet leaf identity.
 - [ ] Add Xcode and toolchain profiles.
 - [ ] Add macOS acceptance jobs.
-- [x] Add physical clone cleanup, runner cancellation, live-helper-loss slot
-  reuse, and live-orphan startup recovery tests.
+- [x] Add physical clone cleanup, runner cancellation, interrupted-launch
+  recovery, live-helper-loss slot reuse, and live-orphan startup recovery tests.
 
 ### Architecture and image breadth
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -442,8 +442,12 @@ test kills the process owning a live VM, reopens the journal, and requires
 startup reconciliation to remove the exact orphan. The helper-loss test kills
 the exact helper bound to a running VM, requires a typed endpoint failure,
 destroys the clone, and proves the same provider slot can run and clean a fresh
-VM. A continuous protected physical lane, launch/destroy helper-crash
-transitions, and a retained repeated-clean soak remain deployment work.
+VM. The interrupted-launch test kills the exact helper after its owned attempt
+appears, requires an uncertain `CreateSandbox` adapter-unavailable error with
+the exact recovery handle, reconciles that handle, and proves the slot can
+launch and clean a replacement VM. A continuous protected physical lane, the
+destroy-time helper-crash transition, and a retained repeated-clean soak remain
+deployment work.
 
 Create `/Volumes/AutomataVM/e2e-state` as an empty `0700` directory owned by
 the physical runner service account before running the command below.
@@ -461,8 +465,9 @@ export AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES=<exact-volume-quota-bytes>
 ```
 
 The entrypoint runs the shipped-runner success/timeout and cancellation matrix,
-live-helper-loss cleanup and slot reuse, live-orphan recovery, and the
-allowlisted runtime-proxy probe serially. Set
+interrupted-launch recovery and slot reuse, live-helper-loss cleanup and slot
+reuse, live-orphan recovery, and the allowlisted runtime-proxy probe serially.
+Set
 `AUTOMATA_MACOS_PHYSICAL_REPETITIONS` from 1 through 10 for a bounded repeated
 runner soak. It refuses a `CARGO_TARGET_DIR` on the VM storage filesystem so
 build artifacts cannot consume the clone-capacity safety margin.

--- a/scripts/ci/run-macos-physical-checks.sh
+++ b/scripts/ci/run-macos-physical-checks.sh
@@ -114,6 +114,10 @@ for ((iteration = 1; iteration <= repetitions; iteration++)); do
     macos_vm_runner_process_e2e:: -- \
     --ignored --nocapture --test-threads=1
 done
+run_test 'helper loss during VM launch recovery and slot reuse' \
+  cargo test -p automata-ci-sandbox-macos --test macos_provider --locked \
+  provider_recovers_an_interrupted_launch_and_reuses_the_slot -- \
+  --ignored --exact --nocapture --test-threads=1
 run_test 'live helper loss cleanup and slot reuse' \
   cargo test -p automata-ci-sandbox-macos --test macos_provider --locked \
   provider_cleans_up_and_reuses_slot_after_live_helper_loss -- \

--- a/scripts/ci/tests/macos-physical-checks.test.py
+++ b/scripts/ci/tests/macos-physical-checks.test.py
@@ -30,7 +30,7 @@ class MacosPhysicalChecksTest(unittest.TestCase):
         result = self.run_script("--plan")
         self.assertEqual(result.returncode, 0, result.stderr)
         commands = [line for line in result.stdout.splitlines() if line.startswith("RUN ")]
-        self.assertEqual(len(commands), 4, result.stdout)
+        self.assertEqual(len(commands), 5, result.stdout)
         for identity in (
             "automata-ci-runner --test runner",
             "automata-ci-sandbox-macos --test macos_provider",
@@ -40,9 +40,12 @@ class MacosPhysicalChecksTest(unittest.TestCase):
         for command in commands:
             self.assertIn("--test-threads=1", command)
         self.assertIn("macos_vm_runner_process_e2e::", commands[0])
-        self.assertIn("provider_cleans_up_and_reuses_slot_after_live_helper_loss", commands[1])
-        self.assertIn("provider_reconciles_a_live_orphan", commands[2])
-        self.assertIn("physical_guest_reaches_an_allowlisted_origin", commands[3])
+        self.assertIn(
+            "provider_recovers_an_interrupted_launch_and_reuses_the_slot", commands[1]
+        )
+        self.assertIn("provider_cleans_up_and_reuses_slot_after_live_helper_loss", commands[2])
+        self.assertIn("provider_reconciles_a_live_orphan", commands[3])
+        self.assertIn("physical_guest_reaches_an_allowlisted_origin", commands[4])
         self.assertNotIn("HELPER_REQUIREMENT=", result.stdout)
         self.assertNotIn("STORAGE_QUOTA_BYTES=", result.stdout)
 
@@ -52,12 +55,12 @@ class MacosPhysicalChecksTest(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         commands = [line for line in result.stdout.splitlines() if line.startswith("RUN ")]
-        self.assertEqual(len(commands), 5, result.stdout)
+        self.assertEqual(len(commands), 6, result.stdout)
         self.assertEqual(
             sum("automata-ci-runner --test runner" in command for command in commands), 2
         )
         self.assertEqual(
-            sum("--test macos_provider" in command for command in commands), 2
+            sum("--test macos_provider" in command for command in commands), 3
         )
 
     def test_invalid_repetition_count_fails_closed(self) -> None:


### PR DESCRIPTION
## Outcome

Adds physical-host acceptance for helper loss during VM launch. The test observes the provider-owned attempt, kills only its exact signed helper process, requires a typed uncertain `CreateSandbox`/`AdapterUnavailable` error carrying that attempt as its recovery handle, reconciles it, and proves the provider slot can launch, execute in, and clean a replacement VM. The bounded serial physical entrypoint now runs this case.

## Related issue

None.

## Trust and compatibility impact

No credential, protocol, storage-format, or runtime behavior changes. This strengthens the private Apple Silicon acceptance boundary by proving explicit recovery semantics for an interrupted launch. The helper is still admitted by the configured hash and strict signing requirement.

## Verification

- `cargo fmt --all`
- `git diff --check`
- `bash -n scripts/ci/run-macos-physical-checks.sh`
- `python3 scripts/ci/tests/macos-physical-checks.test.py` (4 passed)
- Apple Silicon macOS: `cargo clippy -p automata-ci-sandbox-macos --test macos_provider --locked -- -D warnings`
- Apple Silicon macOS exact physical test: 1 passed in 202.25s
- Apple Silicon full serial physical entrypoint: runner matrix 479.64s; interrupted launch 206.10s; live helper loss 215.24s; orphan recovery 403.57s; proxy 9.42s
- Post-run host audit: zero provider attempts, proxy attempts, VM helpers, or bridge processes; 72 GiB free on the VM volume
- Rebased afterward over docs-only `8049f736`; no executable input changed

## AI assistance

OpenAI Codex implemented and validated the focused test, entrypoint, and documentation updates under operator direction.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.