### PR TITLE
Delete superseded check subject writes

### DIFF
--- a/crates/automata-ci-store-postgres/src/admission.rs
+++ b/crates/automata-ci-store-postgres/src/admission.rs
@@ -14,7 +14,6 @@ use uuid::Uuid;
 use super::{
     CurrentAttemptOutputSafety, PostgresStore, RunnerPayloadEncryption,
     durable_schema::current_durable_schemas,
-    github_checks::{GithubJobCheckInsertError, insert_github_job_check_subject},
 };
 use automata_ci_store::{
     AdmissionObject, AdmitWorkflowRun, DocumentSchema, EnqueueRunnerCommand, RepositoryId,
@@ -772,14 +771,6 @@ async fn insert_jobs_and_dag(
         .execute(&mut **transaction)
         .await
         .map_err(operation_error)?;
-        insert_github_job_check_subject(
-            transaction,
-            job.job_id(),
-            job.attempt_id(),
-            command.admitted_at(),
-        )
-        .await
-        .map_err(GithubJobCheckInsertError::into_store_error)?;
     }
     for job in command.jobs() {
         for prerequisite in job.prerequisites() {
@@ -1305,33 +1296,6 @@ async fn lock_logical_cancellation_dependents(
                 .map_err(operation_error)?,
         );
     }
-    let check_rows = sqlx::query(
-        r"
-        SELECT desired_updated_at_ms
-        FROM github_check_subjects
-        WHERE workflow_run_id = $1
-          AND subject_kind = 'workflow'
-        ORDER BY id
-        FOR UPDATE
-        ",
-    )
-    .bind(run_id)
-    .fetch_all(&mut **transaction)
-    .await
-    .map_err(operation_error)?;
-    if check_rows.len() > 1 {
-        return Err(StoreError::corrupt_data(
-            "logical workflow run has multiple linked GitHub Checks",
-        )
-        .into());
-    }
-    for check in &check_rows {
-        updated_at = updated_at.max(
-            check
-                .try_get::<i64, _>("desired_updated_at_ms")
-                .map_err(operation_error)?,
-        );
-    }
     Ok(updated_at)
 }
 
@@ -1434,44 +1398,6 @@ async fn finalize_logical_concurrency_cancellation(
     if invocation_rows != 1 || marker_rows != 1 {
         return Err(StoreError::corrupt_data(
             "logical concurrency cancellation lost orchestration ownership",
-        )
-        .into());
-    }
-    let (linked, updated): (i64, i64) = sqlx::query_as(
-        r"
-        WITH linked AS MATERIALIZED (
-            SELECT id
-            FROM github_check_subjects
-            WHERE workflow_run_id = $1
-              AND subject_kind = 'workflow'
-            FOR UPDATE
-        ), updated AS (
-            UPDATE github_check_subjects AS subject
-            SET desired_state = 'completed',
-                desired_conclusion = 'cancelled',
-                terminal_cause = 'workflow_cancelled',
-                desired_revision = desired_revision + 1,
-                desired_updated_at_ms = $2
-            FROM linked
-            WHERE subject.id = linked.id
-              AND subject.desired_state IN ('queued', 'in_progress')
-              AND subject.desired_conclusion IS NULL
-              AND subject.terminal_cause IS NULL
-              AND subject.desired_updated_at_ms <= $2
-            RETURNING subject.id
-        )
-        SELECT (SELECT count(*) FROM linked),
-               (SELECT count(*) FROM updated)
-        ",
-    )
-    .bind(run_id)
-    .bind(cancelled_at.get())
-    .fetch_one(&mut **transaction)
-    .await
-    .map_err(operation_error)?;
-    if (linked, updated) != (0, 0) && (linked, updated) != (1, 1) {
-        return Err(StoreError::corrupt_data(
-            "logical concurrency cancellation could not terminalize its linked GitHub Check",
         )
         .into());
     }

--- a/crates/automata-ci-store-postgres/src/github_checks.rs
+++ b/crates/automata-ci-store-postgres/src/github_checks.rs
@@ -1,29 +1,28 @@
 use async_trait::async_trait;
 use automata_ci_blob::{BlobDescriptor, BlobKey, MediaType};
-use automata_ci_core::{AttemptId, GitObjectId, JobId, RunId, Sha256Digest, UnixMillis};
+use automata_ci_core::{GitObjectId, JobId, RunId, Sha256Digest, UnixMillis};
 use sqlx::{AssertSqlSafe, PgConnection, Postgres, Row as _, Transaction};
 use uuid::Uuid;
 
 use automata_ci_provider::ProviderConnectionId;
 use automata_ci_store::{
-    AdvanceGithubCheckAnnotations, AttemptStoreError, BeginGithubCheckAnnotationBatch,
-    BeginGithubCheckRunCreate, BindGithubCheckRun, BindGithubCheckSuite,
-    BlockGithubCheckAnnotationMismatch, BlockGithubCheckProjectionForCredentialRejection,
-    ClaimGithubCheckProjection, ClaimedGithubCheckProjection,
-    ClearGithubCheckAnnotationUncertainty, CompleteGithubCheckProjection,
-    GithubCheckAnnotationProgress, GithubCheckAppId, GithubCheckConclusion,
-    GithubCheckCreateReconciliation, GithubCheckDesiredProjection, GithubCheckDetailsTarget,
-    GithubCheckName, GithubCheckProjectionAction, GithubCheckProjectionClaimFence,
-    GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId, GithubCheckRunBindingFence,
-    GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError, GithubCheckSubjectIdentity,
-    GithubCheckSubjectKey, GithubCheckSubjectOrigin, GithubCheckSubjectReceipt, GithubCheckSuiteId,
-    GithubCheckTerminalCause, GithubRepositoryName, GithubScheduleFireId,
-    GithubServerServiceAuthorityId, GithubServerServiceAuthoritySelector,
+    AdvanceGithubCheckAnnotations, BeginGithubCheckAnnotationBatch, BeginGithubCheckRunCreate,
+    BindGithubCheckRun, BindGithubCheckSuite, BlockGithubCheckAnnotationMismatch,
+    BlockGithubCheckProjectionForCredentialRejection, ClaimGithubCheckProjection,
+    ClaimedGithubCheckProjection, ClearGithubCheckAnnotationUncertainty,
+    CompleteGithubCheckProjection, GithubCheckAnnotationProgress, GithubCheckAppId,
+    GithubCheckConclusion, GithubCheckCreateReconciliation, GithubCheckDesiredProjection,
+    GithubCheckDetailsTarget, GithubCheckName, GithubCheckProjectionAction,
+    GithubCheckProjectionClaimFence, GithubCheckProjectionOutbox, GithubCheckProjectionWorkerId,
+    GithubCheckRunBindingFence, GithubCheckRunCreateFence, GithubCheckRunId, GithubCheckStoreError,
+    GithubCheckSubjectIdentity, GithubCheckSubjectKey, GithubCheckSubjectOrigin,
+    GithubCheckSubjectReceipt, GithubCheckSuiteId, GithubCheckTerminalCause, GithubRepositoryName,
+    GithubScheduleFireId, GithubServerServiceAuthorityId, GithubServerServiceAuthoritySelector,
     GithubServerServiceRevision, HUMAN_JOB_RESULT_MEDIA_TYPE, InitializeGithubCheckPresentation,
     MAX_GITHUB_CHECK_PROJECTION_ATTEMPTS, MAX_TERMINAL_RESULT_BYTES, ProviderDeliveryId,
     ProviderInstallationId, ProviderRepositoryId, ReleaseUnissuedGithubCheckAnnotationBatch,
     ReleaseUnissuedGithubCheckRunCreate, RepositoryId, ResolveGithubCheckRunCreate,
-    RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations, StoreError, TenantScope,
+    RetryGithubCheckProjection, RetryUncertainGithubCheckAnnotations, TenantScope,
 };
 
 use super::{PostgresStore, pg_bigint};
@@ -49,128 +48,6 @@ pub(super) const fn github_check_conclusion_name(value: GithubCheckConclusion) -
         GithubCheckConclusion::Skipped => "skipped",
         GithubCheckConclusion::TimedOut => "timed_out",
     }
-}
-
-pub(super) enum GithubJobCheckInsertError {
-    Operation(sqlx::Error),
-    CorruptData(&'static str),
-}
-
-impl GithubJobCheckInsertError {
-    pub(super) fn into_store_error(self) -> StoreError {
-        match self {
-            Self::Operation(error) => StoreError::operation(error),
-            Self::CorruptData(message) => StoreError::corrupt_data(message),
-        }
-    }
-
-    pub(super) fn into_attempt_error(self) -> AttemptStoreError {
-        match self {
-            Self::Operation(error) => AttemptStoreError::operation(error),
-            Self::CorruptData(message) => AttemptStoreError::corrupt_data(message),
-        }
-    }
-}
-
-pub(super) async fn insert_github_job_check_subject(
-    transaction: &mut Transaction<'_, Postgres>,
-    job_id: JobId,
-    attempt_id: AttemptId,
-    queued_at: UnixMillis,
-) -> Result<(), GithubJobCheckInsertError> {
-    let job = sqlx::query_as::<_, (Uuid, String, Option<Uuid>, Option<String>)>(
-        r"
-        SELECT job.run_id, job.display_name,
-               authority.github_check_subject_id, authority.aggregate_check_name
-        FROM jobs AS job
-        LEFT JOIN LATERAL (
-            SELECT origin.github_check_subject_id,
-                   manifest.check_name AS aggregate_check_name
-            FROM github_workflow_run_manifest_origins AS origin
-            JOIN github_provider_manifest_revisions AS manifest
-              ON manifest.tenant_id = origin.tenant_id
-             AND manifest.repository_id = origin.repository_id
-             AND manifest.provider_connection_id = origin.provider_connection_id
-             AND manifest.manifest_revision = origin.provider_manifest_revision
-             AND manifest.manifest_digest = origin.provider_manifest_digest
-            WHERE origin.run_id = job.run_id
-        ) AS authority ON TRUE
-        WHERE job.id = $1
-        FOR KEY SHARE OF job
-        ",
-    )
-    .bind(job_id.as_uuid())
-    .fetch_optional(&mut **transaction)
-    .await
-    .map_err(GithubJobCheckInsertError::Operation)?
-    .ok_or(GithubJobCheckInsertError::CorruptData(
-        "GitHub job Check has no durable job",
-    ))?;
-    let Some(parent_id) = job.2 else {
-        return Ok(());
-    };
-    let check_name = GithubCheckName::from_job_display_name(&job.1).map_err(|_| {
-        GithubJobCheckInsertError::CorruptData("job display name is not Check-safe")
-    })?;
-    let Some(aggregate_check_name) = job.3.as_deref() else {
-        return Err(GithubJobCheckInsertError::CorruptData(
-            "GitHub job Check has no aggregate-name authority",
-        ));
-    };
-    if aggregate_check_name == check_name.as_str() {
-        return Err(GithubJobCheckInsertError::CorruptData(
-            "job display name collides with the reserved aggregate Check name",
-        ));
-    }
-    let subject_id = Uuid::new_v4();
-    let subject_key = format!("job/{}/attempt/{}", job_id.as_uuid(), attempt_id.as_uuid());
-    let external_id = format!("automata-check:{subject_id}");
-    let inserted = sqlx::query_scalar::<_, Uuid>(
-        r"
-        INSERT INTO github_check_subjects (
-            id, tenant_id, repository_id, provider_delivery_id, subject_key,
-            provider_connection_id, provider_installation_id,
-            github_repository_id, github_repository_name, github_app_id,
-            head_sha, check_name, external_id, created_at_ms,
-            desired_updated_at_ms, origin_kind, schedule_fire_id,
-            workflow_rerun_run_id, subject_kind, parent_subject_id,
-            job_id, job_attempt_id, workflow_run_id, linked_at_ms
-        )
-        SELECT $1, parent.tenant_id, parent.repository_id,
-               parent.provider_delivery_id, $2,
-               parent.provider_connection_id, parent.provider_installation_id,
-               parent.github_repository_id, parent.github_repository_name,
-               parent.github_app_id, parent.head_sha, $3, $4, $5, $5,
-               parent.origin_kind, parent.schedule_fire_id,
-               parent.workflow_rerun_run_id, 'job', parent.id, $6, $7, $9, $5
-        FROM github_check_subjects AS parent
-        WHERE parent.id = $8
-          AND parent.subject_kind = 'workflow'
-        RETURNING id
-        ",
-    )
-    .bind(subject_id)
-    .bind(subject_key)
-    .bind(check_name.as_str())
-    .bind(external_id)
-    .bind(queued_at.get())
-    .bind(job_id.as_uuid())
-    .bind(attempt_id.as_uuid())
-    .bind(parent_id)
-    .bind(job.0)
-    .fetch_optional(&mut **transaction)
-    .await
-    .map_err(GithubJobCheckInsertError::Operation)?;
-
-    let Some(inserted) = inserted else {
-        return Ok(());
-    };
-    if inserted != subject_id {
-        return Err(GithubJobCheckInsertError::CorruptData(
-            "GitHub job Check identity changed on insert",
-        ));
-    }
-    Ok(())
 }
 
 pub(super) const SUBJECT_COLUMNS: &str = r"

--- a/crates/automata-ci-store-postgres/src/lib.rs
+++ b/crates/automata-ci-store-postgres/src/lib.rs
@@ -632,14 +632,6 @@ impl InternalAttemptRepository for PostgresStore {
         .execute(&mut *transaction)
         .await
         .map_err(operation_error)?;
-        github_checks::insert_github_job_check_subject(
-            &mut transaction,
-            attempt.job_id(),
-            attempt.attempt_id(),
-            attempt.queued_at(),
-        )
-        .await
-        .map_err(github_checks::GithubJobCheckInsertError::into_attempt_error)?;
         transaction.commit().await.map_err(operation_error)?;
         Ok(())
     }

--- a/crates/automata-ci-store-postgres/src/logical_materialization.rs
+++ b/crates/automata-ci-store-postgres/src/logical_materialization.rs
@@ -11,11 +11,8 @@ use sqlx::{PgPool, Postgres, Row as _, Transaction, postgres::PgRow};
 use uuid::Uuid;
 
 use super::{
-    CurrentAttemptOutputSafety, PostgresStore,
-    durable_schema::current_durable_schemas,
-    github_checks::{GithubJobCheckInsertError, insert_github_job_check_subject},
-    logical_activation::decode_scheduling_policy,
-    pg_bigint,
+    CurrentAttemptOutputSafety, PostgresStore, durable_schema::current_durable_schemas,
+    logical_activation::decode_scheduling_policy, pg_bigint,
 };
 use automata_ci_store::{
     ActivatedLogicalInstanceDescriptor, AdmissionObject, ClaimLogicalInstanceMaterialization,
@@ -247,14 +244,6 @@ impl LogicalMaterializationRepository for PostgresStore {
         insert_job(&mut transaction, &request, &descriptor).await?;
         insert_initial_attempt(&mut transaction, &request, attempt_safety).await?;
         insert_materialization_receipt(&mut transaction, &request, &descriptor).await?;
-        insert_github_job_check_subject(
-            &mut transaction,
-            request.claim().expected_job_id(),
-            request.claim().expected_attempt_id(),
-            request.committed_at(),
-        )
-        .await
-        .map_err(GithubJobCheckInsertError::into_store_error)?;
         let rows = sqlx::query(
             r"
             UPDATE logical_workflow_materialization_claims

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -1313,7 +1313,7 @@ async fn record_admitted_event_subject(
 ) -> Result<(), LogicalWorkflowAdmissionStoreError> {
     let outcome = EventSubjectTerminalOutcome::admitted(command.run_id())
         .map_err(event_subject_value_error)?;
-    let (origin, control_id, registration_replay, progress_replay) =
+    let (_, _, registration_replay, progress_replay) =
         record_event_subject_terminal(transaction, command, subject_evidence, outcome, admitted_at)
             .await?;
     if progress_replay != expected_replay || (expected_replay && !registration_replay) {
@@ -1322,20 +1322,7 @@ async fn record_admitted_event_subject(
         )
         .into());
     }
-    if matches!(
-        subject_evidence,
-        SubjectEvidenceAdmission::AuthenticatedProvider { .. }
-    ) {
-        return Ok(());
-    }
-    link_github_check_event_control(
-        transaction,
-        command,
-        origin,
-        control_id,
-        Some(command.run_id()),
-    )
-    .await
+    Ok(())
 }
 
 async fn record_skipped_event_subject(
@@ -1346,16 +1333,9 @@ async fn record_skipped_event_subject(
 ) -> Result<(), LogicalWorkflowAdmissionStoreError> {
     let outcome = EventSubjectTerminalOutcome::skipped("workflow.disabled")
         .map_err(event_subject_value_error)?;
-    let (origin, control_id, _, _) =
-        record_event_subject_terminal(transaction, command, subject_evidence, outcome, recorded_at)
-            .await?;
-    if matches!(
-        subject_evidence,
-        SubjectEvidenceAdmission::AuthenticatedProvider { .. }
-    ) {
-        return Ok(());
-    }
-    link_github_check_event_control(transaction, command, origin, control_id, None).await
+    record_event_subject_terminal(transaction, command, subject_evidence, outcome, recorded_at)
+        .await?;
+    Ok(())
 }
 
 async fn replay_disabled_event_subject(
@@ -1371,7 +1351,7 @@ async fn replay_disabled_event_subject(
         command.workflow_path(),
     )
     .map_err(event_subject_value_error)?;
-    let Some((selection, control, progress)) =
+    let Some((selection, _control, progress)) =
         load_event_subject_state_in_transaction(transaction, subject_id)
             .await
             .map_err(event_subject_store_error)?
@@ -1395,131 +1375,7 @@ async fn replay_disabled_event_subject(
         )
         .into());
     }
-    if !matches!(
-        subject_evidence,
-        SubjectEvidenceAdmission::AuthenticatedProvider { .. }
-    ) {
-        link_github_check_event_control(transaction, command, origin, control.id(), None).await?;
-    }
     Ok(true)
-}
-
-#[allow(clippy::too_many_lines)] // One exact mutation covers admitted and disabled projections.
-async fn link_github_check_event_control(
-    transaction: &mut Transaction<'_, Postgres>,
-    command: &AdmitLogicalWorkflowRun,
-    origin: EventSubjectOrigin,
-    control_id: EventControlSubjectId,
-    run_id: Option<RunId>,
-) -> Result<(), LogicalWorkflowAdmissionStoreError> {
-    if matches!(
-        origin,
-        EventSubjectOrigin::ManualOperation(_) | EventSubjectOrigin::ProviderDelivery(_)
-    ) {
-        return Ok(());
-    }
-    let linked = if let Some(run_id) = run_id {
-        sqlx::query(
-            r"
-            UPDATE github_check_subjects
-               SET event_control_subject_id = $1
-             WHERE tenant_id = $2
-               AND repository_id = $3
-               AND workflow_run_id = $4
-               AND subject_kind = 'workflow'
-               AND subject_key = $5
-               AND (
-                    (origin_kind = 'provider_delivery'
-                     AND provider_delivery_id = $6)
-                 OR (origin_kind = 'scheduled_fire'
-                     AND schedule_fire_id = $6)
-               )
-               AND (event_control_subject_id IS NULL OR event_control_subject_id = $1)
-            ",
-        )
-        .bind(control_id.as_uuid())
-        .bind(command.tenant().as_str())
-        .bind(command.repository().id().as_uuid())
-        .bind(run_id.as_uuid())
-        .bind(command.workflow_path())
-        .bind(origin.as_uuid())
-        .execute(&mut **transaction)
-        .await
-        .map_err(operation_error)?
-    } else {
-        // A disabled workflow is already terminal generalized progress. Keep
-        // the optional GitHub projection subordinate to that control by
-        // linking and terminalizing it in this same transaction. The second
-        // arm is an exact no-op replay and cannot advance the revision again.
-        sqlx::query(
-            r"
-            UPDATE github_check_subjects
-               SET event_control_subject_id = $1,
-                   desired_state = CASE
-                       WHEN desired_state = 'queued' THEN 'completed'
-                       ELSE desired_state
-                   END,
-                   desired_conclusion = CASE
-                       WHEN desired_state = 'queued' THEN 'skipped'
-                       ELSE desired_conclusion
-                   END,
-                   terminal_cause = CASE
-                       WHEN desired_state = 'queued' THEN 'workflow_skipped'
-                       ELSE terminal_cause
-                   END,
-                   desired_revision = CASE
-                       WHEN desired_state = 'queued' THEN desired_revision + 1
-                       ELSE desired_revision
-                   END,
-                   desired_updated_at_ms = CASE
-                       WHEN desired_state = 'queued' THEN $6
-                       ELSE desired_updated_at_ms
-                   END
-             WHERE tenant_id = $2
-               AND repository_id = $3
-               AND workflow_run_id IS NULL
-               AND linked_at_ms IS NULL
-               AND subject_kind = 'workflow'
-               AND subject_key = $4
-               AND (
-                    (origin_kind = 'provider_delivery'
-                     AND provider_delivery_id = $5)
-                 OR (origin_kind = 'scheduled_fire'
-                     AND schedule_fire_id = $5)
-               )
-               AND (
-                    (event_control_subject_id IS NULL
-                     AND desired_state = 'queued'
-                     AND desired_conclusion IS NULL
-                     AND terminal_cause IS NULL
-                     AND desired_revision = 1
-                     AND desired_updated_at_ms <= $6)
-                 OR (event_control_subject_id = $1
-                     AND desired_state = 'completed'
-                     AND desired_conclusion = 'skipped'
-                     AND terminal_cause = 'workflow_skipped'
-                     AND desired_revision = 2
-                     AND desired_updated_at_ms <= $6)
-               )
-            ",
-        )
-        .bind(control_id.as_uuid())
-        .bind(command.tenant().as_str())
-        .bind(command.repository().id().as_uuid())
-        .bind(command.workflow_path())
-        .bind(origin.as_uuid())
-        .bind(command.admitted_at().get())
-        .execute(&mut **transaction)
-        .await
-        .map_err(operation_error)?
-    };
-    if linked.rows_affected() != 1 {
-        return Err(StoreError::corrupt_data(
-            "generalized event control does not match one Check projection",
-        )
-        .into());
-    }
-    Ok(())
 }
 
 async fn record_event_subject_terminal(


### PR DESCRIPTION
## Outcome

Removes the obsolete PostgreSQL Check-subject write path now that provider-neutral desired results own admission and orchestration. Logical materialization keeps only the common result side effect, eliminating duplicate GitHub-specific persistence and its repository surface.

This is the next bounded cleanup in the staged provider-platform refactor.

## Related issue

None

## Trust and compatibility impact

Result persistence now has one provider-neutral owner. No credential, wire-protocol, or workflow syntax behavior changes. The removed GitHub Check write path is intentionally not retained for backward compatibility because this is a greenfield schema and architecture.

## Verification

- `cargo check --workspace --all-targets` — passed on the rebased provider-platform stack.
- Strict Clippy (`-D warnings`) across the affected provider/application crates — passed on the rebased stack.
- Provider, SCM, GitHub provider, and GitHub delivery test suites — passed on the rebased stack.
- Pull-request CI will validate this isolated stage.

## AI assistance

OpenAI Codex assisted with architecture analysis, implementation, test updates, and verification. All submitted changes were reviewed.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.