### PR TITLE
test(macos): cover helper loss during destroy

### DIFF
--- a/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
+++ b/crates/automata-ci-sandbox-macos/tests/macos_provider.rs
@@ -5,13 +5,15 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    sync::{Condvar, Mutex},
     thread,
     time::{Duration, Instant},
 };
 
 use automata_ci_execution::{
-    DestroySandbox, EnvironmentProfile, EnvironmentProfileId, ExecutionArgv, ExecutionCommand,
-    ExecutionEnvironment, ExecutionErrorKind, ExecutionTermination, NetworkPolicy, NeverCancelled,
+    Cancellation, CancellationDisposition, DestroyDisposition, DestroySandbox, EnvironmentProfile,
+    EnvironmentProfileId, ExecutionArgv, ExecutionCommand, ExecutionEnvironment,
+    ExecutionErrorKind, ExecutionStage, ExecutionTermination, NetworkPolicy, NeverCancelled,
     OperationId, OperationOutcome, ProviderErrorKind, ProviderStage, ResourceLimits,
     RootFilesystemPolicy, RunnerId, SandboxCustody, SandboxEnvironment, SandboxGeneration,
     SandboxHandle, SandboxProvider, SandboxSpec, Sha256Digest, TargetPath,
@@ -315,6 +317,95 @@ fn provider_recovers_an_interrupted_launch_and_reuses_the_slot() {
     assert_attempts_empty(&root);
 }
 
+#[test]
+#[ignore = "requires a sealed VM template on a physical Apple Silicon runner"]
+fn provider_completes_destroy_when_the_helper_dies_during_quiescence() {
+    let root = required_path(VM_STORAGE_ROOT_ENV);
+    assert_attempts_empty(&root);
+    let provider = MacosVirtualizationProvider::open(physical_options(root.clone()))
+        .expect("open physical macOS provider");
+
+    let first_spec = physical_spec("destroy-helper-loss");
+    let first = provider
+        .create(&first_spec, &NeverCancelled)
+        .expect("create destroy-helper-loss VM");
+    let mut first_cleanup = PhysicalSandboxCleanup::new(
+        provider.clone(),
+        first.handle().clone(),
+        first_spec.generation(),
+        first_spec.custody(),
+    );
+    let endpoint = provider
+        .attach(first.handle(), &NeverCancelled)
+        .expect("attach destroy-helper-loss VM");
+    let command = blocking_command(first_spec.workspace());
+    let destroy = DestroySandbox::new(
+        OperationId::new(),
+        first.handle().clone(),
+        first_spec.generation(),
+        first_spec.custody(),
+    );
+    let cancellation = ObservedCancellation::default();
+    let (execution_result, destroy_result) = thread::scope(|scope| {
+        let execution =
+            scope.spawn(|| endpoint.exec(&command, &cancellation, discard_execution_output()));
+        cancellation.wait(Duration::from_secs(30));
+        let destroying = scope.spawn(|| provider.destroy(&destroy, &NeverCancelled));
+        wait_for_destroy_intent(&root, &destroy, Duration::from_secs(30));
+        kill_attempt_helper(&root, first.handle());
+        (
+            execution.join().expect("join active VM execution"),
+            destroying.join().expect("join interrupted VM destroy"),
+        )
+    });
+    let execution_error =
+        execution_result.expect_err("helper loss must close the active guest operation");
+    assert_eq!(execution_error.kind(), ExecutionErrorKind::BackendRejected);
+    assert_eq!(execution_error.stage(), ExecutionStage::Exec);
+    assert_eq!(
+        destroy_result.expect("complete destroy after helper loss"),
+        DestroyDisposition::Destroyed
+    );
+    first_cleanup.disarm();
+    assert_attempts_empty(&root);
+
+    create_probe_and_destroy(
+        &provider,
+        &physical_spec("destroy-helper-loss-reuse"),
+        "reuse provider slot after destroy-time helper loss",
+    );
+    assert_attempts_empty(&root);
+}
+
+#[derive(Debug, Default)]
+struct ObservedCancellation {
+    observed: Mutex<bool>,
+    notification: Condvar,
+}
+
+impl ObservedCancellation {
+    fn wait(&self, timeout: Duration) {
+        let observed = self.observed.lock().expect("lock cancellation observation");
+        let (observed, _) = self
+            .notification
+            .wait_timeout_while(observed, timeout, |observed| !*observed)
+            .expect("wait for cancellation observation");
+        assert!(
+            *observed,
+            "active guest operation did not reach its cancellation checkpoint"
+        );
+    }
+}
+
+impl Cancellation for ObservedCancellation {
+    fn disposition(&self) -> CancellationDisposition {
+        let mut observed = self.observed.lock().expect("lock cancellation observation");
+        *observed = true;
+        self.notification.notify_all();
+        CancellationDisposition::Active
+    }
+}
+
 struct PhysicalSandboxCleanup {
     provider: MacosVirtualizationProvider,
     handle: SandboxHandle,
@@ -406,6 +497,22 @@ fn probe_command(working_directory: &TargetPath) -> ExecutionCommand {
     .expect("probe command")
 }
 
+fn blocking_command(working_directory: &TargetPath) -> ExecutionCommand {
+    ExecutionCommand::new(
+        OperationId::new(),
+        ExecutionArgv::new(
+            TargetPath::posix("/usr/bin/tail").expect("tail path"),
+            vec!["-f".to_owned(), "/dev/null".to_owned()],
+        )
+        .expect("blocking argv"),
+        working_directory.clone(),
+        ExecutionEnvironment::empty(),
+        Duration::from_secs(90),
+        16 * 1024,
+    )
+    .expect("blocking command")
+}
+
 fn create_probe_and_destroy(
     provider: &MacosVirtualizationProvider,
     spec: &SandboxSpec,
@@ -485,6 +592,47 @@ fn kill_helper_for_attempt(root: &Path, attempt: &str, timeout: Duration) {
             [] => panic!("physical VM helper did not start before the deadline"),
             _ => panic!("more than one helper owns the physical VM attempt"),
         }
+    }
+}
+
+fn wait_for_destroy_intent(root: &Path, request: &DestroySandbox, timeout: Duration) {
+    let journal = root.join(".automata-macos-virtualization-v2.events");
+    let operation_id = request.operation_id().to_string();
+    let generation = request.generation().get();
+    let deadline = Instant::now() + timeout;
+    loop {
+        let contents = fs::read_to_string(&journal).expect("read physical provider journal");
+        let observed = contents.split_inclusive('\n').any(|record| {
+            if !record.ends_with('\n') {
+                return false;
+            }
+            let record: serde_json::Value =
+                serde_json::from_str(record).expect("parse complete physical journal record");
+            record
+                .pointer("/event/kind")
+                .and_then(|value| value.as_str())
+                == Some("destroy_intent")
+                && record
+                    .pointer("/event/request/operation_id")
+                    .and_then(|value| value.as_str())
+                    == Some(operation_id.as_str())
+                && record
+                    .pointer("/event/request/handle")
+                    .and_then(|value| value.as_str())
+                    == Some(request.handle().opaque())
+                && record
+                    .pointer("/event/request/generation")
+                    .and_then(serde_json::Value::as_u64)
+                    == Some(generation)
+        });
+        if observed {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "provider did not durably publish the exact destroy intent"
+        );
+        thread::sleep(Duration::from_millis(10));
     }
 }
 

--- a/docs/github-actions-parity-backlog.md
+++ b/docs/github-actions-parity-backlog.md
@@ -1220,7 +1220,8 @@ current baseline.
 - [ ] Add Xcode and toolchain profiles.
 - [ ] Add macOS acceptance jobs.
 - [x] Add physical clone cleanup, runner cancellation, interrupted-launch
-  recovery, live-helper-loss slot reuse, and live-orphan startup recovery tests.
+  recovery, live-helper-loss slot reuse, destroy-time helper-loss cleanup, and
+  live-orphan startup recovery tests.
 
 ### Architecture and image breadth
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -445,8 +445,11 @@ destroys the clone, and proves the same provider slot can run and clean a fresh
 VM. The interrupted-launch test kills the exact helper after its owned attempt
 appears, requires an uncertain `CreateSandbox` adapter-unavailable error with
 the exact recovery handle, reconciles that handle, and proves the slot can
-launch and clean a replacement VM. A continuous protected physical lane, the
-destroy-time helper-crash transition, and a retained repeated-clean soak remain
+launch and clean a replacement VM. The destroy-transition test holds a real
+guest operation, observes its cancellation checkpoint and the exact durable
+destroy intent, kills that attempt's helper, and requires the endpoint to close,
+destruction to complete, and the slot to run and clean a replacement VM. A
+continuous protected physical lane and a retained repeated-clean soak remain
 deployment work.
 
 Create `/Volumes/AutomataVM/e2e-state` as an empty `0700` directory owned by
@@ -466,8 +469,8 @@ export AUTOMATA_MACOS_VM_STORAGE_QUOTA_BYTES=<exact-volume-quota-bytes>
 
 The entrypoint runs the shipped-runner success/timeout and cancellation matrix,
 interrupted-launch recovery and slot reuse, live-helper-loss cleanup and slot
-reuse, live-orphan recovery, and the allowlisted runtime-proxy probe serially.
-Set
+reuse, destroy-time helper-loss cleanup and slot reuse, live-orphan recovery,
+and the allowlisted runtime-proxy probe serially. Set
 `AUTOMATA_MACOS_PHYSICAL_REPETITIONS` from 1 through 10 for a bounded repeated
 runner soak. It refuses a `CARGO_TARGET_DIR` on the VM storage filesystem so
 build artifacts cannot consume the clone-capacity safety margin.

--- a/scripts/ci/run-macos-physical-checks.sh
+++ b/scripts/ci/run-macos-physical-checks.sh
@@ -122,6 +122,10 @@ run_test 'live helper loss cleanup and slot reuse' \
   cargo test -p automata-ci-sandbox-macos --test macos_provider --locked \
   provider_cleans_up_and_reuses_slot_after_live_helper_loss -- \
   --ignored --exact --nocapture --test-threads=1
+run_test 'helper loss during VM destroy cleanup and slot reuse' \
+  cargo test -p automata-ci-sandbox-macos --test macos_provider --locked \
+  provider_completes_destroy_when_the_helper_dies_during_quiescence -- \
+  --ignored --exact --nocapture --test-threads=1
 run_test 'live VM orphan recovery after owner loss' \
   cargo test -p automata-ci-sandbox-macos --test macos_provider --locked \
   provider_reconciles_a_live_orphan_after_owner_process_loss -- \

--- a/scripts/ci/tests/macos-physical-checks.test.py
+++ b/scripts/ci/tests/macos-physical-checks.test.py
@@ -30,7 +30,7 @@ class MacosPhysicalChecksTest(unittest.TestCase):
         result = self.run_script("--plan")
         self.assertEqual(result.returncode, 0, result.stderr)
         commands = [line for line in result.stdout.splitlines() if line.startswith("RUN ")]
-        self.assertEqual(len(commands), 5, result.stdout)
+        self.assertEqual(len(commands), 6, result.stdout)
         for identity in (
             "automata-ci-runner --test runner",
             "automata-ci-sandbox-macos --test macos_provider",
@@ -44,8 +44,12 @@ class MacosPhysicalChecksTest(unittest.TestCase):
             "provider_recovers_an_interrupted_launch_and_reuses_the_slot", commands[1]
         )
         self.assertIn("provider_cleans_up_and_reuses_slot_after_live_helper_loss", commands[2])
-        self.assertIn("provider_reconciles_a_live_orphan", commands[3])
-        self.assertIn("physical_guest_reaches_an_allowlisted_origin", commands[4])
+        self.assertIn(
+            "provider_completes_destroy_when_the_helper_dies_during_quiescence",
+            commands[3],
+        )
+        self.assertIn("provider_reconciles_a_live_orphan", commands[4])
+        self.assertIn("physical_guest_reaches_an_allowlisted_origin", commands[5])
         self.assertNotIn("HELPER_REQUIREMENT=", result.stdout)
         self.assertNotIn("STORAGE_QUOTA_BYTES=", result.stdout)
 
@@ -55,12 +59,12 @@ class MacosPhysicalChecksTest(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         commands = [line for line in result.stdout.splitlines() if line.startswith("RUN ")]
-        self.assertEqual(len(commands), 6, result.stdout)
+        self.assertEqual(len(commands), 7, result.stdout)
         self.assertEqual(
             sum("automata-ci-runner --test runner" in command for command in commands), 2
         )
         self.assertEqual(
-            sum("--test macos_provider" in command for command in commands), 3
+            sum("--test macos_provider" in command for command in commands), 4
         )
 
     def test_invalid_repetition_count_fails_closed(self) -> None:


### PR DESCRIPTION
## Outcome

Adds deterministic physical-host acceptance for helper loss during VM destruction. The test starts a real blocking guest operation, observes its public cancellation checkpoint, starts destroy, waits for that exact operation and handle to appear in the durable `destroy_intent`, kills only the helper bound to the owned attempt, and requires the endpoint to close, destroy to complete, the attempt to disappear, and the provider slot to run and clean a replacement VM. The serial physical entrypoint now includes this case.

## Related issue

None.

## Trust and compatibility impact

No credential, helper protocol, storage schema, provider runtime, or workflow behavior changes. This strengthens the private Apple Silicon acceptance boundary with exact evidence for the destroy-time helper-loss transition. The helper remains admitted by its configured hash and strict signing requirement.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `bash -n scripts/ci/run-macos-physical-checks.sh`
- `python3 scripts/ci/tests/macos-physical-checks.test.py` (4 passed)
- Apple Silicon macOS exact physical test: 1 passed in 210.38s
- Apple Silicon expanded serial physical entrypoint: runner matrix 478.80s; interrupted launch 206.46s; live helper loss 215.63s; destroy-time helper loss 216.03s; orphan recovery 404.06s; proxy 9.29s
- Post-run host audit: zero provider attempts, proxy attempts, VM helpers, or bridge processes; 72 GiB free on the VM volume
- Apple Silicon macOS final rebased commit: `cargo clippy -p automata-ci-sandbox-macos --test macos_provider --locked -- -D warnings`

## AI assistance

OpenAI Codex implemented and validated the focused physical test, serial entrypoint, and support-status updates under operator direction.

## Checklist

- [x] Tests cover the owning public boundary or the change is documentation-only.
- [x] User-facing documentation and compatibility status are updated where needed.
- [x] Logs, fixtures, screenshots, and examples contain no secrets or private data.
- [x] New dependencies, generated assets, licenses, and release metadata are accounted for.
- [x] Unsupported workflow behavior is rejected explicitly rather than ignored.
- [x] I reviewed and understand every submitted change, including AI-assisted work.