### PR TITLE
fix(runner): diagnose job preparation failures

### DIFF
--- a/crates/automata-ci-job-executor-actions/README.md
+++ b/crates/automata-ci-job-executor-actions/README.md
@@ -14,6 +14,13 @@ Secret-derived outputs and values matching registered credentials are marked
 sensitive instead of being returned as public values. The product compatibility
 limit is tracked separately from this component boundary.
 
+Failures before the job reaches `Running` emit one bounded runner-diagnostics
+line with a stable preparation stage, such as `sandbox` or `event_copy`. The
+stage is also recorded in runner tracing alongside the attempt ID and sanitized
+error kind. Provider error text, workflow data, paths, and credentials never
+enter this diagnostic, and a diagnostic-journal failure does not replace the
+original execution failure.
+
 The executor implements the reviewed `GITHUB_ARTIFACTS` environment-file
 delta: every phase receives fresh declaration and read-only list files; file
 subjects resolve relative to the job workspace and are SHA-256 hashed as

--- a/crates/automata-ci-job-executor-actions/src/error.rs
+++ b/crates/automata-ci-job-executor-actions/src/error.rs
@@ -91,15 +91,64 @@ pub enum ActionPreparationErrorKind {
 #[error("Actions job executor failed: {kind:?}")]
 pub struct ExecutorAdapterError {
     kind: ExecutorAdapterErrorKind,
+    preparation_stage: Option<ExecutorPreparationStage>,
 }
 
 impl ExecutorAdapterError {
     pub(crate) const fn new(kind: ExecutorAdapterErrorKind) -> Self {
-        Self { kind }
+        Self {
+            kind,
+            preparation_stage: None,
+        }
     }
 
     pub(crate) const fn kind(self) -> ExecutorAdapterErrorKind {
         self.kind
+    }
+
+    pub(crate) const fn at_preparation_stage(mut self, stage: ExecutorPreparationStage) -> Self {
+        if self.preparation_stage.is_none() {
+            self.preparation_stage = Some(stage);
+        }
+        self
+    }
+
+    pub(crate) const fn preparation_stage(self) -> Option<ExecutorPreparationStage> {
+        self.preparation_stage
+    }
+}
+
+/// Stable, secret-free stages of job preparation before user code can run.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExecutorPreparationStage {
+    RuntimeContext,
+    RepositoryActions,
+    SecretCustody,
+    Workspace,
+    Event,
+    JobContext,
+    Services,
+    Sandbox,
+    AttemptDirectories,
+    EventCopy,
+    RunningTransition,
+}
+
+impl ExecutorPreparationStage {
+    pub(crate) const fn code(self) -> &'static str {
+        match self {
+            Self::RuntimeContext => "runtime_context",
+            Self::RepositoryActions => "repository_actions",
+            Self::SecretCustody => "secret_custody",
+            Self::Workspace => "workspace",
+            Self::Event => "event",
+            Self::JobContext => "job_context",
+            Self::Services => "services",
+            Self::Sandbox => "sandbox",
+            Self::AttemptDirectories => "attempt_directories",
+            Self::EventCopy => "event_copy",
+            Self::RunningTransition => "running_transition",
+        }
     }
 }
 

--- a/crates/automata-ci-job-executor-actions/src/executor.rs
+++ b/crates/automata-ci-job-executor-actions/src/executor.rs
@@ -71,7 +71,9 @@ use crate::{
         EnvironmentBuilder, ResolvedActionInputs, ResolvedEnvironmentValue,
         validate_environment_overlay_names,
     },
-    error::{ExecutorAdapterError, ExecutorAdapterErrorKind, PortErrorKind},
+    error::{
+        ExecutorAdapterError, ExecutorAdapterErrorKind, ExecutorPreparationStage, PortErrorKind,
+    },
     output::{
         DIAGNOSTICS_LOG_GROUP_ID, PhaseOutputSink, SecretMasker, emit_system, emit_system_for_group,
     },
@@ -725,12 +727,19 @@ impl ActionsJobExecutor {
             return self.cancelled_job_result(attempt_id, &masker);
         }
         let started_at = self.ports.clock.now();
-        let runtime_context = self.hydrate_runtime_context(request.job()).await;
+        let runtime_context = self
+            .hydrate_runtime_context(request.job())
+            .await
+            .map_err(|error| error.at_preparation_stage(ExecutorPreparationStage::RuntimeContext));
         let Some(runtime_context) = reconcile_cancelled_operation(runtime_context, &cancellation)?
         else {
             return self.cancelled_job_result(attempt_id, &masker);
         };
-        let runtime_context = self.apply_managed_secret_bindings(runtime_context)?;
+        let runtime_context = self
+            .apply_managed_secret_bindings(runtime_context)
+            .map_err(|error| {
+                error.at_preparation_stage(ExecutorPreparationStage::RuntimeContext)
+            })?;
         if request.job().job().authority_profile() == JobAuthorityProfile::CredentialFree
             && (!request.runtime_authorities().as_slice().is_empty()
                 || !runtime_context.secrets().is_empty()
@@ -744,9 +753,14 @@ impl ActionsJobExecutor {
             if cancellation.is_cancelled() {
                 return self.cancelled_job_result(attempt_id, &masker);
             }
-            return Err(invalid_job());
+            return Err(
+                invalid_job().at_preparation_stage(ExecutorPreparationStage::RuntimeContext)
+            );
         }
-        self.register_runtime_context_secret_masks(&runtime_context, &mut masker)?;
+        self.register_runtime_context_secret_masks(&runtime_context, &mut masker)
+            .map_err(|error| {
+                error.at_preparation_stage(ExecutorPreparationStage::RuntimeContext)
+            })?;
         if cancellation.is_cancelled() {
             return self.cancelled_job_result(attempt_id, &masker);
         }
@@ -756,24 +770,32 @@ impl ActionsJobExecutor {
         {
             Ok(actions) => actions,
             Err(ActionLoadError::Preparation(kind)) => {
-                if emit_system_while_active(
+                let emitted = emit_system_while_active(
                     &format!("Action preparation failed ({kind:?})"),
                     &mut masker,
                     &events,
                     &cancellation,
-                )?
-                .is_none()
-                {
+                )
+                .map_err(|error| {
+                    error.at_preparation_stage(ExecutorPreparationStage::RepositoryActions)
+                })?;
+                if emitted.is_none() {
                     return self.cancelled_job_result(attempt_id, &masker);
                 }
-                return self.failed_job_result(attempt_id, &masker);
+                return self
+                    .failed_job_result(attempt_id, &masker)
+                    .map_err(|error| {
+                        error.at_preparation_stage(ExecutorPreparationStage::RepositoryActions)
+                    });
             }
             Err(ActionLoadError::Executor(error))
                 if error.kind() == ExecutorAdapterErrorKind::Cancelled =>
             {
                 return self.cancelled_job_result(attempt_id, &masker);
             }
-            Err(ActionLoadError::Executor(error)) => return Err(error),
+            Err(ActionLoadError::Executor(error)) => {
+                return Err(error.at_preparation_stage(ExecutorPreparationStage::RepositoryActions));
+            }
         };
         if cancellation.is_cancelled() {
             return self.cancelled_job_result(attempt_id, &masker);
@@ -782,7 +804,10 @@ impl ActionsJobExecutor {
             acknowledger
                 .acknowledge(cancellation.token())
                 .await
-                .map_err(map_executor_error)?;
+                .map_err(map_executor_error)
+                .map_err(|error| {
+                    error.at_preparation_stage(ExecutorPreparationStage::SecretCustody)
+                })?;
             if cancellation.is_cancelled() {
                 return self.cancelled_job_result(attempt_id, &masker);
             }
@@ -797,7 +822,9 @@ impl ActionsJobExecutor {
             Err(error) if matches!(error.kind(), ExecutorAdapterErrorKind::Cancelled) => {
                 return self.cancelled_job_result(attempt_id, &masker);
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                return Err(error.at_preparation_stage(ExecutorPreparationStage::Workspace));
+            }
         };
         let paths = cancellation_dominant(
             AttemptPaths::new(self.config.runner_root(), attempt_id, &workspace),
@@ -808,7 +835,9 @@ impl ActionsJobExecutor {
             Err(error) if matches!(error.kind(), ExecutorAdapterErrorKind::Cancelled) => {
                 return self.cancelled_job_result(attempt_id, &masker);
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                return Err(error.at_preparation_stage(ExecutorPreparationStage::Workspace));
+            }
         };
         let mut commands = JobCommandState::new(command_file_platform(workspace.platform()));
         let mut records = Vec::<MutableStepResult>::new();
@@ -818,7 +847,8 @@ impl ActionsJobExecutor {
             .content
             .load(request.job().execution().event())
             .await
-            .map_err(|error| map_port_error(error.kind()));
+            .map_err(|error| map_port_error(error.kind()))
+            .map_err(|error| error.at_preparation_stage(ExecutorPreparationStage::Event));
         let Some(event) = reconcile_cancelled_operation(event, &cancellation)? else {
             return self.cancelled_job_result(attempt_id, &masker);
         };
@@ -832,7 +862,9 @@ impl ActionsJobExecutor {
             Err(error) if matches!(error.kind(), ExecutorAdapterErrorKind::Cancelled) => {
                 return self.cancelled_job_result(attempt_id, &masker);
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                return Err(error.at_preparation_stage(ExecutorPreparationStage::Event));
+            }
         };
         let event_context =
             cancellation_dominant(github_value_from_json(&event_document, 0), &cancellation);
@@ -841,15 +873,18 @@ impl ActionsJobExecutor {
             Err(error) if matches!(error.kind(), ExecutorAdapterErrorKind::Cancelled) => {
                 return self.cancelled_job_result(attempt_id, &masker);
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                return Err(error.at_preparation_stage(ExecutorPreparationStage::Event));
+            }
         };
         if !matches!(&event_context, GithubValue::Object(_)) {
             if cancellation.is_cancelled() {
                 return self.cancelled_job_result(attempt_id, &masker);
             }
-            return Err(ExecutorAdapterError::new(
-                ExecutorAdapterErrorKind::InvalidJob,
-            ));
+            return Err(
+                ExecutorAdapterError::new(ExecutorAdapterErrorKind::InvalidJob)
+                    .at_preparation_stage(ExecutorPreparationStage::Event),
+            );
         }
         let job_context = self.context(
             &request,
@@ -861,10 +896,14 @@ impl ActionsJobExecutor {
             None,
             ActionsExecutionPhase::Job,
         );
+        let job_context = job_context
+            .map_err(|error| error.at_preparation_stage(ExecutorPreparationStage::JobContext));
         let Some(job_context) = reconcile_cancelled_operation(job_context, &cancellation)? else {
             return self.cancelled_job_result(attempt_id, &masker);
         };
         let service_specs = self.service_specs(&request, &job_context, &mut masker, &cancellation);
+        let service_specs = service_specs
+            .map_err(|error| error.at_preparation_stage(ExecutorPreparationStage::Services));
         let Some(service_specs) = reconcile_cancelled_operation(service_specs, &cancellation)?
         else {
             return self.cancelled_job_result(attempt_id, &masker);
@@ -877,6 +916,8 @@ impl ActionsJobExecutor {
             &events,
             &cancellation,
         );
+        let sandbox =
+            sandbox.map_err(|error| error.at_preparation_stage(ExecutorPreparationStage::Sandbox));
         let Some(sandbox) = reconcile_cancelled_operation(sandbox, &cancellation)? else {
             return self.cancelled_job_result(attempt_id, &masker);
         };
@@ -909,6 +950,9 @@ impl ActionsJobExecutor {
             request.environment().default_environment(),
             &cancellation,
         );
+        let prepared = prepared.map_err(|error| {
+            error.at_preparation_stage(ExecutorPreparationStage::AttemptDirectories)
+        });
         if reconcile_cancelled_operation(prepared, &cancellation)?.is_none() {
             return self.cancelled_job_result(attempt_id, &masker);
         }
@@ -921,10 +965,15 @@ impl ActionsJobExecutor {
             &event,
             &cancellation,
         );
+        let copied =
+            copied.map_err(|error| error.at_preparation_stage(ExecutorPreparationStage::EventCopy));
         if reconcile_cancelled_operation(copied, &cancellation)?.is_none() {
             return self.cancelled_job_result(attempt_id, &masker);
         }
         let transitioned = Self::transition_running(request.recovery_lifecycle(), &events);
+        let transitioned = transitioned.map_err(|error| {
+            error.at_preparation_stage(ExecutorPreparationStage::RunningTransition)
+        });
         if reconcile_cancelled_operation(transitioned, &cancellation)?.is_none() {
             return self.cancelled_job_result(attempt_id, &masker);
         }
@@ -5744,6 +5793,8 @@ impl JobExecutor for ActionsJobExecutor {
         cancellation: ExecutionCancellation,
     ) -> ExecutorFuture<'_> {
         Box::pin(async move {
+            let attempt_id = request.lease().attempt_id();
+            let diagnostic_cancellation = cancellation.clone();
             let system_group_id = LogGroupId::new(DIAGNOSTICS_LOG_GROUP_ID).map_err(|_| {
                 ExecutorError::from(ExecutorAdapterError::new(
                     ExecutorAdapterErrorKind::Internal,
@@ -5769,6 +5820,9 @@ impl JobExecutor for ActionsJobExecutor {
             let result = self
                 .execute_job(request, Arc::clone(&events), cancellation)
                 .await;
+            if let Err(error) = &result {
+                report_preparation_failure(*error, attempt_id, &events, &diagnostic_cancellation);
+            }
             let conclusion = result
                 .as_ref()
                 .map_or(JobConclusion::Failure, JobResult::conclusion);
@@ -5793,6 +5847,39 @@ impl JobExecutor for ActionsJobExecutor {
             self.cleanup_sandbox(&request, &events, &cancellation)
                 .map_err(ExecutorError::from)
         })
+    }
+}
+
+fn report_preparation_failure(
+    error: ExecutorAdapterError,
+    attempt_id: AttemptId,
+    events: &Arc<dyn ExecutionEvents>,
+    cancellation: &ExecutionCancellation,
+) {
+    let Some(stage) = error.preparation_stage() else {
+        return;
+    };
+    if error.kind() == ExecutorAdapterErrorKind::Cancelled {
+        return;
+    }
+    tracing::warn!(
+        attempt_id = %attempt_id,
+        preparation_stage = stage.code(),
+        error_kind = ?error.kind(),
+        "GitHub job preparation failed"
+    );
+    let diagnostic = format!("Runner preparation failed (stage: {}).", stage.code());
+    let mut masker = SecretMasker::new();
+    if let Err(diagnostic_error) =
+        emit_system_while_active(&diagnostic, &mut masker, events, cancellation)
+    {
+        tracing::warn!(
+            attempt_id = %attempt_id,
+            preparation_stage = stage.code(),
+            error_kind = ?error.kind(),
+            diagnostic_error_kind = ?diagnostic_error.kind(),
+            "Runner preparation failure diagnostic could not be committed"
+        );
     }
 }
 

--- a/crates/automata-ci-job-executor-actions/tests/provider_saga.rs
+++ b/crates/automata-ci-job-executor-actions/tests/provider_saga.rs
@@ -82,6 +82,59 @@ const PROVIDER_FAILURE_CASES: &[(ProviderErrorKind, ExecutorErrorKind, ProviderF
 ];
 
 #[tokio::test]
+async fn pre_running_provider_failure_emits_a_sanitized_preparation_stage() {
+    let fixture = Fixture::new(Vec::new(), Vec::new());
+    fixture.provider.fail_next_create(
+        ProviderErrorKind::BackendRejected,
+        OperationOutcome::KnownNoEffect,
+    );
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let error = fixture
+        .executor
+        .execute(
+            fixture.request(run_job("true\n")),
+            events,
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect_err("injected provider creation failure");
+
+    assert_eq!(error.kind(), ExecutorErrorKind::Internal);
+    assert!(fixture.events.transitions().is_empty());
+    let logs = fixture.events.logs();
+    assert_eq!(logs.len(), 1);
+    assert_eq!(
+        logs[0].payload(),
+        b"Runner preparation failed (stage: sandbox).\n"
+    );
+}
+
+#[tokio::test]
+async fn preparation_diagnostic_failure_preserves_the_original_error() {
+    let fixture = Fixture::new(Vec::new(), Vec::new());
+    fixture.provider.fail_next_create(
+        ProviderErrorKind::AdapterUnavailable,
+        OperationOutcome::KnownNoEffect,
+    );
+    fixture.events.fail_next_log();
+    let events: Arc<dyn ExecutionEvents> = fixture.events.clone();
+
+    let error = fixture
+        .executor
+        .execute(
+            fixture.request(run_job("true\n")),
+            events,
+            ExecutionCancellation::new(),
+        )
+        .await
+        .expect_err("provider availability failure remains primary");
+
+    assert_eq!(error.kind(), ExecutorErrorKind::Unavailable);
+    assert!(fixture.events.logs().is_empty());
+}
+
+#[tokio::test]
 async fn provider_intent_commit_failure_prevents_every_provider_call() {
     let fixture = Fixture::new(Vec::new(), Vec::new());
     fixture.events.fail_next_begin_provider_operation();

--- a/crates/automata-ci-job-executor-actions/tests/support/mod.rs
+++ b/crates/automata-ci-job-executor-actions/tests/support/mod.rs
@@ -2586,6 +2586,7 @@ struct EventState {
     provider_operation_failures: Vec<(OperationId, ProviderFailureOutcome)>,
     pending_provider_operation: Option<(OperationId, ProviderOperationKind)>,
     provider_event_failures: BTreeSet<ProviderEventFailurePoint>,
+    fail_next_log: bool,
     cancellation_on_log: Option<ExecutionCancellation>,
     fail_log_after_cancellation: bool,
 }
@@ -2674,6 +2675,10 @@ impl FakeEvents {
             .insert(ProviderEventFailurePoint::OperationFailed);
     }
 
+    pub fn fail_next_log(&self) {
+        self.state.lock().expect("events lock").fail_next_log = true;
+    }
+
     pub fn cancel_on_next_log(&self, cancellation: ExecutionCancellation) {
         self.state.lock().expect("events lock").cancellation_on_log = Some(cancellation);
     }
@@ -2746,6 +2751,10 @@ impl ExecutionEvents for FakeEvents {
         let (cancellation, fail_after_cancellation) = {
             let mut state = self.state.lock().expect("events lock");
             if !state.active_log_groups.contains(event.group_id()) {
+                return Err(ExecutionEventError::InvalidEvent);
+            }
+            if state.fail_next_log {
+                state.fail_next_log = false;
                 return Err(ExecutionEventError::InvalidEvent);
             }
             state.logs.push(event);


### PR DESCRIPTION
## Summary

- retain a stable, secret-free stage on executor errors raised before the job reaches Running
- emit one bounded runner-diagnostics line and structured tracing for staged preparation failures
- preserve the original executor error if diagnostics storage fails

This closes the observability gap seen in the Hetzner incidents, where attempts failed in Preparing with an empty diagnostics group and only a generic internal category.

## Safety

The diagnostic contains only a fixed stage code. Provider text, workflow data, paths, and credentials are never included. Cancellation remains dominant.

## Validation

- cargo test -p automata-ci-job-executor-actions --all-targets
- cargo clippy -p automata-ci-job-executor-actions --all-targets -- -D warnings
- cargo fmt --all -- --check
- targeted provider-saga tests after rebasing onto current main