### PR TITLE
Fail fast on insufficient macOS VM clone capacity

### DIFF
--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -473,7 +473,10 @@ reuse, destroy-time helper-loss cleanup and slot reuse, live-orphan recovery,
 and the allowlisted runtime-proxy probe serially. Set
 `AUTOMATA_MACOS_PHYSICAL_REPETITIONS` from 1 through 10 for a bounded repeated
 runner soak. It refuses a `CARGO_TARGET_DIR` on the VM storage filesystem so
-build artifacts cannot consume the clone-capacity safety margin.
+build artifacts cannot consume the clone-capacity safety margin. Before
+compiling or hashing the sealed template, it also checks the storage
+filesystem's currently available bytes against the template artifacts' logical
+length plus the provider's 32 GiB headroom and reports the exact shortfall.
 
 The runtime proxy has a separate physical contract test. It starts a temporary
 loopback HTTP origin on the host, boots the sealed NIC-less guest through the

--- a/scripts/ci/run-macos-physical-checks.sh
+++ b/scripts/ci/run-macos-physical-checks.sh
@@ -60,6 +60,47 @@ assert_directory_empty() {
   fi
 }
 
+manifest_artifact_path() {
+  local artifact=$1
+  local path
+  if ! path=$(/usr/bin/plutil -extract "$artifact.path" raw -o - \
+    "$AUTOMATA_MACOS_VM_TEMPLATE_MANIFEST" 2>/dev/null) || [[ -z "$path" ]]; then
+    printf 'error: template manifest must contain a non-empty %s.path\n' "$artifact" >&2
+    exit 2
+  fi
+  printf '%s\n' "$path"
+}
+
+assert_clone_capacity() {
+  local disk_image auxiliary_storage disk_bytes auxiliary_bytes available_kib
+  local available_bytes required_bytes shortfall_bytes
+  disk_image=$(manifest_artifact_path disk_image)
+  auxiliary_storage=$(manifest_artifact_path auxiliary_storage)
+  for artifact in "$disk_image" "$auxiliary_storage"; do
+    if [[ ! -f "$artifact" ]]; then
+      printf 'error: template artifact is not a regular file: %s\n' "$artifact" >&2
+      exit 2
+    fi
+  done
+  disk_bytes=$(stat -f %z "$disk_image")
+  auxiliary_bytes=$(stat -f %z "$auxiliary_storage")
+  available_kib=$(df -Pk "$AUTOMATA_MACOS_VM_STORAGE_ROOT" | awk 'END {print $4}')
+  if [[ ! "$disk_bytes" =~ ^[0-9]+$ || ! "$auxiliary_bytes" =~ ^[0-9]+$ || \
+    ! "$available_kib" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' 'error: could not determine macOS VM storage capacity' >&2
+    exit 2
+  fi
+  available_bytes=$((available_kib * 1024))
+  required_bytes=$((disk_bytes + auxiliary_bytes + 32 * 1024 * 1024 * 1024))
+  if (( available_bytes < required_bytes )); then
+    shortfall_bytes=$((required_bytes - available_bytes))
+    printf '%s\n' \
+      "error: macOS VM storage requires at least $required_bytes bytes available for the template clone and 32 GiB headroom; found $available_bytes bytes (short by $shortfall_bytes bytes)" \
+      >&2
+    exit 2
+  fi
+}
+
 if [[ "$plan" != true ]]; then
   if [[ "$(uname -s)" != Darwin || "$(uname -m)" != arm64 ]]; then
     printf '%s\n' 'error: physical macOS checks require an Apple Silicon macOS host' >&2
@@ -106,6 +147,7 @@ if [[ "$plan" != true ]]; then
   install -d -m 0700 "$AUTOMATA_MACOS_PHYSICAL_ATTEMPT_ROOT"
   assert_directory_empty 'provider attempts' "$AUTOMATA_MACOS_VM_STORAGE_ROOT/attempts"
   assert_directory_empty 'runtime proxy attempts' "$AUTOMATA_MACOS_PHYSICAL_ATTEMPT_ROOT"
+  assert_clone_capacity
 fi
 
 for ((iteration = 1; iteration <= repetitions; iteration++)); do


### PR DESCRIPTION
## Summary

- read the sealed template artifact paths before starting the physical suite
- compare their logical lengths plus the provider's 32 GiB headroom with the VM filesystem's available capacity
- fail immediately with the exact required, available, and shortfall byte counts
- document the new physical-suite preflight

## Why

The provider validates this invariant, but only after verifying the 64 GiB template image. On the physical Apple Silicon host, an undersized APFS volume therefore spent several minutes hashing before returning a generic provider-open failure. The entrypoint can diagnose the same operator-actionable capacity problem before compilation or hashing while leaving the provider's fail-closed check intact.

## Validation

- `python3 scripts/ci/tests/macos-physical-checks.test.py`
- `shellcheck scripts/ci/run-macos-physical-checks.sh`
- `bash -n scripts/ci/run-macos-physical-checks.sh`
- physical Apple Silicon invocation against the current undersized volume: failed in 0.13s and reported required 103112794268 bytes, available 76970725376 bytes, shortfall 26142068892 bytes