### PR TITLE
Generalize workflow invocation results

### DIFF
--- a/crates/automata-ci-provider-postgres/src/result.rs
+++ b/crates/automata-ci-provider-postgres/src/result.rs
@@ -2,16 +2,16 @@ use automata_ci_core::{GitObjectAlgorithm, GitObjectId, JobId, RunId, Sha256Dige
 use automata_ci_provider::{
     ClaimProviderResult, ClaimedProviderResult, CompleteProviderResult, DesiredProviderResult,
     ExternalResultId, FailProviderResult, ProviderConnectionId, ProviderConnectionRevision,
-    ProviderDeliveryId, ProviderRepositoryPath, ProviderResultAnnotation,
-    ProviderResultAnnotationLevel, ProviderResultAnnotationMessage, ProviderResultAnnotationTitle,
-    ProviderResultBinding, ProviderResultClaimFence, ProviderResultConclusion,
-    ProviderResultContinuation, ProviderResultDetailsUrl, ProviderResultFailureKind,
-    ProviderResultModelError, ProviderResultName, ProviderResultPhase, ProviderResultProjection,
+    ProviderRepositoryPath, ProviderResultAnnotation, ProviderResultAnnotationLevel,
+    ProviderResultAnnotationMessage, ProviderResultAnnotationTitle, ProviderResultBinding,
+    ProviderResultClaimFence, ProviderResultConclusion, ProviderResultContinuation,
+    ProviderResultDetailsUrl, ProviderResultFailureKind, ProviderResultModelError,
+    ProviderResultName, ProviderResultPhase, ProviderResultProjection,
     ProviderResultPublicationModel, ProviderResultRepositoryError, ProviderResultSaveOutcome,
     ProviderResultSubject, ProviderResultSubjectId, ProviderResultSubjectKind,
     ProviderResultSummary, ProviderResultTitle, ProviderResultWorkerId, ProviderSchemaVersion,
-    ProviderWorkflowResultObservation, ProviderWorkflowRunState, RenewProviderResult,
-    RetryProviderResult, SaveDesiredProviderResult,
+    ProviderWorkflowInvocationId, ProviderWorkflowResultObservation, ProviderWorkflowRunState,
+    RenewProviderResult, RetryProviderResult, SaveDesiredProviderResult,
 };
 use sqlx::{FromRow, Postgres, Transaction};
 
@@ -28,7 +28,7 @@ struct ResultRow {
     result_name: String,
     result_details_url: String,
     subject_kind: String,
-    delivery_id: Option<uuid::Uuid>,
+    invocation_id: Option<uuid::Uuid>,
     workflow_path: Option<String>,
     run_id: Option<uuid::Uuid>,
     job_id: Option<uuid::Uuid>,
@@ -652,7 +652,7 @@ async fn insert_subject(
         INSERT INTO provider_result_subjects (
             subject_id, connection_id, connection_revision, connection_digest,
             object_algorithm, object_bytes, result_name, result_details_url,
-            subject_kind, delivery_id, workflow_path, run_id, job_id, attempt,
+            subject_kind, invocation_id, workflow_path, run_id, job_id, attempt,
             created_at_ms, subject_digest
         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
         ",
@@ -666,7 +666,7 @@ async fn insert_subject(
     .bind(subject.name().as_str())
     .bind(subject.details_url().as_url().as_str())
     .bind(kind.kind)
-    .bind(kind.delivery_id)
+    .bind(kind.invocation_id)
     .bind(kind.workflow_path)
     .bind(kind.run_id)
     .bind(kind.job_id)
@@ -681,7 +681,7 @@ async fn insert_subject(
 
 struct SubjectColumns<'a> {
     kind: &'static str,
-    delivery_id: Option<uuid::Uuid>,
+    invocation_id: Option<uuid::Uuid>,
     workflow_path: Option<&'a str>,
     run_id: Option<uuid::Uuid>,
     job_id: Option<uuid::Uuid>,
@@ -690,26 +690,26 @@ struct SubjectColumns<'a> {
 impl<'a> From<&'a ProviderResultSubjectKind> for SubjectColumns<'a> {
     fn from(value: &'a ProviderResultSubjectKind) -> Self {
         match value {
-            ProviderResultSubjectKind::PendingWorkflow {
-                delivery_id,
+            ProviderResultSubjectKind::WorkflowInvocation {
+                invocation_id,
                 workflow_path,
             } => Self {
-                kind: "pending-workflow",
-                delivery_id: Some(delivery_id.as_uuid()),
+                kind: "workflow-invocation",
+                invocation_id: Some(invocation_id.as_uuid()),
                 workflow_path: Some(workflow_path.as_str()),
                 run_id: None,
                 job_id: None,
             },
             ProviderResultSubjectKind::WorkflowRun { run_id } => Self {
                 kind: "workflow-run",
-                delivery_id: None,
+                invocation_id: None,
                 workflow_path: None,
                 run_id: Some(run_id.as_uuid()),
                 job_id: None,
             },
             ProviderResultSubjectKind::Job { run_id, job_id } => Self {
                 kind: "job",
-                delivery_id: None,
+                invocation_id: None,
                 workflow_path: None,
                 run_id: Some(run_id.as_uuid()),
                 job_id: Some(job_id.as_uuid()),
@@ -824,7 +824,7 @@ async fn load_result_row(
                subject.connection_revision, subject.connection_digest,
                subject.object_algorithm, subject.object_bytes, subject.result_name,
                subject.result_details_url, subject.subject_kind,
-               subject.delivery_id, subject.workflow_path,
+               subject.invocation_id, subject.workflow_path,
                subject.run_id, subject.job_id, subject.attempt,
                subject.created_at_ms, subject.subject_digest,
                outbox.generation, outbox.phase, outbox.conclusion,
@@ -871,9 +871,9 @@ fn subject_kind(
     row: &ResultRow,
 ) -> Result<ProviderResultSubjectKind, ProviderResultRepositoryError> {
     match row.subject_kind.as_str() {
-        "pending-workflow" => Ok(ProviderResultSubjectKind::PendingWorkflow {
-            delivery_id: ProviderDeliveryId::from_uuid(
-                row.delivery_id
+        "workflow-invocation" => Ok(ProviderResultSubjectKind::WorkflowInvocation {
+            invocation_id: ProviderWorkflowInvocationId::from_uuid(
+                row.invocation_id
                     .ok_or(ProviderResultRepositoryError::Corrupt)?,
             )
             .map_err(|_| ProviderResultRepositoryError::Corrupt)?,

--- a/crates/automata-ci-provider/src/identity.rs
+++ b/crates/automata-ci-provider/src/identity.rs
@@ -207,6 +207,11 @@ uuid_identity!(
     "provider result subject ID"
 );
 uuid_identity!(
+    /// Provider-neutral identity of one workflow invocation before admission.
+    ProviderWorkflowInvocationId,
+    "provider workflow invocation ID"
+);
+uuid_identity!(
     /// Durable identity of one provider result publication worker.
     ProviderResultWorkerId,
     "provider result worker ID"

--- a/crates/automata-ci-provider/src/lib.rs
+++ b/crates/automata-ci-provider/src/lib.rs
@@ -99,7 +99,7 @@ pub use identity::{
     MAX_PROVIDER_TYPE_ID_BYTES, ProviderConnectionId, ProviderControlCredentialId,
     ProviderDeliveryId, ProviderIdentityError, ProviderInstanceId, ProviderProcessingInvocationId,
     ProviderProcessingWorkerId, ProviderResultSubjectId, ProviderResultWorkerId, ProviderTypeId,
-    ProviderWebhookEndpointId, ProviderWorkloadCredentialId,
+    ProviderWebhookEndpointId, ProviderWorkflowInvocationId, ProviderWorkloadCredentialId,
 };
 pub use result::{
     ClaimProviderResult, ClaimedProviderResult, CompleteProviderResult, DesiredProviderResult,

--- a/crates/automata-ci-provider/src/result.rs
+++ b/crates/automata-ci-provider/src/result.rs
@@ -16,8 +16,9 @@ use uuid::Uuid;
 use crate::{
     ExternalRepositoryIdentity, ExternalResultId, ProviderCapabilities, ProviderCapability,
     ProviderCapabilityKind, ProviderConnectionId, ProviderConnectionManifest,
-    ProviderConnectionRevision, ProviderDeliveryId, ProviderLifecycleState, ProviderRepositoryPath,
-    ProviderResultSubjectId, ProviderResultWorkerId, ProviderSchemaVersion, StatusHistoryModel,
+    ProviderConnectionRevision, ProviderLifecycleState, ProviderRepositoryPath,
+    ProviderResultSubjectId, ProviderResultWorkerId, ProviderSchemaVersion,
+    ProviderWorkflowInvocationId, StatusHistoryModel,
 };
 
 /// Maximum desired-result title bytes.
@@ -55,9 +56,9 @@ const RESULT_SUBJECT_ID_DOMAIN: &[u8] = b"automata.provider.result-subject-id.v1
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProviderResultSubjectKind {
     /// A workflow selected from an authenticated delivery before admission.
-    PendingWorkflow {
-        /// Authenticated delivery that selected the workflow.
-        delivery_id: ProviderDeliveryId,
+    WorkflowInvocation {
+        /// Opaque provider-neutral invocation identity.
+        invocation_id: ProviderWorkflowInvocationId,
         /// Canonical repository-relative workflow path.
         workflow_path: ProviderRepositoryPath,
     },
@@ -78,12 +79,12 @@ pub enum ProviderResultSubjectKind {
 impl ProviderResultSubjectKind {
     fn hash_into(&self, hash: &mut Sha256) {
         match self {
-            Self::PendingWorkflow {
-                delivery_id,
+            Self::WorkflowInvocation {
+                invocation_id,
                 workflow_path,
             } => {
                 hash.update([1]);
-                hash.update(delivery_id.as_uuid().as_bytes());
+                hash.update(invocation_id.as_uuid().as_bytes());
                 part(hash, workflow_path.as_str().as_bytes());
             }
             Self::WorkflowRun { run_id } => {

--- a/crates/automata-ci-store-postgres/migrations/0064_provider_result_outbox.sql
+++ b/crates/automata-ci-store-postgres/migrations/0064_provider_result_outbox.sql
@@ -359,7 +359,7 @@ CREATE TABLE provider_result_subjects (
     object_algorithm TEXT NOT NULL,
     object_bytes BYTEA NOT NULL,
     subject_kind TEXT NOT NULL,
-    delivery_id UUID,
+    invocation_id UUID,
     workflow_path TEXT,
     run_id UUID,
     job_id UUID,
@@ -376,14 +376,14 @@ CREATE TABLE provider_result_subjects (
         OR (object_algorithm = 'sha256' AND octet_length(object_bytes) = 32)
     ),
     CHECK (
-        (subject_kind = 'pending-workflow'
-            AND delivery_id IS NOT NULL AND workflow_path IS NOT NULL
+        (subject_kind = 'workflow-invocation'
+            AND invocation_id IS NOT NULL AND workflow_path IS NOT NULL
             AND run_id IS NULL AND job_id IS NULL)
         OR (subject_kind = 'workflow-run'
-            AND delivery_id IS NULL AND workflow_path IS NULL
+            AND invocation_id IS NULL AND workflow_path IS NULL
             AND run_id IS NOT NULL AND job_id IS NULL)
         OR (subject_kind = 'job'
-            AND delivery_id IS NULL AND workflow_path IS NULL
+            AND invocation_id IS NULL AND workflow_path IS NULL
             AND run_id IS NOT NULL AND job_id IS NOT NULL)
     ),
     CHECK (

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -259,7 +259,7 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0064_provider_result_outbox.sql",
-        "1f8ae184bc2926c8a447afa7ad1ea9d466d0e064a89a69aa1c52dbd9ceabcf6af3ac7849bfa8871e911d6daae54d327f",
+        "7af01449d74f3b67004da67a15de7b627ee3b8016bcb3eb39fabb2e8319ac3d30792255a4286796241e0cff544a9d488",
     ),
     (
         "0065_provider_result_recovery_state.sql",

--- a/crates/automata-ci-workflow-service/src/lib.rs
+++ b/crates/automata-ci-workflow-service/src/lib.rs
@@ -89,8 +89,10 @@ pub use observer::{
     WorkflowAdmissionObserver, WorkflowAdmissionStage, WorkflowAdmissionStageOutcome,
 };
 pub use port::{AdmissionClock, AdmissionIdGenerator, WorkflowPlanVerifier};
-pub(crate) use provider_result::ProviderWorkflowResultRequest;
-pub use provider_result::{ProviderWorkflowResultService, ProviderWorkflowResultServiceError};
+pub use provider_result::{
+    ProviderWorkflowResultDisposition, ProviderWorkflowResultRequest,
+    ProviderWorkflowResultService, ProviderWorkflowResultServiceError,
+};
 pub use provider_result_projection::{
     ProviderWorkflowResultProjectionError, ProviderWorkflowResultProjectionOutcome,
     ProviderWorkflowResultProjectionService,

--- a/crates/automata-ci-workflow-service/src/provider_result.rs
+++ b/crates/automata-ci-workflow-service/src/provider_result.rs
@@ -9,24 +9,73 @@ use automata_ci_provider::{
     ProviderResultProjection, ProviderResultRepository, ProviderResultRepositoryError,
     ProviderResultSaveOutcome, ProviderResultSubject, ProviderResultSubjectId,
     ProviderResultSubjectKind, ProviderResultSummary, ProviderResultTitle,
-    ProviderWorkflowRunState, SaveDesiredProviderResult, VerifiedProviderTriggerDelivery,
+    ProviderWorkflowInvocationId, ProviderWorkflowRunState, SaveDesiredProviderResult,
 };
 use automata_ci_store::WorkflowRerunReceipt;
 use thiserror::Error;
 use url::Url;
 
-use crate::ProviderWorkflowDisposition;
+use crate::WorkflowAdmissionResult;
 
 const RESULT_NAME_PREFIX: &str = "Automata CI / ";
 
-pub(crate) struct ProviderWorkflowResultRequest<'a> {
-    pub(crate) connection: &'a ProviderConnectionManifest,
-    pub(crate) delivery: &'a VerifiedProviderTriggerDelivery,
-    pub(crate) object: GitObjectId,
-    pub(crate) workflow_path: &'a str,
-    pub(crate) attempt: u32,
-    pub(crate) created_at: UnixMillis,
-    pub(crate) disposition: ProviderWorkflowDisposition,
+/// Exact provider-neutral inputs for an invocation's initial desired result.
+#[derive(Debug)]
+pub struct ProviderWorkflowResultRequest<'a> {
+    connection: &'a ProviderConnectionManifest,
+    invocation_id: ProviderWorkflowInvocationId,
+    repository_path: ProviderRepositoryPath,
+    object: GitObjectId,
+    workflow_path: ProviderRepositoryPath,
+    attempt: u32,
+    created_at: UnixMillis,
+    disposition: ProviderWorkflowResultDisposition,
+}
+
+impl<'a> ProviderWorkflowResultRequest<'a> {
+    /// Creates one provider-neutral initial workflow-result projection.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid repository coordinates, workflow paths, attempts, or timestamps.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        connection: &'a ProviderConnectionManifest,
+        invocation_id: ProviderWorkflowInvocationId,
+        repository_path: impl Into<String>,
+        object: GitObjectId,
+        workflow_path: impl Into<String>,
+        attempt: u32,
+        created_at: UnixMillis,
+        disposition: ProviderWorkflowResultDisposition,
+    ) -> Result<Self, ProviderWorkflowResultServiceError> {
+        if attempt == 0 || created_at.get() < 0 {
+            return Err(ProviderWorkflowResultServiceError::InvalidEvidence);
+        }
+        Ok(Self {
+            connection,
+            invocation_id,
+            repository_path: ProviderRepositoryPath::new(repository_path)
+                .map_err(|_| ProviderWorkflowResultServiceError::InvalidEvidence)?,
+            object,
+            workflow_path: ProviderRepositoryPath::new(workflow_path)
+                .map_err(|_| ProviderWorkflowResultServiceError::InvalidEvidence)?,
+            attempt,
+            created_at,
+            disposition,
+        })
+    }
+}
+
+/// Closed provider-facing outcome of one workflow invocation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProviderWorkflowResultDisposition {
+    /// A logical workflow run exists, including an exact idempotent replay.
+    Admitted(WorkflowAdmissionResult),
+    /// The valid workflow did not select the invocation.
+    Skipped,
+    /// The invocation reached a deterministic terminal rejection.
+    Failed,
 }
 
 /// Provider-neutral producer for initial workflow result state.
@@ -62,40 +111,42 @@ impl ProviderWorkflowResultService {
         })
     }
 
-    pub(crate) async fn project(
+    /// Creates or exactly replays the initial desired result for one invocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a closed error when immutable invocation evidence is invalid or
+    /// contradicts the durable result subject.
+    pub async fn project_invocation(
         &self,
         request: ProviderWorkflowResultRequest<'_>,
     ) -> Result<ProviderResultSaveOutcome, ProviderWorkflowResultServiceError> {
         let ProviderWorkflowResultRequest {
             connection,
-            delivery,
+            invocation_id,
+            repository_path,
             object,
             workflow_path,
             attempt,
             created_at,
             disposition,
         } = request;
-        let path = ProviderRepositoryPath::new(workflow_path)
-            .map_err(|_| ProviderWorkflowResultServiceError::InvalidEvidence)?;
         let kind = match disposition {
-            ProviderWorkflowDisposition::Admitted(admission) => {
+            ProviderWorkflowResultDisposition::Admitted(admission) => {
                 ProviderResultSubjectKind::WorkflowRun {
                     run_id: admission.receipt().run_id(),
                 }
             }
-            ProviderWorkflowDisposition::NotSelected(_)
-            | ProviderWorkflowDisposition::Rejected(_) => {
-                ProviderResultSubjectKind::PendingWorkflow {
-                    delivery_id: delivery.evidence().delivery_id(),
-                    workflow_path: path,
+            ProviderWorkflowResultDisposition::Skipped
+            | ProviderWorkflowResultDisposition::Failed => {
+                ProviderResultSubjectKind::WorkflowInvocation {
+                    invocation_id,
+                    workflow_path: workflow_path.clone(),
                 }
             }
         };
-        let name = bounded_name(workflow_path);
-        let details_url = self.details_url(
-            delivery.trigger().trigger().target_repository().path(),
-            &kind,
-        )?;
+        let name = bounded_name(workflow_path.as_str());
+        let details_url = self.details_url(&repository_path, &kind)?;
         let subject = ProviderResultSubject::new(
             ProviderResultSubjectId::derive(connection.connection_id(), &kind),
             connection,
@@ -108,15 +159,15 @@ impl ProviderWorkflowResultService {
         )
         .map_err(model_error)?;
         let (phase, conclusion, summary) = match disposition {
-            ProviderWorkflowDisposition::Admitted(_) => {
+            ProviderWorkflowResultDisposition::Admitted(_) => {
                 (ProviderResultPhase::Queued, None, "Workflow run queued.")
             }
-            ProviderWorkflowDisposition::NotSelected(_) => (
+            ProviderWorkflowResultDisposition::Skipped => (
                 ProviderResultPhase::Completed,
                 Some(ProviderResultConclusion::Skipped),
                 "Workflow was not selected for this event.",
             ),
-            ProviderWorkflowDisposition::Rejected(_) => (
+            ProviderWorkflowResultDisposition::Failed => (
                 ProviderResultPhase::Completed,
                 Some(ProviderResultConclusion::Failure),
                 "Workflow could not be admitted.",
@@ -606,8 +657,8 @@ mod tests {
         let pending = service
             .details_url(
                 &repository,
-                &ProviderResultSubjectKind::PendingWorkflow {
-                    delivery_id: automata_ci_provider::ProviderDeliveryId::new(),
+                &ProviderResultSubjectKind::WorkflowInvocation {
+                    invocation_id: automata_ci_provider::ProviderWorkflowInvocationId::new(),
                     workflow_path: ProviderRepositoryPath::new(".ci/workflows/build.yml").unwrap(),
                 },
             )

--- a/crates/automata-ci-workflow-service/src/provider_trigger.rs
+++ b/crates/automata-ci-workflow-service/src/provider_trigger.rs
@@ -6,7 +6,7 @@ use automata_ci_core::{JobRuntimeContext, TrustSnapshot, WorkflowEventProvenance
 use automata_ci_provider::{
     ClaimedProviderProcessing, NormalizedTrigger, ProviderConnectionManifest, ProviderGitRef,
     ProviderLifecycleState, ProviderProcessingClaimSource, ProviderProcessingInput,
-    ProviderWorkflowSource, VerifiedProviderTriggerDelivery,
+    ProviderWorkflowInvocationId, ProviderWorkflowSource, VerifiedProviderTriggerDelivery,
 };
 use automata_ci_scm::{ArchiveFormat, RepositorySourceArchive};
 use automata_ci_store::{
@@ -22,7 +22,8 @@ use bytes::Bytes;
 use thiserror::Error;
 
 use crate::{
-    AdmissionRepositoryCoordinates, ProviderWorkflowResultRequest, ProviderWorkflowResultService,
+    AdmissionRepositoryCoordinates, ProviderWorkflowResultDisposition,
+    ProviderWorkflowResultRequest, ProviderWorkflowResultService,
     ProviderWorkflowResultServiceError, RepositoryWorkflowSource, WorkflowAdmissionError,
     WorkflowAdmissionRequest, WorkflowAdmissionRequestError, WorkflowAdmissionResult,
     WorkflowAdmissionService,
@@ -243,16 +244,16 @@ impl ProviderWorkflowApplicationService {
                     ProviderWorkflowRejection::UnsupportedCompilationDisposition,
                 ),
             };
+            let result_request = initial_result_request(
+                &request,
+                object,
+                workflow.path.clone(),
+                attempt,
+                created_at,
+                outcome,
+            )?;
             self.results
-                .project(ProviderWorkflowResultRequest {
-                    connection: &request.connection,
-                    delivery: &request.delivery,
-                    object,
-                    workflow_path: &workflow.path,
-                    attempt,
-                    created_at,
-                    disposition: outcome,
-                })
+                .project_invocation(result_request)
                 .await
                 .map_err(provider_result_error)?;
             results.push(ProviderWorkflowApplicationReport {
@@ -262,6 +263,43 @@ impl ProviderWorkflowApplicationService {
         }
         Ok(ProviderWorkflowApplicationOutcome::Applied(results))
     }
+}
+
+fn initial_result_request(
+    request: &ProviderWorkflowApplicationRequest,
+    object: automata_ci_core::GitObjectId,
+    workflow_path: String,
+    attempt: u32,
+    created_at: automata_ci_core::UnixMillis,
+    disposition: ProviderWorkflowDisposition,
+) -> Result<ProviderWorkflowResultRequest<'_>, ProviderWorkflowApplicationError> {
+    let disposition = match disposition {
+        ProviderWorkflowDisposition::Admitted(admission) => {
+            ProviderWorkflowResultDisposition::Admitted(admission)
+        }
+        ProviderWorkflowDisposition::NotSelected(_) => ProviderWorkflowResultDisposition::Skipped,
+        ProviderWorkflowDisposition::Rejected(_) => ProviderWorkflowResultDisposition::Failed,
+    };
+    ProviderWorkflowResultRequest::new(
+        &request.connection,
+        ProviderWorkflowInvocationId::from_uuid(
+            request.delivery.evidence().delivery_id().as_uuid(),
+        )
+        .map_err(|_| ProviderWorkflowApplicationError::InvalidEvidence)?,
+        request
+            .delivery
+            .trigger()
+            .trigger()
+            .target_repository()
+            .path()
+            .as_str(),
+        object,
+        workflow_path,
+        attempt,
+        created_at,
+        disposition,
+    )
+    .map_err(provider_result_error)
 }
 
 impl fmt::Debug for ProviderWorkflowApplicationService {


### PR DESCRIPTION
## Summary
- replace GitHub-specific workflow result identities with provider-neutral invocation identities
- carry provider workflow invocation IDs through trigger and workflow-service boundaries
- update the common result outbox schema and PostgreSQL adapter without compatibility columns

## Validation
- cargo check --workspace --all-targets
- cargo test -p automata-ci-provider
- migration layout and fingerprint tests (validated in the stacked branch)

Stacked foundation PR; 255 changed lines.