### PR TITLE
Fix production PostgreSQL migration upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
 
 ### Changed
 
+- PostgreSQL upgrades now preserve the checksums of deployed migrations 0053
+  and 0056, move the provider-instance webhook cutover into forward migration
+  0069, and safely convert historical Check evidence in migration 0061.
 - GitHub Actions cache eviction now durably reclaims unreachable S3 blocks with
   crash-safe, replica-safe exact-object garbage collection.
 

--- a/crates/automata-ci-store-postgres/migrations/0053_provider_delivery_foundation.sql
+++ b/crates/automata-ci-store-postgres/migrations/0053_provider_delivery_foundation.sql
@@ -23,6 +23,8 @@ CREATE TABLE provider_webhook_endpoint_revisions (
     provider_type TEXT NOT NULL,
     provider_instance_id UUID NOT NULL,
     provider_revision BIGINT NOT NULL,
+    connection_id UUID NOT NULL,
+    connection_revision BIGINT NOT NULL,
     body_limit BIGINT NOT NULL,
     raw_retention_millis BIGINT NOT NULL,
     candidate_count SMALLINT NOT NULL,
@@ -31,12 +33,18 @@ CREATE TABLE provider_webhook_endpoint_revisions (
     PRIMARY KEY (endpoint_id, revision),
     UNIQUE (
         endpoint_id, revision, provider_type, provider_instance_id,
-        provider_revision
+        provider_revision, connection_id, connection_revision
     ),
     FOREIGN KEY (provider_instance_id, provider_revision, provider_type)
         REFERENCES provider_instance_revisions (
             instance_id, revision, provider_type
         ) ON DELETE RESTRICT,
+    FOREIGN KEY (
+        connection_id, connection_revision,
+        provider_instance_id, provider_revision
+    ) REFERENCES provider_connection_revisions (
+        connection_id, revision, provider_instance_id, provider_revision
+    ) ON DELETE RESTRICT,
     CHECK (revision > 0),
     CHECK (lifecycle_state IN ('active', 'disabled', 'retired')),
     CHECK (octet_length(provider_type) BETWEEN 1 AND 64),
@@ -125,16 +133,12 @@ CREATE TABLE provider_delivery_records (
     UNIQUE (provider_instance_id, external_delivery_id),
     FOREIGN KEY (
         endpoint_id, endpoint_revision, provider_type,
-        provider_instance_id, provider_revision
+        provider_instance_id, provider_revision,
+        connection_id, connection_revision
     ) REFERENCES provider_webhook_endpoint_revisions (
         endpoint_id, revision, provider_type,
-        provider_instance_id, provider_revision
-    ) ON DELETE RESTRICT,
-    FOREIGN KEY (
-        connection_id, connection_revision,
-        provider_instance_id, provider_revision
-    ) REFERENCES provider_connection_revisions (
-        connection_id, revision, provider_instance_id, provider_revision
+        provider_instance_id, provider_revision,
+        connection_id, connection_revision
     ) ON DELETE RESTRICT,
     FOREIGN KEY (
         provider_instance_id, signature_configuration_revision,

--- a/crates/automata-ci-store-postgres/migrations/0056_provider_processing_invocations.sql
+++ b/crates/automata-ci-store-postgres/migrations/0056_provider_processing_invocations.sql
@@ -43,16 +43,12 @@ CREATE TABLE provider_deliveries (
     UNIQUE (delivery_id, disposition),
     FOREIGN KEY (
         endpoint_id, endpoint_revision, provider_type,
-        provider_instance_id, provider_revision
+        provider_instance_id, provider_revision,
+        connection_id, connection_revision
     ) REFERENCES provider_webhook_endpoint_revisions (
         endpoint_id, revision, provider_type,
-        provider_instance_id, provider_revision
-    ) ON DELETE RESTRICT,
-    FOREIGN KEY (
-        connection_id, connection_revision,
-        provider_instance_id, provider_revision
-    ) REFERENCES provider_connection_revisions (
-        connection_id, revision, provider_instance_id, provider_revision
+        provider_instance_id, provider_revision,
+        connection_id, connection_revision
     ) ON DELETE RESTRICT,
     FOREIGN KEY (
         provider_instance_id, signature_configuration_revision,

--- a/crates/automata-ci-store-postgres/migrations/0061_job_check_topology.sql
+++ b/crates/automata-ci-store-postgres/migrations/0061_job_check_topology.sql
@@ -1,10 +1,17 @@
 -- Publish one revision gate plus concrete jobs, never workflow bookkeeping.
+-- The evidence rows are immutable outside this exact transactional cutover.
 
 ALTER TABLE github_provider_delivery_evidence
     DROP CONSTRAINT github_provider_delivery_evidence_aggregate_check_kind;
+DROP TRIGGER github_provider_delivery_evidence_no_update_delete
+    ON github_provider_delivery_evidence;
 UPDATE github_provider_delivery_evidence
 SET aggregate_check_kind = 'jobs_only'
 WHERE aggregate_check_kind = 'auxiliary';
+CREATE TRIGGER github_provider_delivery_evidence_no_update_delete
+    BEFORE DELETE OR UPDATE ON github_provider_delivery_evidence
+    FOR EACH ROW
+    EXECUTE FUNCTION automata_github_provider_delivery_evidence_immutable();
 ALTER TABLE github_provider_delivery_evidence
     ADD CONSTRAINT github_provider_delivery_evidence_aggregate_check_kind
     CHECK (aggregate_check_kind IN ('required', 'jobs_only'));

--- a/crates/automata-ci-store-postgres/migrations/0069_provider_instance_webhook_endpoints.sql
+++ b/crates/automata-ci-store-postgres/migrations/0069_provider_instance_webhook_endpoints.sql
@@ -1,0 +1,33 @@
+-- Advance provider webhook endpoints from repository-connection ownership to
+-- provider-instance ownership without rewriting the deployed 0053/0056
+-- lineage. Deliveries retain an exact direct connection-revision binding.
+
+ALTER TABLE provider_deliveries
+    DROP CONSTRAINT provider_deliveries_endpoint_id_endpoint_revision_provider_fkey;
+
+ALTER TABLE provider_webhook_endpoint_revisions
+    DROP CONSTRAINT provider_webhook_endpoint_rev_connection_id_connection_rev_fkey,
+    DROP CONSTRAINT provider_webhook_endpoint_rev_endpoint_id_revision_provider_key,
+    ADD UNIQUE (
+        endpoint_id, revision, provider_type, provider_instance_id,
+        provider_revision
+    );
+
+ALTER TABLE provider_deliveries
+    ADD FOREIGN KEY (
+        endpoint_id, endpoint_revision, provider_type,
+        provider_instance_id, provider_revision
+    ) REFERENCES provider_webhook_endpoint_revisions (
+        endpoint_id, revision, provider_type,
+        provider_instance_id, provider_revision
+    ) ON DELETE RESTRICT,
+    ADD FOREIGN KEY (
+        connection_id, connection_revision,
+        provider_instance_id, provider_revision
+    ) REFERENCES provider_connection_revisions (
+        connection_id, revision, provider_instance_id, provider_revision
+    ) ON DELETE RESTRICT;
+
+ALTER TABLE provider_webhook_endpoint_revisions
+    DROP COLUMN connection_id,
+    DROP COLUMN connection_revision;

--- a/crates/automata-ci-store-postgres/src/lib.rs
+++ b/crates/automata-ci-store-postgres/src/lib.rs
@@ -30,6 +30,8 @@ use automata_ci_store::{
 
 mod migration;
 #[cfg(test)]
+mod migration_0061_tests;
+#[cfg(test)]
 mod migration_layout_tests;
 #[cfg(test)]
 mod schema_bindings_tests;

--- a/crates/automata-ci-store-postgres/src/migration_0061_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_0061_tests.rs
@@ -1,0 +1,262 @@
+use std::{env, future::Future, str::FromStr, sync::Arc};
+
+use sqlx::{
+    AssertSqlSafe, Connection as _, PgConnection, PgPool,
+    postgres::{PgConnectOptions, PgPoolOptions},
+};
+use uuid::Uuid;
+
+use crate::migration::MIGRATOR;
+
+const DATABASE_URL_ENVIRONMENT: &str = "AUTOMATA_TEST_DATABASE_URL";
+const TEST_SCHEMA: &str = "automata_test";
+const MINIMUM_POSTGRES_VERSION: i32 = 180_000;
+
+type TestError = Box<dyn std::error::Error + Send + Sync + 'static>;
+type TestResult<T = ()> = Result<T, TestError>;
+
+#[derive(Debug)]
+struct TestDatabase {
+    pool: PgPool,
+}
+
+async fn run_with_unmigrated_database<Test, TestFuture>(test: Test) -> TestResult
+where
+    Test: FnOnce(Arc<TestDatabase>) -> TestFuture + Send + 'static,
+    TestFuture: Future<Output = TestResult> + Send + 'static,
+{
+    let database_url = env::var(DATABASE_URL_ENVIRONMENT).map_err(|error| {
+        message_error(format!(
+            "set {DATABASE_URL_ENVIRONMENT} to an isolated PostgreSQL 18 test server URL: {error}"
+        ))
+    })?;
+    let admin_options = PgConnectOptions::from_str(&database_url)?;
+    let database_name = format!("automata_m61_{}", Uuid::new_v4().simple());
+
+    let mut admin = PgConnection::connect_with(&admin_options).await?;
+    require_postgres_18(&mut admin).await?;
+    sqlx::query(AssertSqlSafe(format!(
+        "CREATE DATABASE \"{database_name}\" TEMPLATE template0"
+    )))
+    .execute(&mut admin)
+    .await?;
+    admin.close().await?;
+
+    let database_options = admin_options.clone().database(&database_name);
+    let pool = match PgPoolOptions::new()
+        .max_connections(4)
+        .after_connect(|connection, _metadata| {
+            Box::pin(async move {
+                sqlx::query("SELECT pg_catalog.set_config('search_path', $1, false)")
+                    .bind(format!("{TEST_SCHEMA}, pg_catalog"))
+                    .execute(connection)
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect_with(database_options)
+        .await
+    {
+        Ok(pool) => pool,
+        Err(error) => {
+            cleanup_database(&admin_options, &database_name).await?;
+            return Err(error.into());
+        }
+    };
+    if let Err(error) = sqlx::query("CREATE SCHEMA automata_test")
+        .execute(&pool)
+        .await
+    {
+        pool.close().await;
+        cleanup_database(&admin_options, &database_name).await?;
+        return Err(error.into());
+    }
+
+    let database = Arc::new(TestDatabase { pool });
+    let task = tokio::spawn(test(Arc::clone(&database))).await;
+    database.pool.close().await;
+    let cleanup = cleanup_database(&admin_options, &database_name).await;
+
+    match task {
+        Ok(Ok(())) => cleanup,
+        Ok(Err(test_error)) => {
+            cleanup?;
+            Err(test_error)
+        }
+        Err(join_error) => {
+            let _ = cleanup;
+            if join_error.is_panic() {
+                std::panic::resume_unwind(join_error.into_panic());
+            }
+            Err(join_error.into())
+        }
+    }
+}
+
+async fn require_postgres_18(connection: &mut PgConnection) -> TestResult {
+    let version: i32 =
+        sqlx::query_scalar("SELECT pg_catalog.current_setting('server_version_num')::INTEGER")
+            .fetch_one(&mut *connection)
+            .await?;
+    if version < MINIMUM_POSTGRES_VERSION {
+        return Err(message_error(format!(
+            "migration 0061 live tests require PostgreSQL 18 or newer; server_version_num is {version}"
+        )));
+    }
+    let is_superuser: bool =
+        sqlx::query_scalar("SELECT rolsuper FROM pg_catalog.pg_roles WHERE rolname = CURRENT_USER")
+            .fetch_one(&mut *connection)
+            .await?;
+    if !is_superuser {
+        return Err(message_error(
+            "migration 0061 live tests require a superuser on the isolated PostgreSQL server",
+        ));
+    }
+    Ok(())
+}
+
+async fn cleanup_database(options: &PgConnectOptions, database_name: &str) -> TestResult {
+    let mut admin = PgConnection::connect_with(options).await?;
+    sqlx::query(AssertSqlSafe(format!(
+        "DROP DATABASE \"{database_name}\" WITH (FORCE)"
+    )))
+    .execute(&mut admin)
+    .await?;
+    admin.close().await?;
+    Ok(())
+}
+
+fn message_error(message: impl Into<String>) -> TestError {
+    std::io::Error::other(message.into()).into()
+}
+
+async fn seed_immutable_auxiliary_evidence(pool: &PgPool) -> TestResult {
+    let mut transaction = pool.begin().await?;
+    sqlx::query("SET LOCAL session_replication_role = 'replica'")
+        .execute(&mut *transaction)
+        .await?;
+    sqlx::query(
+        r"
+        INSERT INTO github_provider_delivery_evidence (
+            provider_delivery_id,tenant_id,repository_id,
+            provider_connection_id,provider_installation_id,
+            github_repository_id,github_repository_owner_id,
+            github_repository_name,repository_visibility,
+            provider_manifest_revision,provider_manifest_digest,
+            authenticated_webhook_verifier_fingerprint_sha256,
+            authenticated_webhook_verifier_revision,
+            checks_authority_id,checks_authority_identity_digest,
+            checks_authority_app_configuration_revision,
+            checks_authority_policy_revision,
+            repository_contents_authority_id,
+            repository_contents_authority_identity_digest,
+            repository_contents_authority_app_configuration_revision,
+            repository_contents_authority_policy_revision,
+            github_check_subject_id,github_check_head_sha,
+            authenticated_event_envelope_version,
+            authenticated_event_name,authenticated_event_git_ref,
+            aggregate_check_kind
+        ) VALUES (
+            $1,'migration-upgrade',$2,$3,1,2,3,'automata-ci/automata',
+            'private',1,$4,$5,1,$6,$7,1,1,$8,$9,1,1,$10,$11,
+            1,'push','refs/heads/main','auxiliary'
+        )
+        ",
+    )
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(vec![0x11_u8; 32])
+    .bind(vec![0x12_u8; 32])
+    .bind(Uuid::new_v4())
+    .bind(vec![0x13_u8; 32])
+    .bind(Uuid::new_v4())
+    .bind(vec![0x14_u8; 32])
+    .bind(Uuid::new_v4())
+    .bind(vec![0x15_u8; 20])
+    .execute(&mut *transaction)
+    .await?;
+    transaction.commit().await?;
+    Ok(())
+}
+
+async fn assert_migrated_contract(pool: &PgPool) -> TestResult {
+    let aggregate_check_kind: String =
+        sqlx::query_scalar("SELECT aggregate_check_kind FROM github_provider_delivery_evidence")
+            .fetch_one(pool)
+            .await?;
+    assert_eq!(aggregate_check_kind, "jobs_only");
+
+    let endpoint_connection_columns: i64 = sqlx::query_scalar(
+        r"
+        SELECT count(*)
+        FROM information_schema.columns
+        WHERE table_schema = 'automata_test'
+          AND table_name = 'provider_webhook_endpoint_revisions'
+          AND column_name IN ('connection_id', 'connection_revision')
+        ",
+    )
+    .fetch_one(pool)
+    .await?;
+    assert_eq!(endpoint_connection_columns, 0);
+
+    let connection_foreign_key: bool = sqlx::query_scalar(
+        r"
+        SELECT EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_constraint
+            WHERE conrelid = 'provider_deliveries'::regclass
+              AND contype = 'f'
+              AND pg_catalog.pg_get_constraintdef(oid) =
+                  'FOREIGN KEY (connection_id, connection_revision, provider_instance_id, provider_revision) REFERENCES provider_connection_revisions(connection_id, revision, provider_instance_id, provider_revision) ON DELETE RESTRICT'
+        )
+        ",
+    )
+    .fetch_one(pool)
+    .await?;
+    assert!(connection_foreign_key);
+
+    let immutable =
+        sqlx::query("UPDATE github_provider_delivery_evidence SET aggregate_check_kind='required'")
+            .execute(pool)
+            .await
+            .expect_err("delivery evidence remains immutable after migration");
+    assert_eq!(
+        immutable
+            .as_database_error()
+            .and_then(sqlx::error::DatabaseError::constraint),
+        Some("github_provider_delivery_evidence_immutable")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 via AUTOMATA_TEST_DATABASE_URL"]
+async fn production_migrations_upgrade_deployed_schema_and_immutable_evidence() -> TestResult {
+    run_with_unmigrated_database(|database| async move {
+        let deployed = sqlx::migrate::Migrator::with_migrations(
+            MIGRATOR
+                .iter()
+                .filter(|migration| migration.version <= 60)
+                .cloned()
+                .collect(),
+        );
+        deployed.run(&database.pool).await?;
+        let deployed_version: i64 = sqlx::query_scalar("SELECT max(version) FROM _sqlx_migrations")
+            .fetch_one(&database.pool)
+            .await?;
+        assert_eq!(deployed_version, 60);
+
+        seed_immutable_auxiliary_evidence(&database.pool).await?;
+
+        MIGRATOR.run(&database.pool).await?;
+        let applied_version: i64 = sqlx::query_scalar("SELECT max(version) FROM _sqlx_migrations")
+            .fetch_one(&database.pool)
+            .await?;
+        assert_eq!(applied_version, 69);
+
+        assert_migrated_contract(&database.pool).await?;
+        Ok(())
+    })
+    .await
+}

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -215,7 +215,7 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0053_provider_delivery_foundation.sql",
-        "4fd137b340fda9709a9920703599e708568e44b1df69cd4ffb4b57435ec791603e2ac50798c0f1359d528c3921671843",
+        "52a3ab7e1e78fedee448882f0f400f3b4ae9ef0accf02b2f990543fdacb261a3f280774ba7787f4a9a1c4cd99c0d93f1",
     ),
     (
         "0054_provider_neutral_workload_oidc.sql",
@@ -227,7 +227,7 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0056_provider_processing_invocations.sql",
-        "0e75bfa116e5e182be1d3f4a86ca8baed1bbb3301a64a295757e6ee8f4c185021953b9482b7c55ab3a5f7395ba20f50a",
+        "47302f91ed241062d1d9366a326d48d804bd6bbf7daba589501f6c2b92dbf6ef23707fea7999f27398bc1ef7b54203f5",
     ),
     (
         "0057_merge_queue_check_aggregation.sql",
@@ -247,7 +247,7 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
     ),
     (
         "0061_job_check_topology.sql",
-        "befdac4d4754eb1b39e6954c95b012b67797fccb7baa248a53c0559162d295b38069f41e78f0e724ded395df965c5e58",
+        "60f02eab0525229de39a16af82419217916c39989b1837f80e6bf11082bf12ae2c1245e67966993deb9782ea67a802a6",
     ),
     (
         "0062_runner_protocol_v3.sql",
@@ -276,6 +276,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
     (
         "0068_provider_credential_envelope_revisions.sql",
         "6f8805e0a386ac29de076173d29d1cd62dc7f68c8b318edc014bd206200126d8748ec93a607b18b703216932c4d760db",
+    ),
+    (
+        "0069_provider_instance_webhook_endpoints.sql",
+        "b47bdc4fd116ceca54490f5ed7ab4ecb07122dd62ea50cf893749218b2066f654d58b6ff6c3da081ac6f2da860e4ac4a",
     ),
 ];
 
@@ -500,6 +504,8 @@ fn github_check_projection_is_one_gate_plus_jobs() {
     let source = include_str!("../migrations/0061_job_check_topology.sql");
 
     for required in [
+        "DROP TRIGGER github_provider_delivery_evidence_no_update_delete",
+        "CREATE TRIGGER github_provider_delivery_evidence_no_update_delete",
         "CHECK (aggregate_check_kind IN ('required', 'jobs_only'))",
         "CREATE OR REPLACE FUNCTION automata_create_github_check_projection_outbox()",
         "NEW.subject_kind = 'job'",
@@ -525,6 +531,24 @@ fn github_check_projection_is_one_gate_plus_jobs() {
         assert!(
             !source.contains(forbidden),
             "job-only Check topology retained a workflow projection: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn provider_webhook_endpoints_are_instance_owned_with_direct_delivery_connections() {
+    let source = include_str!("../migrations/0069_provider_instance_webhook_endpoints.sql");
+
+    for required in [
+        "DROP CONSTRAINT provider_deliveries_endpoint_id_endpoint_revision_provider_fkey",
+        "DROP CONSTRAINT provider_webhook_endpoint_rev_connection_id_connection_rev_fkey",
+        "REFERENCES provider_connection_revisions (",
+        "DROP COLUMN connection_id",
+        "DROP COLUMN connection_revision",
+    ] {
+        assert!(
+            source.contains(required),
+            "provider-instance endpoint migration lost contract: {required}"
         );
     }
 }

--- a/scripts/ci/run-postgres-tests.sh
+++ b/scripts/ci/run-postgres-tests.sh
@@ -116,6 +116,17 @@ run_bounded_tests cargo test \
   --ignored \
   --test-threads=4
 
+printf 'PostgreSQL tests: production migration upgrades\n' >&2
+run_bounded_tests cargo test \
+  -p automata-ci-store-postgres \
+  --lib \
+  --all-features \
+  --locked \
+  -- \
+  migration_0061_tests:: \
+  --ignored \
+  --test-threads=1
+
 printf 'PostgreSQL tests: database harness\n' >&2
 run_bounded_tests cargo test \
   -p automata-ci-postgres \

--- a/scripts/ci/tests/rust-coverage.test.py
+++ b/scripts/ci/tests/rust-coverage.test.py
@@ -1451,7 +1451,7 @@ exit 99
             capture_output=True,
         )
         commands = planned.stdout.splitlines()
-        assert len(commands) == 14, planned.stdout
+        assert len(commands) == 15, planned.stdout
         expected_inventory = [
             ("cargo test --workspace",),
             (
@@ -1461,6 +1461,10 @@ exit 99
                 "--test postgres",
                 "--test postgres_artifacts",
                 "--test postgres_cache",
+            ),
+            (
+                "-p automata-ci-store-postgres --lib",
+                "migration_0061_tests::",
             ),
             ("-p automata-ci-postgres --lib",),
             ("--test blob_s3",),
@@ -1482,8 +1486,10 @@ exit 99
         assert all("--ignored" in command for command in commands[1:])
         assert "--test-threads=4" in commands[1]
         assert "--test-threads=1" in commands[2]
-        assert "test_support::tests::" in commands[2]
+        assert "migration_0061_tests::" in commands[2]
         assert "--test-threads=1" in commands[3]
+        assert "test_support::tests::" in commands[3]
+        assert "--test-threads=1" in commands[4]
         assert "--tests" not in commands[1]
         assert sum(
             command.count("-p automata-ci-postgres-test-support")
@@ -1501,7 +1507,7 @@ exit 99
             "crates/automata-ci-store-postgres/src/",
         }.issubset(postgres_prefixes)
         assert "crates/automata-ci-postgres-test-support/src/" not in postgres_prefixes
-        assert all("-p automata-ci-store" not in command for command in commands)
+        assert all("-p automata-ci-store " not in command for command in commands)
         unknown_plan = subprocess.run(
             [str(RUN), "--plan", str(scratch / "unknown-plan"), "ordinary", "policy-only"],
             cwd=ROOT.parent,


### PR DESCRIPTION
## Summary

- restore migrations 0053 and 0056 byte-for-byte to the checksums already applied in production
- convert historical Check evidence safely inside unapplied migration 0061 by suspending and restoring its immutable update/delete trigger
- move the provider-instance webhook endpoint cutover into dedicated forward migration 0069, after main's credential-envelope migration 0068
- add a PostgreSQL 18 schema-60-to-current upgrade regression and run it in the required PostgreSQL/coverage lane

## Why

Production is currently at migration 0060. Latest `main` could not start because 0053 and 0056 had been rewritten after deployment, and the first unapplied migration attempted to update immutable delivery evidence without crossing its trigger boundary. This restores the deployed lineage and gives production one forward-only path to the current schema without editing the SQLx ledger or adding a compatibility mode.

## Validation

- `cargo test --locked -p automata-ci-store-postgres --lib --all-features`
- `cargo clippy --locked -p automata-ci-store-postgres --all-targets --all-features -- -D warnings`
- PostgreSQL 18 full application/storage, upgrade, and harness lane
- schema-60 → current regression with legacy immutable `auxiliary` evidence
- `python3 scripts/ci/tests/rust-coverage.test.py`
- migration checksum/inventory and `git diff --check`
