### PR TITLE
Fix provider projection bootstrap at advanced revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ structure of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
 
 ### Changed
 
+- Provider instance projections can bootstrap from an already-advanced
+  source-of-truth revision while retaining contiguous durable successors.
 - PostgreSQL upgrades now preserve the checksums of deployed migrations 0053
   and 0056, move the provider-instance webhook cutover into forward migration
   0069, and safely convert historical Check evidence in migration 0061.

--- a/crates/automata-ci-provider-delivery/src/reconciliation.rs
+++ b/crates/automata-ci-provider-delivery/src/reconciliation.rs
@@ -715,7 +715,7 @@ fn validate_provider_revision(
     current: Option<&ProviderInstanceRecord>,
     desired: ProviderConfigurationRevision,
 ) -> Result<(), ProviderReconciliationError> {
-    let valid = current.map_or(desired.get() == 1, |current| {
+    let valid = current.is_none_or(|current| {
         let current = current.manifest().revision().get();
         desired.get() == current || current.checked_add(1) == Some(desired.get())
     });
@@ -956,8 +956,6 @@ mod tests {
                     manifest
                         .validate_successor(&current.manifest)
                         .map_err(|_| ProviderRepositoryError::Conflict)?;
-                } else if manifest.revision().get() != 1 {
-                    return Err(ProviderRepositoryError::Conflict);
                 }
                 let stored = secrets
                     .into_secrets()
@@ -1251,7 +1249,7 @@ mod tests {
                 instance_id,
                 connection_id,
                 endpoint_id,
-                1,
+                2,
                 b"first-secret",
                 true,
             ))
@@ -1266,7 +1264,7 @@ mod tests {
                 instance_id,
                 connection_id,
                 endpoint_id,
-                1,
+                2,
                 b"first-secret",
                 true,
             ))
@@ -1281,7 +1279,7 @@ mod tests {
                 instance_id,
                 connection_id,
                 endpoint_id,
-                2,
+                3,
                 b"second-secret",
                 false,
             ))
@@ -1290,7 +1288,7 @@ mod tests {
         assert_eq!(removed.connections_disabled(), 1);
         let state = repository.state.lock().expect("repository state");
         let instance = state.instance.as_ref().expect("instance");
-        assert_eq!(instance.manifest.revision().get(), 2);
+        assert_eq!(instance.manifest.revision().get(), 3);
         assert_eq!(
             instance
                 .manifest
@@ -1307,7 +1305,7 @@ mod tests {
         assert_eq!(connection.state(), ProviderLifecycleState::Disabled);
         let endpoint = state.endpoint.as_ref().expect("endpoint");
         assert_eq!(endpoint.revision().get(), 2);
-        assert_eq!(endpoint.provider_revision().get(), 2);
+        assert_eq!(endpoint.provider_revision().get(), 3);
         assert_eq!(endpoint.state(), ProviderWebhookEndpointState::Disabled);
     }
 }

--- a/crates/automata-ci-provider-postgres/src/instance.rs
+++ b/crates/automata-ci-provider-postgres/src/instance.rs
@@ -175,8 +175,6 @@ impl PostgresProviderManifestRepository {
                 .validate_successor(&current_manifest)
                 .map_err(|_| ProviderRepositoryError::Conflict)?;
             Some(current_manifest.secrets().clone())
-        } else if manifest.revision().get() != 1 {
-            return Err(ProviderRepositoryError::Conflict);
         } else {
             None
         };

--- a/crates/automata-ci-provider-postgres/tests/postgres.rs
+++ b/crates/automata-ci-provider-postgres/tests/postgres.rs
@@ -495,6 +495,36 @@ async fn instance_and_connection_revisions_are_atomic_encrypted_and_exact() -> T
 
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 via AUTOMATA_TEST_DATABASE_URL"]
+async fn instance_projection_can_bootstrap_at_an_existing_source_revision() -> TestResult {
+    run_with_database(|database| async move {
+        let repository = repository(database.pool().clone());
+        let instance_id = ProviderInstanceId::from_uuid(Uuid::from_u128(0x7001))?;
+        assert_eq!(
+            repository
+                .save_instance(instance_record(
+                    instance_id,
+                    "github",
+                    7,
+                    TOKEN,
+                    1,
+                    ProviderLifecycleState::Disabled,
+                    None,
+                ))
+                .await?,
+            ProviderSaveOutcome::Inserted
+        );
+        let current = repository
+            .current_instance(instance_id)
+            .await?
+            .expect("current projected instance");
+        assert_eq!(current.manifest().revision().get(), 7);
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL 18 via AUTOMATA_TEST_DATABASE_URL"]
 async fn disabled_endpoint_does_not_require_an_active_connection() -> TestResult {
     run_with_database(|database| async move {
         let repository = repository(database.pool().clone());

--- a/crates/automata-ci-provider/src/storage.rs
+++ b/crates/automata-ci-provider/src/storage.rs
@@ -76,7 +76,8 @@ pub enum ProviderSaveOutcome {
 
 /// Durable repository for provider instance and connection manifests.
 pub trait ProviderManifestRepository: fmt::Debug + Send + Sync {
-    /// Atomically stores one first or contiguous instance revision.
+    /// Atomically stores one source-revisioned first instance or a contiguous
+    /// successor.
     ///
     /// A secret name newly present in the adjacent revision must use one more
     /// than its largest historical generation, or generation one if unseen.


### PR DESCRIPTION
## Summary

- allow an empty provider-instance projection to start at the positive revision already held by its source of truth
- keep current-or-next validation for every durable successor
- cover the behavior in reconciliation and PostgreSQL repository tests

## Production impact

Production legacy GitHub desired state is at revision 2 after the runner-policy update, while the new provider-neutral registry is empty. Current reconciliation requires an empty registry to start at revision 1, so the current-main control process restart-loops with `provider desired-state revision conflicts with durable state`. This preserves the established source revision during first projection and unblocks the rollout.

## Validation

- `cargo test -p automata-ci-provider-delivery --lib reconciliation::tests --locked`
- `cargo test -p automata-ci-provider-postgres --test postgres --locked --no-run`
- `cargo clippy -p automata-ci-provider-delivery -p automata-ci-provider-postgres --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`