### PR TITLE
Allow provider registry bootstrap from durable revision

### DIFF
--- a/crates/automata-ci-provider-delivery/src/reconciliation.rs
+++ b/crates/automata-ci-provider-delivery/src/reconciliation.rs
@@ -715,7 +715,13 @@ fn validate_provider_revision(
     current: Option<&ProviderInstanceRecord>,
     desired: ProviderConfigurationRevision,
 ) -> Result<(), ProviderReconciliationError> {
-    let valid = current.map_or(desired.get() == 1, |current| {
+    // The provider-neutral registry may be empty when it is first introduced
+    // alongside an already-established provider configuration.  In that
+    // bootstrap case the durable provider configuration revision is the
+    // authoritative starting point and need not be replayed from revision 1.
+    // Once a neutral manifest exists, every subsequent observation remains
+    // strictly idempotent or contiguous.
+    let valid = current.is_none_or(|current| {
         let current = current.manifest().revision().get();
         desired.get() == current || current.checked_add(1) == Some(desired.get())
     });
@@ -956,8 +962,6 @@ mod tests {
                     manifest
                         .validate_successor(&current.manifest)
                         .map_err(|_| ProviderRepositoryError::Conflict)?;
-                } else if manifest.revision().get() != 1 {
-                    return Err(ProviderRepositoryError::Conflict);
                 }
                 let stored = secrets
                     .into_secrets()
@@ -1309,5 +1313,32 @@ mod tests {
         assert_eq!(endpoint.revision().get(), 2);
         assert_eq!(endpoint.provider_revision().get(), 2);
         assert_eq!(endpoint.state(), ProviderWebhookEndpointState::Disabled);
+    }
+
+    #[tokio::test]
+    async fn first_observation_bootstraps_an_existing_provider_revision() {
+        let repository = Arc::new(MemoryRepository::default());
+        let factory = Arc::new(TestFactory {
+            provider_type: ProviderTypeId::new("forgejo").expect("provider type"),
+        }) as Arc<dyn ProviderConfigurationFactory>;
+        let service = ProviderReconciliationService::new(
+            ProviderFactoryRegistry::new([factory]).expect("registry"),
+            repository.clone(),
+            repository,
+        );
+
+        let report = service
+            .reconcile(desired(
+                ProviderInstanceId::new(),
+                ProviderConnectionId::new(),
+                ProviderWebhookEndpointId::new(),
+                2,
+                b"bootstrap-secret",
+                false,
+            ))
+            .await
+            .expect("first observation with an existing durable revision");
+        assert_eq!(report.instance(), ProviderSaveOutcome::Inserted);
+        assert_eq!(report.endpoint(), ProviderSaveOutcome::Inserted);
     }
 }

--- a/crates/automata-ci-provider-postgres/src/instance.rs
+++ b/crates/automata-ci-provider-postgres/src/instance.rs
@@ -175,8 +175,6 @@ impl PostgresProviderManifestRepository {
                 .validate_successor(&current_manifest)
                 .map_err(|_| ProviderRepositoryError::Conflict)?;
             Some(current_manifest.secrets().clone())
-        } else if manifest.revision().get() != 1 {
-            return Err(ProviderRepositoryError::Conflict);
         } else {
             None
         };


### PR DESCRIPTION
The first clean-main production rollout exposed a migration bootstrap gap: durable GitHub provider configuration can already be revision 2 while the new provider-neutral registry is empty.

Allow the first neutral registry observation to establish that durable revision, while retaining strict idempotent/contiguous checks once a neutral manifest exists. Adds a regression for first observation at revision 2.

Validation: cargo fmt, provider-delivery/provider-postgres clippy with -D warnings, focused provider-delivery test, diff-check.