### PR TITLE
Add safe APFS compaction for macOS templates

### DIFF
--- a/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSTemplateTool/main.swift
+++ b/crates/automata-ci-sandbox-macos/swift/Sources/AutomataMacOSTemplateTool/main.swift
@@ -13,6 +13,7 @@ private enum ToolFailure: Error, CustomStringConvertible {
   case invalidArtifact
   case unsupportedRestoreImage
   case installationFailed
+  case compactionFailed
 
   var description: String {
     switch self {
@@ -24,6 +25,8 @@ private enum ToolFailure: Error, CustomStringConvertible {
       return "restore image is not supported by this host or the requested VM resources"
     case .installationFailed:
       return "macOS installation did not return a result"
+    case .compactionFailed:
+      return "APFS image compaction failed"
     }
   }
 }
@@ -431,6 +434,17 @@ private func createDisk(at url: URL, bytes: UInt64) throws {
   try handle.close()
 }
 
+private func run(_ executable: String, arguments: [String]) throws {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: executable)
+  process.arguments = arguments
+  process.standardOutput = FileHandle.standardOutput
+  process.standardError = FileHandle.standardError
+  try process.run()
+  process.waitUntilExit()
+  guard process.terminationStatus == 0 else { throw ToolFailure.compactionFailed }
+}
+
 private func prepareInstallDirectory(_ url: URL) throws {
   let manager = FileManager.default
   var isDirectory = ObjCBool(false)
@@ -573,6 +587,33 @@ private func install(arguments: ArraySlice<String>) throws {
   try wait { completion in
     queue.async { installer.install(completionHandler: completion) }
   } as Void
+}
+
+private func compact(arguments: ArraySlice<String>) throws {
+  guard arguments.count == 2,
+    let templateURL = normalizedAbsolute(arguments[arguments.startIndex]),
+    let containerGiB = UInt64(arguments[arguments.index(arguments.startIndex, offsetBy: 1)]),
+    (24...1024).contains(containerGiB)
+  else {
+    throw ToolFailure.invalidArguments
+  }
+  let manager = FileManager.default
+  let diskURL = templateURL.appendingPathComponent("Disk.img")
+  let manifestURL = templateURL.appendingPathComponent("manifest.json")
+  var isDirectory = ObjCBool(false)
+  guard manager.fileExists(atPath: templateURL.path, isDirectory: &isDirectory),
+    isDirectory.boolValue,
+    manager.fileExists(atPath: diskURL.path),
+    !manager.fileExists(atPath: manifestURL.path),
+    let attributes = try? manager.attributesOfItem(atPath: diskURL.path),
+    attributes[.type] as? FileAttributeType == .typeRegular
+  else {
+    throw ToolFailure.invalidArtifact
+  }
+  try run(
+    "/usr/bin/hdiutil",
+    arguments: ["resize", "-size", "\(containerGiB)g", diskURL.path]
+  )
 }
 
 private func sha256(_ url: URL) throws -> String {
@@ -748,6 +789,8 @@ private func main() -> Int32 {
     switch CommandLine.arguments[1] {
     case "install":
       try install(arguments: CommandLine.arguments.dropFirst(2))
+    case "compact":
+      try compact(arguments: CommandLine.arguments.dropFirst(2))
     case "boot":
       try boot(arguments: CommandLine.arguments.dropFirst(2))
     case "seal":

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -360,6 +360,24 @@ Remote Login, Screen Sharing, or other remote service is enabled, then shut
 down cleanly. Use the identity copied into the dedicated host output directory
 for sealing.
 
+The installer deliberately starts with a disk of at least 64 GiB because that
+is the supported sizing range for `VZMacOSInstaller`. After provisioning,
+removing temporary guest material, and shutting down, the unsealed image can
+be compacted to reclaim unused APFS capacity. The size passed to `compact` is
+the macOS APFS container size; the image also contains Apple's approximately
+512 MiB internal-storage container:
+
+```console
+"$tool" compact "$template" 28
+```
+
+`compact` refuses an already sealed template and invokes Apple's APFS-aware
+`hdiutil resize` operation. It fails if the requested size is below the
+guest's actual APFS minimum, so do not delete the System, Preboot, Recovery,
+or Data volumes to force a smaller image. A 28 GiB container is a compact
+smoke/basic-CI tier; Xcode-heavy jobs still need a larger template and a host
+volume with the corresponding quota.
+
 Seal only on an offline trusted builder:
 
 ```console


### PR DESCRIPTION
## Summary
- add a template-tool `compact` command that uses APFS-aware `hdiutil resize`
- reject compaction after sealing so manifest digests cannot become stale
- document the 28 GiB compact smoke/basic-CI tier and its limits

The installer remains at 64 GiB because that is the supported VZMacOSInstaller sizing range; compaction is an explicit post-provisioning, pre-sealing step. The command refuses sizes below 24 GiB and lets hdiutil enforce the guest-specific APFS minimum.

Validated on Apple Silicon macOS 26.5.1:
- Swift release build passes
- sealed template is rejected
- unsealed 28 GiB image compacts successfully
