### PR TITLE
Add headless macOS launchd service supervision

### DIFF
--- a/crates/automata-ci-runner/config/README.md
+++ b/crates/automata-ci-runner/config/README.md
@@ -315,7 +315,10 @@ host-specific path, replace every helper/template pin plus the identity and
 endpoints, provision its owner-only state roots, TLS files, and Keychain items, then start
 `automata-runner run --config /absolute/path/to/runner.macos.json`. Template
 construction, signing, isolation details, and the physical-host acceptance gate
-are documented in the [macOS guide](../../../docs/platforms/macos.md).
+are documented in the [macOS guide](../../../docs/platforms/macos.md). The
+checked-in [launchd installer](../../../scripts/macos/launchd/README.md) starts
+the runner at boot under the exact non-root service account without requiring a
+GUI session.
 
 The remainder of this guide describes the three-process rootless-Podman Linux
 host. macOS uses one runner process with one slot; Windows has no supported

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -422,6 +422,37 @@ disposable VM before connecting to the control plane. Missing or wrong-major
 Node runtimes therefore cannot be advertised. Old schema/native configuration
 is an error.
 
+### Headless launchd supervision
+
+The checked-in headless service installer uses a root-owned macOS
+`LaunchDaemon`, so the control plane and runner can start at boot and restart
+without a GUI, monitor, or interactive SSH session. It runs each process as a
+named non-root service account and refuses a root account or insecure input
+files. See
+[`scripts/macos/launchd/README.md`](../../scripts/macos/launchd/README.md) for
+the exact commands.
+
+Create the control-plane environment file as the service account with mode
+`0600`. It must contain only reviewed `NAME=value` assignments; every
+credential-bearing Automata variable must be a `file:` or `env:` reference,
+never a secret value. The runner JSON must also be mode `0600` and owned by the
+runner account. Provision TLS files, Keychain items, and the APFS state root
+before installing the daemon. Validate both commands directly as their service
+accounts first, then install with `sudo`:
+
+```console
+sudo scripts/macos/launchd/install.sh control-plane automata-control \
+  /Library/Automata/etc/control-plane.env /Library/Automata/bin/automata
+sudo scripts/macos/launchd/install.sh runner automata-runner \
+  /Library/Automata/etc/runner.macos.json /Library/Automata/bin/automata-runner
+```
+
+Inspect the exact system domain with `sudo launchctl print
+system/dev.automata.runner`; service output is written beneath
+`/Library/Logs/Automata`. `launchd` only supervises process lifetime: server
+readiness, runner mTLS, VM helper signature, template digest, APFS quota, and
+guest admission remain enforced by Automata at startup.
+
 ## Validation
 
 Repository CI intentionally does not schedule paid GitHub-hosted macOS jobs.

--- a/scripts/ci/tests/macos-launchd.test.sh
+++ b/scripts/ci/tests/macos-launchd.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != Darwin ]]; then
+    printf 'macOS launchd wrapper contract skipped on non-macOS\n'
+    exit 0
+fi
+
+script_directory="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(CDPATH='' cd -- "${script_directory}/../../.." && pwd)"
+wrapper="${repository_root}/scripts/macos/launchd/automata-launchd-run"
+install -d -m 0700 -- "${repository_root}/target"
+scratch_directory="$(mktemp -d "${repository_root}/target/macos-launchd-test.XXXXXXXX")"
+trap 'rm -rf -- "${scratch_directory}"' EXIT
+
+env_file="${scratch_directory}/service.env"
+fake_binary="${scratch_directory}/fake-service"
+config_file="${scratch_directory}/runner.json"
+printf '%s\n' 'AUTOMATA_TEST_VALUE=from-owner-only-env' >"${env_file}"
+printf '%s\n' '{}' >"${config_file}"
+chmod 0600 "${env_file}" "${config_file}"
+cat >"${fake_binary}" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${AUTOMATA_TEST_VALUE}"
+printf '%s\n' "$*"
+EOF
+chmod 0755 "${fake_binary}"
+
+[[ "$(${wrapper} "${env_file}" "${fake_binary}" server)" == $'from-owner-only-env\nserver' ]]
+[[ "$(${wrapper} "${env_file}" "${fake_binary}" run --config "${config_file}")" == $'from-owner-only-env\nrun --config '* ]]
+[[ "$(${wrapper} - "${fake_binary}" run --config "${config_file}")" == $'\nrun --config '* ]]
+
+chmod 0644 "${env_file}"
+if "${wrapper}" "${env_file}" "${fake_binary}" server >/dev/null 2>&1; then
+    printf 'wrapper accepted a group-readable environment file\n' >&2
+    exit 1
+fi
+
+printf 'macOS launchd wrapper contract verified\n'

--- a/scripts/macos/launchd/README.md
+++ b/scripts/macos/launchd/README.md
@@ -1,0 +1,45 @@
+# Headless macOS services
+
+`install.sh` installs one root-owned `LaunchDaemon` for the control plane or
+the macOS runner. The daemon runs as the named non-root service account, starts
+at boot, restarts after a process exit, and does not require a GUI, monitor, or
+interactive SSH session.
+
+The control-plane input file is an owner-only file containing reviewed
+`NAME=value` assignments. Control-plane secret variables must contain
+Automata's `file:` or `env:` references, never secret values. A runner input is
+its owner-only schema 8 JSON configuration; the runner service does not source
+that JSON as shell and uses `-` for its optional environment-file argument.
+The installer refuses missing, symlinked, group/world-writable, or
+non-canonical input paths and refuses a root service account.
+
+Install from a reviewed checkout or release tree as root:
+
+```console
+sudo scripts/macos/launchd/install.sh control-plane automata-control \
+  /Library/Automata/etc/control-plane.env \
+  /Library/Automata/bin/automata
+
+sudo scripts/macos/launchd/install.sh runner automata-runner \
+  /Library/Automata/etc/runner.macos.json \
+  /Library/Automata/bin/automata-runner
+```
+
+The service account must already own its input file and all referenced
+owner-only secret files. For a runner, provision its TLS files, Keychain items,
+APFS state root, and template/helper pins before installation. `automata-runner
+capabilities` should pass as that account before starting the daemon.
+
+Inspect or remove the services without a GUI:
+
+```console
+sudo launchctl print system/dev.automata.control-plane
+sudo launchctl print system/dev.automata.runner
+sudo launchctl bootout system/dev.automata.control-plane
+sudo launchctl bootout system/dev.automata.runner
+tail -f /Library/Logs/Automata/dev.automata.runner.log
+```
+
+The daemon is only process supervision. Automata still performs its own startup
+admission, dependency readiness, mTLS validation, APFS layout checks, template
+and helper digest checks, and runner capability probe before accepting work.

--- a/scripts/macos/launchd/automata-launchd-run
+++ b/scripts/macos/launchd/automata-launchd-run
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+die() {
+    printf 'automata macOS launchd: %s\n' "$*" >&2
+    exit 1
+}
+
+is_absolute_safe_path() {
+    case "$1" in
+        /*) ;;
+        *) return 1 ;;
+    esac
+    case "$1" in
+        *[!A-Za-z0-9_./:-]*) return 1 ;;
+    esac
+}
+
+require_owner_only_file() {
+    path=$1
+    is_absolute_safe_path "$path" || die "path is not a canonical absolute path: $path"
+    [ -f "$path" ] || die "path is not a regular file: $path"
+    [ ! -L "$path" ] || die "path must not be a symbolic link: $path"
+    owner=$(stat -f '%Su' -- "$path") || die "could not inspect path: $path"
+    [ "$owner" = "$(id -un)" ] || die "path is not owned by the service account: $path"
+    mode=$(stat -f '%Lp' -- "$path") || die "could not inspect path mode: $path"
+    case "$mode" in
+        600|400) ;;
+        *) die "path must be owner-only (0600 or 0400): $path" ;;
+    esac
+}
+
+require_executable() {
+    path=$1
+    is_absolute_safe_path "$path" || die "executable is not a canonical absolute path: $path"
+    [ -f "$path" ] || die "executable is not a regular file: $path"
+    [ ! -L "$path" ] || die "executable must not be a symbolic link: $path"
+    [ -x "$path" ] || die "executable is not executable: $path"
+    if find "$path" -prune -perm -022 -print | grep . >/dev/null 2>&1; then
+        die "executable is group- or world-writable: $path"
+    fi
+    return 0
+}
+
+[ "$#" -ge 3 ] || die "usage: automata-launchd-run ENV_FILE EXECUTABLE COMMAND [--config CONFIG]"
+env_file=$1
+executable=$2
+command=$3
+shift 3
+
+if [ "$env_file" != - ]; then
+    require_owner_only_file "$env_file"
+fi
+require_executable "$executable"
+
+if [ "$command" = run ]; then
+    [ "$#" -eq 2 ] && [ "$1" = --config ] ||
+        die "runner service requires --config CONFIG"
+    config=$2
+    require_owner_only_file "$config"
+    set -- "$command" --config "$config"
+else
+    [ "$#" -eq 0 ] || die "unexpected service arguments"
+    set -- "$command"
+fi
+
+# The environment file contains only reviewed NAME=value assignments and
+# secret references (file:/... or env:NAME), never secret values. It is
+# owner-only and is loaded after all launchd ambient variables are present.
+if [ "$env_file" != - ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$env_file"
+    set +a
+fi
+
+exec "$executable" "$@"

--- a/scripts/macos/launchd/install.sh
+++ b/scripts/macos/launchd/install.sh
@@ -1,0 +1,174 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+wrapper_source=$script_directory/automata-launchd-run
+label_prefix=dev.automata
+plist_directory=/Library/LaunchDaemons
+log_directory=/Library/Logs/Automata
+install_root=/Library/Automata
+
+die() {
+    printf 'automata macOS launchd installer: %s\n' "$*" >&2
+    exit 1
+}
+
+usage() {
+    printf '%s\n' \
+        'usage: install.sh control-plane SERVICE_USER ENV_FILE AUTOMATA_BINARY' \
+        '       install.sh runner SERVICE_USER RUNNER_CONFIG RUNNER_BINARY' >&2
+    exit 2
+}
+
+is_absolute_safe_path() {
+    case "$1" in
+        /*) ;;
+        *) return 1 ;;
+    esac
+    case "$1" in
+        *[!A-Za-z0-9_./:-]*) return 1 ;;
+    esac
+}
+
+require_absolute_safe_path() {
+    is_absolute_safe_path "$1" || die "path is not a canonical absolute path: $1"
+}
+
+require_owner_only_file() {
+    path=$1
+    expected_owner=$2
+    require_absolute_safe_path "$path"
+    [ -f "$path" ] || die "path is not a regular file: $path"
+    [ ! -L "$path" ] || die "path must not be a symbolic link: $path"
+    [ "$(stat -f '%Su' -- "$path")" = "$expected_owner" ] ||
+        die "path is not owned by $expected_owner: $path"
+    case "$(stat -f '%Lp' -- "$path")" in
+        600|400) ;;
+        *) die "path must be owner-only (0600 or 0400): $path" ;;
+    esac
+}
+
+require_executable() {
+    path=$1
+    require_absolute_safe_path "$path"
+    [ -f "$path" ] || die "executable is not a regular file: $path"
+    [ ! -L "$path" ] || die "executable must not be a symbolic link: $path"
+    [ -x "$path" ] || die "executable is not executable: $path"
+    if find "$path" -prune -perm -022 -print | grep . >/dev/null 2>&1; then
+        die "executable is group- or world-writable: $path"
+    fi
+    return 0
+}
+
+xml_path() {
+    case "$1" in
+        *[\&\<\>\"\']*) die "path contains an XML metacharacter: $1" ;;
+    esac
+    printf '%s' "$1"
+}
+
+[ "$(id -u)" -eq 0 ] || die "run this installer with sudo"
+[ "$#" -eq 4 ] || usage
+role=$1
+service_user=$2
+input_path=$3
+binary=$4
+
+service_uid=$(id -u "$service_user" 2>/dev/null) ||
+    die "service account does not exist: $service_user"
+[ "$service_uid" -ne 0 ] || die "service account must not be root"
+service_group=$(id -gn "$service_user") ||
+    die "service group name could not be resolved: $service_user"
+
+case "$role" in
+    control-plane)
+        label=$label_prefix.control-plane
+        require_owner_only_file "$input_path" "$service_user"
+        ;;
+    runner)
+        label=$label_prefix.runner
+        require_owner_only_file "$input_path" "$service_user"
+        ;;
+    *) die "unknown service role: $role" ;;
+esac
+require_executable "$binary"
+
+install -d -o root -g wheel -m 0755 "$plist_directory" "$install_root/bin"
+install -d -o "$service_user" -g "$service_group" -m 0750 "$log_directory"
+install -o root -g wheel -m 0555 "$wrapper_source" "$install_root/bin/automata-launchd-run"
+
+plist=$plist_directory/$label.plist
+temporary_plist=$plist_directory/.$label.plist.$$
+wrapper=$install_root/bin/automata-launchd-run
+
+input_xml=$(xml_path "$input_path")
+binary_xml=$(xml_path "$binary")
+wrapper_xml=$(xml_path "$wrapper")
+log_xml=$(xml_path "$log_directory/$label.log")
+error_xml=$(xml_path "$log_directory/$label.error.log")
+
+if [ "$role" = control-plane ]; then
+    env_xml=$input_xml
+    command_xml='<string>server</string>'
+    argument_xml=''
+else
+    env_xml='-'
+    command_xml='<string>run</string>'
+    argument_xml=$(printf '%s\n' \
+        '        <string>--config</string>' \
+        "        <string>$input_xml</string>")
+fi
+
+cat > "$temporary_plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$label</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>$wrapper_xml</string>
+        <string>$env_xml</string>
+        <string>$binary_xml</string>
+        $command_xml
+$argument_xml
+    </array>
+    <key>UserName</key>
+    <string>$service_user</string>
+    <key>GroupName</key>
+    <string>$service_group</string>
+    <key>WorkingDirectory</key>
+    <string>$install_root</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardOutPath</key>
+    <string>$log_xml</string>
+    <key>StandardErrorPath</key>
+    <string>$error_xml</string>
+</dict>
+</plist>
+EOF
+
+plutil -lint "$temporary_plist" >/dev/null || {
+    rm -f "$temporary_plist"
+    die "generated launchd plist failed validation"
+}
+
+launchctl bootout "system/$label" >/dev/null 2>&1 || true
+install -o root -g wheel -m 0600 "$temporary_plist" "$plist"
+rm -f "$temporary_plist"
+launchctl bootstrap system "$plist"
+printf 'installed and started %s as %s\n' "$label" "$service_user"

--- a/scripts/macos/launchd/install.sh
+++ b/scripts/macos/launchd/install.sh
@@ -172,6 +172,7 @@ plutil -lint "$temporary_plist" >/dev/null || {
 launchctl bootout "system/$label" >/dev/null 2>&1 || true
 install -o root -g wheel -m 0600 "$temporary_plist" "$plist"
 rm -f "$temporary_plist"
-install -o "$service_user" -g "$service_group" -m 0600 /dev/null "$log_file" "$error_file"
+install -o "$service_user" -g "$service_group" -m 0600 /dev/null "$log_file"
+install -o "$service_user" -g "$service_group" -m 0600 /dev/null "$error_file"
 launchctl bootstrap system "$plist"
 printf 'installed and started %s as %s\n' "$label" "$service_user"

--- a/scripts/macos/launchd/install.sh
+++ b/scripts/macos/launchd/install.sh
@@ -106,6 +106,8 @@ binary_xml=$(xml_path "$binary")
 wrapper_xml=$(xml_path "$wrapper")
 log_xml=$(xml_path "$log_directory/$label.log")
 error_xml=$(xml_path "$log_directory/$label.error.log")
+log_file=$log_directory/$label.log
+error_file=$log_directory/$label.error.log
 
 if [ "$role" = control-plane ]; then
     env_xml=$input_xml
@@ -170,5 +172,6 @@ plutil -lint "$temporary_plist" >/dev/null || {
 launchctl bootout "system/$label" >/dev/null 2>&1 || true
 install -o root -g wheel -m 0600 "$temporary_plist" "$plist"
 rm -f "$temporary_plist"
+install -o "$service_user" -g "$service_group" -m 0600 /dev/null "$log_file" "$error_file"
 launchctl bootstrap system "$plist"
 printf 'installed and started %s as %s\n' "$label" "$service_user"


### PR DESCRIPTION
## Summary

- add a root-owned `LaunchDaemon` installer for the control plane and macOS runner
- run services as named non-root accounts with owner-only inputs, fixed PATH, restart policy, and dedicated logs
- keep runner schema-8 JSON out of the shell environment; runner services use the wrapper's optional environment-file `-` form
- document headless boot/restart/inspection and add a macOS wrapper contract test

The installer deliberately leaves Automata startup admission (mTLS, Keychain, helper/template pins, APFS quota, and readiness) to the binaries.

## Verification

- `git diff --cached --check`
- `sh -n scripts/macos/launchd/automata-launchd-run scripts/macos/launchd/install.sh`
- `bash -n scripts/ci/tests/macos-launchd.test.sh`
- Mac Mini: `bash scripts/ci/tests/macos-launchd.test.sh`
- Mac Mini: installed both control-plane and runner LaunchDaemons with `launchctl`; each loaded as `nlight` with `runs = 1`; removed them cleanly
