### PR TITLE
Record completed macOS physical acceptance

### DIFF
--- a/docs/github-actions-parity/github-actions-parity-09-platforms.md
+++ b/docs/github-actions-parity/github-actions-parity-09-platforms.md
@@ -291,9 +291,14 @@ Acceptance:
 - [x] Self-hosted macOS 15 differential fixtures cover stable environment,
   working-directory, command-file, output, timeout, cancellation, and
   conclusion behavior.
-- [ ] Physical Apple Silicon acceptance proves VM template identity,
+- [x] Physical Apple Silicon acceptance proves VM template identity,
   filesystem/network separation, CPU/memory/process enforcement, helper-crash
   recovery, and repeated clean execution.
+
+  The dedicated Apple Silicon Mac mini completed the full ignored physical
+  suite with three repetitions on 2026-08-19; the retained evidence and the
+  exact deployment-only continuous-lane gap are recorded in the
+  [macOS platform guide](../platforms/macos.md#validation).
 
 ### PLAT-03 — Windows Hyper-V-container scale and expanded profiles
 


### PR DESCRIPTION
## Summary

- mark the physical Apple Silicon macOS acceptance gate complete after the dedicated Mac mini's three-repetition ignored-suite soak
- link the platform guide, which retains the exact evidence and leaves the continuously scheduled protected lane explicitly open

## Verification

- `git diff --check`
