### PR TITLE
refactor: use tenant terminology across Core

### DIFF
--- a/crates/automata-ci-auth-postgres/src/delegated_actor.rs
+++ b/crates/automata-ci-auth-postgres/src/delegated_actor.rs
@@ -23,7 +23,7 @@ const MAX_DELEGATED_ACTOR_ROLE_GRANTS: usize = 10_000;
 /// `PostgreSQL` resolver for externally delegated actor identities.
 ///
 /// The external assertion is only identity evidence. This adapter always reloads
-/// the Core-owned principal, current workspace membership, authorization
+/// the Core-owned principal, current tenant membership, authorization
 /// revision, and direct scoped role grants in one transaction.
 #[derive(Clone)]
 pub struct PostgresDelegatedActorResolver {

--- a/crates/automata-ci-auth/src/delegated_actor.rs
+++ b/crates/automata-ci-auth/src/delegated_actor.rs
@@ -2,7 +2,7 @@
 //!
 //! Delegated assertions are deliberately separate from durable browser and CLI
 //! sessions. The issuer authenticates an external actor, while Core remains the
-//! authority for principal mapping, workspace membership, and RBAC.
+//! authority for principal mapping, tenant membership, and RBAC.
 
 use std::{collections::BTreeSet, fmt, future::Future, pin::Pin};
 
@@ -178,7 +178,7 @@ impl DelegatedRepositoryMutationActor {
     ///
     /// # Errors
     ///
-    /// Rejects anonymous, revisionless, or cross-workspace snapshots.
+    /// Rejects anonymous, revisionless, or cross-tenant snapshots.
     pub fn from_snapshot(
         snapshot: &DelegatedActorRequestSnapshot,
     ) -> Result<Self, DelegatedRepositoryMutationActorError> {
@@ -209,7 +209,7 @@ impl DelegatedRepositoryMutationActor {
         &self.assertion
     }
 
-    /// Returns the exact Core workspace bounding the mutation.
+    /// Returns the exact Core tenant bounding the mutation.
     #[must_use]
     pub const fn tenant_id(&self) -> &TenantId {
         &self.tenant_id
@@ -258,7 +258,7 @@ pub enum RepositoryMutationActor {
 }
 
 impl RepositoryMutationActor {
-    /// Returns the exact Core workspace bounding the mutation.
+    /// Returns the exact Core tenant bounding the mutation.
     #[must_use]
     pub const fn tenant_id(&self) -> &TenantId {
         match self {
@@ -329,11 +329,11 @@ impl From<DelegatedRepositoryMutationActor> for RepositoryMutationActor {
 }
 
 impl DelegatedActorRequestSnapshot {
-    /// Creates a workspace-consistent delegated request snapshot.
+    /// Creates a tenant-consistent delegated request snapshot.
     ///
     /// # Errors
     ///
-    /// Rejects anonymous or cross-workspace authorization evidence.
+    /// Rejects anonymous or cross-tenant authorization evidence.
     pub fn new(
         assertion: DelegatedActorAssertion,
         expected_tenant_id: &TenantId,
@@ -367,7 +367,7 @@ impl DelegatedActorRequestSnapshot {
         &self.viewer
     }
 
-    /// Returns Core's current workspace-scoped RBAC evidence.
+    /// Returns Core's current tenant-scoped RBAC evidence.
     #[must_use]
     pub const fn authorization(&self) -> &AuthorizationContext {
         &self.authorization
@@ -388,7 +388,7 @@ impl DelegatedActorRequestSnapshot {
 #[error("delegated actor request snapshot is inconsistent")]
 pub struct DelegatedActorRequestSnapshotError;
 
-/// A verified assertion paired with the exact requested workspace.
+/// A verified assertion paired with the exact requested tenant.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResolveDelegatedActorRequest {
     assertion: DelegatedActorAssertion,
@@ -429,7 +429,7 @@ impl ResolveDelegatedActorRequest {
         &self.assertion
     }
 
-    /// Returns the requested Core workspace identity.
+    /// Returns the requested Core tenant identity.
     #[must_use]
     pub const fn tenant_id(&self) -> &TenantId {
         &self.tenant_id
@@ -452,11 +452,11 @@ pub struct DelegatedActorPermissionRequestError;
 pub enum ResolveDelegatedActorOutcome {
     /// The external identity resolved to current Core membership and RBAC.
     Authenticated(Box<DelegatedActorRequestSnapshot>),
-    /// The external identity or requested workspace membership does not exist.
+    /// The external identity or requested tenant membership does not exist.
     NotFound,
     /// The mapped Core principal is disabled.
     PrincipalDisabled,
-    /// The mapped workspace membership is suspended.
+    /// The mapped tenant membership is suspended.
     MembershipSuspended,
 }
 
@@ -471,7 +471,7 @@ pub type DelegatedActorResolutionFuture<'a> = Pin<
 
 /// Resolves verified external identities against current Core-owned authority.
 pub trait DelegatedActorResolver: fmt::Debug + Send + Sync {
-    /// Loads the principal mapping, workspace membership, and RBAC snapshot.
+    /// Loads the principal mapping, tenant membership, and RBAC snapshot.
     fn resolve<'a>(
         &'a self,
         request: &'a ResolveDelegatedActorRequest,

--- a/crates/automata-ci-core/src/id.rs
+++ b/crates/automata-ci-core/src/id.rs
@@ -76,33 +76,33 @@ uuid_id!(/// Idempotency key for a mutating operation.
 uuid_id!(/// Identifies a durable stream of log frames.
     LogStreamId);
 
-/// Canonical non-nil identity of one Automata workspace.
+/// Canonical non-nil identity of one Automata tenant.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(try_from = "String", into = "String")]
-pub struct WorkspaceId(Uuid);
+pub struct ManagedTenantId(Uuid);
 
-impl WorkspaceId {
-    /// Parses an exact lower-case hyphenated non-nil workspace UUID.
+impl ManagedTenantId {
+    /// Parses an exact lower-case hyphenated non-nil tenant UUID.
     ///
     /// # Errors
     ///
     /// Rejects nil, non-hyphenated, upper-case, or otherwise noncanonical text.
-    pub fn parse(value: &str) -> Result<Self, WorkspaceIdError> {
-        let parsed = Uuid::parse_str(value).map_err(|_| WorkspaceIdError)?;
+    pub fn parse(value: &str) -> Result<Self, ManagedTenantIdError> {
+        let parsed = Uuid::parse_str(value).map_err(|_| ManagedTenantIdError)?;
         if parsed.is_nil() || parsed.hyphenated().to_string() != value {
-            return Err(WorkspaceIdError);
+            return Err(ManagedTenantIdError);
         }
         Ok(Self(parsed))
     }
 
-    /// Constructs a workspace identity from a non-nil UUID.
+    /// Constructs a tenant identity from a non-nil UUID.
     ///
     /// # Errors
     ///
     /// Rejects the nil UUID.
-    pub const fn from_uuid(value: Uuid) -> Result<Self, WorkspaceIdError> {
+    pub const fn from_uuid(value: Uuid) -> Result<Self, ManagedTenantIdError> {
         if value.is_nil() {
-            return Err(WorkspaceIdError);
+            return Err(ManagedTenantIdError);
         }
         Ok(Self(value))
     }
@@ -114,38 +114,38 @@ impl WorkspaceId {
     }
 }
 
-impl fmt::Display for WorkspaceId {
+impl fmt::Display for ManagedTenantId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "{}", self.0.hyphenated())
     }
 }
 
-impl FromStr for WorkspaceId {
-    type Err = WorkspaceIdError;
+impl FromStr for ManagedTenantId {
+    type Err = ManagedTenantIdError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         Self::parse(value)
     }
 }
 
-impl TryFrom<String> for WorkspaceId {
-    type Error = WorkspaceIdError;
+impl TryFrom<String> for ManagedTenantId {
+    type Error = ManagedTenantIdError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         Self::parse(&value)
     }
 }
 
-impl From<WorkspaceId> for String {
-    fn from(value: WorkspaceId) -> Self {
+impl From<ManagedTenantId> for String {
+    fn from(value: ManagedTenantId) -> Self {
         value.to_string()
     }
 }
 
-/// Invalid canonical workspace identity.
+/// Invalid canonical tenant identity.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-#[error("workspace ID is invalid")]
-pub struct WorkspaceIdError;
+#[error("tenant ID is invalid")]
+pub struct ManagedTenantIdError;
 
 /// Stable positive numeric alias for a workflow run.
 ///

--- a/crates/automata-ci-core/tests/identifier_contract.rs
+++ b/crates/automata-ci-core/tests/identifier_contract.rs
@@ -1,16 +1,17 @@
 use automata_ci_core::{
-    AttemptNumber, FencingToken, IdentifierError, RunId, RunIdAlias, WorkspaceId, WorkspaceIdError,
+    AttemptNumber, FencingToken, IdentifierError, ManagedTenantId, ManagedTenantIdError, RunId,
+    RunIdAlias,
 };
 use uuid::Uuid;
 
 #[test]
-fn workspace_ids_are_canonical_and_non_nil() {
+fn tenant_ids_are_canonical_and_non_nil() {
     let value = "22222222-2222-4222-8222-222222222222";
-    let workspace = WorkspaceId::parse(value).expect("workspace ID");
-    assert_eq!(workspace.to_string(), value);
+    let tenant = ManagedTenantId::parse(value).expect("tenant ID");
+    assert_eq!(tenant.to_string(), value);
     assert_eq!(
-        serde_json::from_str::<WorkspaceId>(&format!("\"{value}\"")).expect("deserialize"),
-        workspace
+        serde_json::from_str::<ManagedTenantId>(&format!("\"{value}\"")).expect("deserialize"),
+        tenant
     );
 
     for invalid in [
@@ -18,9 +19,12 @@ fn workspace_ids_are_canonical_and_non_nil() {
         "22222222222242228222222222222222",
         "22222222-2222-4222-8222-22222222222A",
     ] {
-        assert_eq!(WorkspaceId::parse(invalid), Err(WorkspaceIdError));
+        assert_eq!(ManagedTenantId::parse(invalid), Err(ManagedTenantIdError));
     }
-    assert_eq!(WorkspaceId::from_uuid(Uuid::nil()), Err(WorkspaceIdError));
+    assert_eq!(
+        ManagedTenantId::from_uuid(Uuid::nil()),
+        Err(ManagedTenantIdError)
+    );
 }
 
 #[test]

--- a/crates/automata-ci-github-delivery/src/common_runtime.rs
+++ b/crates/automata-ci-github-delivery/src/common_runtime.rs
@@ -149,7 +149,7 @@ fn check_rerun_request(
     let sender_id = parse_provider_id(actor.external_id().as_str())?;
     let repository_id = parse_provider_id(control.repository().external_id().as_str())?;
     let tenant = TenantScope::from_authenticated_tenant_id(
-        connection.configuration().workspace_id().to_string(),
+        connection.configuration().tenant_id().to_string(),
     )
     .map_err(|_| ProviderControlHandlingError::InvalidEvidence)?;
     let target = match native.target() {
@@ -233,7 +233,7 @@ const fn result_error(error: ProviderWorkflowResultServiceError) -> ProviderCont
 
 #[cfg(test)]
 mod tests {
-    use automata_ci_core::{GitObjectId, Sha256Digest, UnixMillis, WorkspaceId};
+    use automata_ci_core::{GitObjectId, ManagedTenantId, Sha256Digest, UnixMillis};
     use automata_ci_provider::{
         ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId,
         ExternalRepositoryIdentity, ExternalSubjectId, ExternalSubjectIdentity,
@@ -421,7 +421,7 @@ mod tests {
         .document()
         .expect("GitHub policy document");
         let configuration = ProviderConnectionConfiguration::new(
-            WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+            ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
             repository.clone(),
             revision,
             provider.configuration().digest(),

--- a/crates/automata-ci-github-delivery/src/result_adapter.rs
+++ b/crates/automata-ci-github-delivery/src/result_adapter.rs
@@ -1307,7 +1307,7 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
 
-    use automata_ci_core::{GitObjectId, RunId, UnixMillis, WorkspaceId};
+    use automata_ci_core::{GitObjectId, ManagedTenantId, RunId, UnixMillis};
     use automata_ci_provider::{
         ClaimedProviderResult, DesiredProviderResult, ExternalRepositoryIdentity,
         ProviderArchiveLimits, ProviderConfigurationRevision, ProviderConnectionConfiguration,
@@ -1659,7 +1659,7 @@ mod tests {
         .document()
         .expect("connection document");
         let configuration = ProviderConnectionConfiguration::new(
-            WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+            ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
             ExternalRepositoryIdentity::new(
                 instance_id,
                 ExternalRepositoryId::new("42").expect("repository ID"),

--- a/crates/automata-ci-github-delivery/tests/trigger_handler.rs
+++ b/crates/automata-ci-github-delivery/tests/trigger_handler.rs
@@ -9,7 +9,7 @@ use std::{
 use async_trait::async_trait;
 use automata_ci_auth::secret::SecretString;
 use automata_ci_blob::MemoryBlobStore;
-use automata_ci_core::{Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{ManagedTenantId, Sha256Digest, UnixMillis};
 use automata_ci_github_delivery::{
     GithubTriggerCredential, GithubTriggerCredentialOperation, GithubTriggerCredentialProvider,
     GithubTriggerCredentialProviderError, GithubTriggerCredentialRelease,
@@ -685,7 +685,7 @@ fn manifests(
     )
     .expect("provider manifest");
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
         ExternalRepositoryIdentity::new(
             instance_id,
             ExternalRepositoryId::new("42").expect("repository ID"),

--- a/crates/automata-ci-postgres/tests/auth/delegated_actor.rs
+++ b/crates/automata-ci-postgres/tests/auth/delegated_actor.rs
@@ -10,14 +10,14 @@ use automata_ci_auth::{
     time::UnixTimestamp,
 };
 use automata_ci_auth_postgres::PostgresDelegatedActorResolver;
-use automata_ci_core::WorkspaceId;
+use automata_ci_core::ManagedTenantId;
 use automata_ci_postgres::test_support::run_with_unmigrated_database;
 use automata_ci_provisioning::{
-    AuthorizedProvisionWorkspace, DelegatedActorIssuer, DisplayName, ExternalAccountSubject,
-    OperationId, ProvisionWorkspaceCommand, ProvisioningAuthority, ProvisioningAuthorityId,
-    ShardId, WorkspaceProvisioner as _,
+    AuthorizedProvisionTenant, DelegatedActorIssuer, DisplayName, ExternalAccountSubject,
+    OperationId, ProvisionTenantCommand, ProvisioningAuthority, ProvisioningAuthorityId, ShardId,
+    TenantProvisioner as _,
 };
-use automata_ci_provisioning_postgres::PostgresWorkspaceProvisioner;
+use automata_ci_provisioning_postgres::PostgresTenantProvisioner;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -37,18 +37,18 @@ fn authority() -> ProvisioningAuthority {
     )
 }
 
-fn provision_request(workspace_id: WorkspaceId, subject: Uuid) -> AuthorizedProvisionWorkspace {
+fn provision_request(tenant_id: ManagedTenantId, subject: Uuid) -> AuthorizedProvisionTenant {
     let authority = authority();
-    let command = ProvisionWorkspaceCommand::new(
+    let command = ProvisionTenantCommand::new(
         OperationId::from_uuid(Uuid::new_v4()).expect("operation ID"),
         authority.shard_id().clone(),
-        workspace_id,
-        DisplayName::new("Billing authorization test").expect("workspace display name"),
+        tenant_id,
+        DisplayName::new("Billing authorization test").expect("tenant display name"),
         authority.delegated_actor_issuer().clone(),
         ExternalAccountSubject::from_uuid(subject).expect("external subject"),
         DisplayName::new("Test Owner").expect("owner display name"),
     );
-    AuthorizedProvisionWorkspace::authorize(authority, command).expect("authorized request")
+    AuthorizedProvisionTenant::authorize(authority, command).expect("authorized request")
 }
 
 async fn wait_for_pending_lock(pool: &PgPool, query: &'static str) -> TestResult {
@@ -64,7 +64,7 @@ async fn wait_for_pending_lock(pool: &PgPool, query: &'static str) -> TestResult
     Ok(())
 }
 
-async fn billing_permissions(pool: &PgPool, workspace_id: WorkspaceId) -> TestResult<Vec<String>> {
+async fn billing_permissions(pool: &PgPool, tenant_id: ManagedTenantId) -> TestResult<Vec<String>> {
     Ok(sqlx::query_scalar(
         r"
         SELECT permission.permission_name
@@ -73,20 +73,20 @@ async fn billing_permissions(pool: &PgPool, workspace_id: WorkspaceId) -> TestRe
           ON permission.tenant_id = role.tenant_id
          AND permission.role_id = role.id
         WHERE role.tenant_id = $1
-          AND role.name = 'workspace-owner'
+          AND role.name = 'tenant-owner'
           AND permission.permission_name = ANY(ARRAY['billing:manage', 'billing:read'])
         ORDER BY permission.permission_name
         ",
     )
-    .bind(workspace_id.to_string())
+    .bind(tenant_id.to_string())
     .fetch_all(pool)
     .await?)
 }
 
-async fn install_workspace_owner_pause(pool: &PgPool) -> TestResult {
+async fn install_tenant_owner_pause(pool: &PgPool) -> TestResult {
     sqlx::raw_sql(
         r"
-        CREATE FUNCTION automata_test.pause_workspace_owner_insert()
+        CREATE FUNCTION automata_test.pause_tenant_owner_insert()
         RETURNS TRIGGER
         LANGUAGE plpgsql
         AS $$
@@ -96,11 +96,11 @@ async fn install_workspace_owner_pause(pool: &PgPool) -> TestResult {
         END;
         $$;
 
-        CREATE TRIGGER pause_workspace_owner_insert
+        CREATE TRIGGER pause_tenant_owner_insert
         AFTER INSERT ON rbac_roles
         FOR EACH ROW
-        WHEN (NEW.name = 'workspace-owner')
-        EXECUTE FUNCTION automata_test.pause_workspace_owner_insert();
+        WHEN (NEW.name = 'tenant-owner')
+        EXECUTE FUNCTION automata_test.pause_tenant_owner_insert();
         ",
     )
     .execute(pool)
@@ -117,7 +117,7 @@ async fn billing_migration_serializes_concurrent_owner_provisioning() -> TestRes
             MIGRATOR
                 .run_to(PRE_BILLING_MIGRATION_VERSION, database.pool())
                 .await?;
-            install_workspace_owner_pause(database.pool()).await?;
+            install_tenant_owner_pause(database.pool()).await?;
 
             let mut pause_guard = database.pool().acquire().await?;
             sqlx::query("SELECT pg_advisory_lock($1)")
@@ -125,12 +125,12 @@ async fn billing_migration_serializes_concurrent_owner_provisioning() -> TestRes
                 .execute(&mut *pause_guard)
                 .await?;
 
-            let workspace_id = WorkspaceId::from_uuid(Uuid::new_v4())?;
+            let tenant_id = ManagedTenantId::from_uuid(Uuid::new_v4())?;
             let subject = Uuid::new_v4();
-            let adapter = PostgresWorkspaceProvisioner::new(database.pool().clone());
+            let adapter = PostgresTenantProvisioner::new(database.pool().clone());
             let provisioning = tokio::spawn(async move {
                 adapter
-                    .provision(provision_request(workspace_id, subject))
+                    .provision(provision_request(tenant_id, subject))
                     .await
             });
 
@@ -183,7 +183,7 @@ async fn billing_migration_serializes_concurrent_owner_provisioning() -> TestRes
             tokio::time::timeout(Duration::from_secs(10), migration).await???;
 
             assert_eq!(
-                billing_permissions(database.pool(), workspace_id).await?,
+                billing_permissions(database.pool(), tenant_id).await?,
                 ["billing:manage".to_owned(), "billing:read".to_owned()]
             );
             let authorization_revision: i64 = sqlx::query_scalar(
@@ -193,7 +193,7 @@ async fn billing_migration_serializes_concurrent_owner_provisioning() -> TestRes
                 WHERE tenant_id = $1 AND principal_id = $2
                 ",
             )
-            .bind(workspace_id.to_string())
+            .bind(tenant_id.to_string())
             .bind(result.initial_owner_principal_id().as_uuid())
             .fetch_one(database.pool())
             .await?;
@@ -208,13 +208,13 @@ async fn billing_migration_serializes_concurrent_owner_provisioning() -> TestRes
 #[ignore = "requires AUTOMATA_TEST_DATABASE_URL and creates a temporary schema"]
 async fn delegated_actor_resolver_loads_exact_requested_billing_permissions() -> TestResult {
     run_with_database(|database| async move {
-        let workspace_id = WorkspaceId::from_uuid(Uuid::new_v4())?;
+        let tenant_id = ManagedTenantId::from_uuid(Uuid::new_v4())?;
         let subject = Uuid::new_v4();
-        let provisioned = PostgresWorkspaceProvisioner::new(database.pool().clone())
-            .provision(provision_request(workspace_id, subject))
+        let provisioned = PostgresTenantProvisioner::new(database.pool().clone())
+            .provision(provision_request(tenant_id, subject))
             .await?;
 
-        let tenant_id = TenantId::new(workspace_id.to_string())?;
+        let tenant_id = TenantId::new(tenant_id.to_string())?;
         let assertion = DelegatedActorAssertion::new(
             "https://cloud.automata.example",
             subject,

--- a/crates/automata-ci-provider-delivery/src/reconciliation.rs
+++ b/crates/automata-ci-provider-delivery/src/reconciliation.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, fmt, sync::Arc};
 
-use automata_ci_core::{UnixMillis, WorkspaceId};
+use automata_ci_core::{ManagedTenantId, UnixMillis};
 use automata_ci_key_management::SecretBytes;
 use automata_ci_provider::{
     ExternalRepositoryId, MAX_PROVIDER_SECRET_BINDINGS, MAX_PROVIDER_WEBHOOK_CONNECTIONS,
@@ -120,7 +120,7 @@ impl fmt::Debug for ProviderInstanceDesiredState {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProviderConnectionDesiredState {
     connection_id: ProviderConnectionId,
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     external_repository_id: ExternalRepositoryId,
     visibility: RepositoryVisibility,
     default_branch: ProviderDefaultBranch,
@@ -140,7 +140,7 @@ impl ProviderConnectionDesiredState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         connection_id: ProviderConnectionId,
-        workspace_id: WorkspaceId,
+        tenant_id: ManagedTenantId,
         external_repository_id: ExternalRepositoryId,
         visibility: RepositoryVisibility,
         default_branch: ProviderDefaultBranch,
@@ -155,7 +155,7 @@ impl ProviderConnectionDesiredState {
         }
         Ok(Self {
             connection_id,
-            workspace_id,
+            tenant_id,
             external_repository_id,
             visibility,
             default_branch,
@@ -539,7 +539,7 @@ impl ProviderReconciliationService {
                     desired.connection_id,
                     revision,
                     ProviderLifecycleState::Active,
-                    desired.workspace_id,
+                    desired.tenant_id,
                     desired.external_repository_id,
                     desired.visibility,
                     desired.default_branch,
@@ -1195,7 +1195,7 @@ mod tests {
             .then(|| {
                 ProviderConnectionDesiredState::new(
                     connection_id,
-                    WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+                    ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
                     ExternalRepositoryId::new("42").expect("external repository"),
                     RepositoryVisibility::Private,
                     ProviderDefaultBranch::new("main").expect("default branch"),

--- a/crates/automata-ci-provider-delivery/src/result_worker.rs
+++ b/crates/automata-ci-provider-delivery/src/result_worker.rs
@@ -652,7 +652,7 @@ mod tests {
         atomic::{AtomicI64, AtomicUsize, Ordering},
     };
 
-    use automata_ci_core::{GitObjectId, RunId, WorkspaceId};
+    use automata_ci_core::{GitObjectId, ManagedTenantId, RunId};
     use automata_ci_provider::{
         CompleteProviderResult, DesiredProviderResult, ExternalRepositoryId,
         ExternalRepositoryIdentity, FailProviderResult, ProviderArchiveLimits, ProviderCapability,
@@ -994,7 +994,7 @@ mod tests {
         )
         .expect("provider manifest");
         let connection_configuration = ProviderConnectionConfiguration::new(
-            WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+            ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
             ExternalRepositoryIdentity::new(
                 instance_id,
                 ExternalRepositoryId::new("42").expect("repository"),

--- a/crates/automata-ci-provider-delivery/src/worker.rs
+++ b/crates/automata-ci-provider-delivery/src/worker.rs
@@ -500,7 +500,7 @@ mod tests {
         atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering},
     };
 
-    use automata_ci_core::{GitObjectId, Sha256Digest, WorkspaceId};
+    use automata_ci_core::{GitObjectId, ManagedTenantId, Sha256Digest};
     use automata_ci_provider::{
         ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId,
         ExternalRepositoryIdentity, NormalizedTrigger, ProviderArchiveLimits,
@@ -1419,7 +1419,7 @@ mod tests {
         )
         .expect("connection policy");
         let configuration = ProviderConnectionConfiguration::new(
-            WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+            ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
             repository.clone(),
             manifest.revision(),
             manifest.configuration().digest(),

--- a/crates/automata-ci-provider-github/tests/common_changed_files.rs
+++ b/crates/automata-ci-provider-github/tests/common_changed_files.rs
@@ -1,7 +1,7 @@
 use crate::support::{FixtureServer, ResponseSpec};
 
 use automata_ci_auth::secret::SecretString;
-use automata_ci_core::{GitObjectId, Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{GitObjectId, ManagedTenantId, Sha256Digest, UnixMillis};
 use automata_ci_provider::{
     ExternalRepositoryId, ExternalRepositoryIdentity, NormalizedTrigger, ProviderArchiveLimits,
     ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
@@ -37,7 +37,7 @@ fn identity() -> ExternalRepositoryIdentity {
 
 fn connection() -> ProviderConnectionManifest {
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
         identity(),
         ProviderConfigurationRevision::new(1).expect("provider revision"),
         Sha256Digest::from_bytes([3; 32]),

--- a/crates/automata-ci-provider-github/tests/delivery_adapter.rs
+++ b/crates/automata-ci-provider-github/tests/delivery_adapter.rs
@@ -3,7 +3,7 @@ use crate::support::{
     signed_webhook_headers,
 };
 
-use automata_ci_core::{GitObjectId, Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{GitObjectId, ManagedTenantId, Sha256Digest, UnixMillis};
 use automata_ci_key_management::SecretBytes;
 use automata_ci_provider::{
     DeliveryAdapter as _, ExternalRepositoryId, ExternalRepositoryIdentity, NormalizedTrigger,
@@ -83,7 +83,7 @@ impl Fixture {
         .document()
         .expect("policy document");
         let configuration = ProviderConnectionConfiguration::new(
-            WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+            ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
             ExternalRepositoryIdentity::new(
                 instance_id,
                 ExternalRepositoryId::new(repository_id).expect("repository ID"),

--- a/crates/automata-ci-provider-github/tests/factory.rs
+++ b/crates/automata-ci-provider-github/tests/factory.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use automata_ci_core::{Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{ManagedTenantId, Sha256Digest, UnixMillis};
 use automata_ci_key_management::SecretBytes;
 use automata_ci_provider::{
     ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits, ProviderCapability,
@@ -103,7 +103,7 @@ fn connection(
     repository: &str,
 ) -> ProviderConnectionManifest {
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
         ExternalRepositoryIdentity::new(
             instance.instance_id(),
             ExternalRepositoryId::new(external_repository_id).expect("external repository ID"),

--- a/crates/automata-ci-provider-postgres/src/connection.rs
+++ b/crates/automata-ci-provider-postgres/src/connection.rs
@@ -1,4 +1,4 @@
-use automata_ci_core::WorkspaceId;
+use automata_ci_core::ManagedTenantId;
 use automata_ci_provider::{
     ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits,
     ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
@@ -19,7 +19,7 @@ struct ConnectionRow {
     connection_id: uuid::Uuid,
     revision: i64,
     lifecycle_state: String,
-    workspace_id: String,
+    tenant_id: String,
     provider_instance_id: uuid::Uuid,
     external_repository_id: String,
     provider_revision: i64,
@@ -228,13 +228,13 @@ async fn ensure_connection_references(
     .fetch_one(&mut **transaction)
     .await
     .map_err(unavailable)?;
-    let workspace_exists =
+    let tenant_exists =
         sqlx::query_scalar::<_, bool>("SELECT EXISTS (SELECT 1 FROM tenants WHERE id = $1)")
-            .bind(configuration.workspace_id().to_string())
+            .bind(configuration.tenant_id().to_string())
             .fetch_one(&mut **transaction)
             .await
             .map_err(unavailable)?;
-    if !provider_exists || !workspace_exists {
+    if !provider_exists || !tenant_exists {
         return Err(ProviderRepositoryError::NotFound);
     }
     Ok(())
@@ -253,7 +253,7 @@ async fn insert_connection(
     sqlx::query(
         r"
         INSERT INTO provider_connection_revisions (
-            connection_id, revision, lifecycle_state, workspace_id,
+            connection_id, revision, lifecycle_state, tenant_id,
             provider_instance_id, external_repository_id, provider_revision,
             provider_configuration_digest, capability_digest,
             repository_visibility, default_branch, workflow_source_kind,
@@ -272,7 +272,7 @@ async fn insert_connection(
     .bind(manifest.connection_id().as_uuid())
     .bind(i64::try_from(manifest.revision().get()).map_err(|_| ProviderRepositoryError::Corrupt)?)
     .bind(lifecycle_text(manifest.state()))
-    .bind(configuration.workspace_id().to_string())
+    .bind(configuration.tenant_id().to_string())
     .bind(configuration.repository().instance_id().as_uuid())
     .bind(configuration.repository().external_id().as_str())
     .bind(
@@ -368,7 +368,7 @@ fn decode_connection(
         return Err(ProviderRepositoryError::Corrupt);
     }
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse(&row.workspace_id).map_err(|_| ProviderRepositoryError::Corrupt)?,
+        ManagedTenantId::parse(&row.tenant_id).map_err(|_| ProviderRepositoryError::Corrupt)?,
         ExternalRepositoryIdentity::new(
             instance_id,
             ExternalRepositoryId::new(row.external_repository_id)

--- a/crates/automata-ci-provider-postgres/tests/postgres.rs
+++ b/crates/automata-ci-provider-postgres/tests/postgres.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use automata_ci_core::{
-    GitObjectAlgorithm, GitObjectId, RunId, Sha256Digest, TrustEventKind, TrustEvidence,
-    TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustTokenRecursion, UnixMillis,
-    WorkflowId, WorkflowJobKey, WorkspaceId,
+    GitObjectAlgorithm, GitObjectId, ManagedTenantId, RunId, Sha256Digest, TrustEventKind,
+    TrustEvidence, TrustOriginKind, TrustPolicy, TrustRepositoryEvidence, TrustTokenRecursion,
+    UnixMillis, WorkflowId, WorkflowJobKey,
 };
 use automata_ci_key_management::{KeyId, LocalAes256GcmKeyring, LocalKeyMaterial, SecretBytes};
 use automata_ci_postgres::test_support::{TestResult, run_with_database};
@@ -140,20 +140,20 @@ fn instance_record(
 }
 
 fn connection(
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     instance: &ProviderInstanceManifest,
 ) -> ProviderConnectionManifest {
-    connection_for(workspace_id, instance, 99, "42")
+    connection_for(tenant_id, instance, 99, "42")
 }
 
 fn connection_for(
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     instance: &ProviderInstanceManifest,
     connection_id: u128,
     external_repository_id: &str,
 ) -> ProviderConnectionManifest {
     let configuration = ProviderConnectionConfiguration::new(
-        workspace_id,
+        tenant_id,
         ExternalRepositoryIdentity::new(
             instance.instance_id(),
             ExternalRepositoryId::new(external_repository_id).expect("repository"),
@@ -198,13 +198,13 @@ fn connection_for(
 }
 
 fn connection_with_runner_policy(
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     instance: &ProviderInstanceManifest,
     runner_policy: ProviderRunnerPolicyBinding,
 ) -> ProviderConnectionManifest {
-    let mut connection = connection(workspace_id, instance);
+    let mut connection = connection(tenant_id, instance);
     let configuration = ProviderConnectionConfiguration::new(
-        workspace_id,
+        tenant_id,
         connection.configuration().repository().clone(),
         instance.revision(),
         instance.configuration().digest(),
@@ -441,27 +441,27 @@ async fn instance_and_connection_revisions_are_atomic_encrypted_and_exact() -> T
             TOKEN
         );
 
-        let workspace = WorkspaceId::parse("11111111-1111-4111-8111-111111111111")?;
+        let tenant = ManagedTenantId::parse("11111111-1111-4111-8111-111111111111")?;
         assert_eq!(
             repository
-                .save_connection(connection(workspace, current.manifest()))
+                .save_connection(connection(tenant, current.manifest()))
                 .await,
             Err(ProviderRepositoryError::NotFound)
         );
         sqlx::query(
             "INSERT INTO tenants (id, display_name, created_at_ms, updated_at_ms) VALUES ($1, 'Provider test', 1, 1)",
         )
-        .bind(workspace.to_string())
+        .bind(tenant.to_string())
         .execute(database.pool())
         .await?;
-        let first_connection = connection(workspace, current.manifest());
+        let first_connection = connection(tenant, current.manifest());
         assert_eq!(
             repository.save_connection(first_connection).await?,
             ProviderSaveOutcome::Inserted
         );
         assert_eq!(
             repository
-                .save_connection(connection(workspace, current.manifest()))
+                .save_connection(connection(tenant, current.manifest()))
                 .await?,
             ProviderSaveOutcome::Unchanged
         );
@@ -471,7 +471,7 @@ async fn instance_and_connection_revisions_are_atomic_encrypted_and_exact() -> T
             )
             .await?
             .expect("current connection");
-        assert_eq!(loaded_connection.configuration().workspace_id(), workspace);
+        assert_eq!(loaded_connection.configuration().tenant_id(), tenant);
         assert_eq!(
             loaded_connection
                 .configuration()
@@ -548,11 +548,11 @@ async fn disabled_endpoint_does_not_require_an_active_connection() -> TestResult
 async fn provider_results_are_contiguous_fenced_and_rehydratable() -> TestResult {
     run_with_database(|database| async move {
         let repository = repository(database.pool().clone());
-        let workspace = WorkspaceId::from_uuid(Uuid::from_u128(0x5900))?;
+        let tenant = ManagedTenantId::from_uuid(Uuid::from_u128(0x5900))?;
         sqlx::query(
             "INSERT INTO tenants (id, display_name, created_at_ms, updated_at_ms) VALUES ($1, 'Provider results', 1, 1)",
         )
-        .bind(workspace.to_string())
+        .bind(tenant.to_string())
         .execute(database.pool())
         .await?;
         let instance_id = ProviderInstanceId::from_uuid(Uuid::from_u128(0x5901))?;
@@ -571,7 +571,7 @@ async fn provider_results_are_contiguous_fenced_and_rehydratable() -> TestResult
             .current_instance(instance_id)
             .await?
             .expect("provider instance");
-        let connection = connection(workspace, instance.manifest());
+        let connection = connection(tenant, instance.manifest());
         repository.save_connection(connection.clone()).await?;
 
         let subject = ProviderResultSubject::new(
@@ -857,8 +857,8 @@ async fn provider_results_are_contiguous_fenced_and_rehydratable() -> TestResult
 async fn github_result_credentials_revalidate_the_common_result_lease() -> TestResult {
     run_with_database(|database| async move {
         let manifests = repository(database.pool().clone());
-        let workspace = WorkspaceId::from_uuid(Uuid::from_u128(0x5a00))?;
-        let tenant = workspace.to_string();
+        let managed_tenant = ManagedTenantId::from_uuid(Uuid::from_u128(0x5a00))?;
+        let tenant = managed_tenant.to_string();
         let internal_repository_id = RepositoryId::from_uuid(Uuid::from_u128(0x5a01));
         sqlx::query(
             "INSERT INTO tenants (id, display_name, created_at_ms, updated_at_ms) VALUES ($1, 'GitHub result authority', 1, 1)",
@@ -895,7 +895,7 @@ async fn github_result_credentials_revalidate_the_common_result_lease() -> TestR
             .current_instance(instance_id)
             .await?
             .expect("GitHub provider instance");
-        let connection = connection(workspace, instance.manifest());
+        let connection = connection(managed_tenant, instance.manifest());
         manifests.save_connection(connection.clone()).await?;
 
         let subject = ProviderResultSubject::new(
@@ -1325,13 +1325,13 @@ async fn provider_admission_binds_normalized_trigger_and_replays_after_claim_rot
             .current_instance(instance_id)
             .await?
             .expect("provider instance");
-        let workspace = WorkspaceId::parse("00000000-0000-4000-8000-000000005142")?;
-        let tenant = workspace.to_string();
+        let managed_tenant = ManagedTenantId::parse("00000000-0000-4000-8000-000000005142")?;
+        let tenant = managed_tenant.to_string();
         let repository_id = RepositoryId::from_uuid(Uuid::from_u128(0x5149));
         sqlx::query(
             "INSERT INTO tenants (id, display_name, created_at_ms, updated_at_ms) VALUES ($1, 'Provider admission test', 1, 1)",
         )
-        .bind(workspace.to_string())
+        .bind(managed_tenant.to_string())
         .execute(database.pool())
         .await?;
         let runtime_policy = WorkflowRuntimePolicy::decode_configuration(RUNTIME_POLICY)?;
@@ -1339,7 +1339,8 @@ async fn provider_admission_binds_normalized_trigger_and_replays_after_claim_rot
             ProviderSchemaVersion::new(runtime_policy.schema())?,
             runtime_policy.canonical_digest(),
         );
-        let connection = connection_with_runner_policy(workspace, instance.manifest(), runner_policy);
+        let connection =
+            connection_with_runner_policy(managed_tenant, instance.manifest(), runner_policy);
         repository.save_connection(connection.clone()).await?;
         seed_provider_runtime_policy(
             database.pool(),
@@ -1637,16 +1638,16 @@ async fn endpoint_secrets_replay_conflicts_and_worker_fences_are_exact() -> Test
             .current_instance(instance_id)
             .await?
             .expect("instance");
-        let workspace = WorkspaceId::parse("22222222-2222-4222-8222-222222222222")?;
+        let tenant = ManagedTenantId::parse("22222222-2222-4222-8222-222222222222")?;
         sqlx::query(
             "INSERT INTO tenants (id, display_name, created_at_ms, updated_at_ms) VALUES ($1, 'Delivery test', 1, 1)",
         )
-        .bind(workspace.to_string())
+        .bind(tenant.to_string())
         .execute(database.pool())
         .await?;
-        let connection = connection(workspace, instance.manifest());
+        let connection = connection(tenant, instance.manifest());
         repository.save_connection(connection.clone()).await?;
-        let second_connection = connection_for(workspace, instance.manifest(), 100, "43");
+        let second_connection = connection_for(tenant, instance.manifest(), 100, "43");
         repository
             .save_connection(second_connection.clone())
             .await?;

--- a/crates/automata-ci-provider/src/connection.rs
+++ b/crates/automata-ci-provider/src/connection.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt, num::NonZeroU64};
 
-use automata_ci_core::{Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{ManagedTenantId, Sha256Digest, UnixMillis};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
@@ -432,7 +432,7 @@ impl ProviderConnectionPolicyDocument {
 /// Complete provider-neutral configuration of one repository connection.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProviderConnectionConfiguration {
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     repository: ExternalRepositoryIdentity,
     provider_revision: ProviderConfigurationRevision,
     provider_configuration_digest: Sha256Digest,
@@ -451,7 +451,7 @@ impl ProviderConnectionConfiguration {
     #[allow(clippy::too_many_arguments)]
     #[must_use]
     pub fn new(
-        workspace_id: WorkspaceId,
+        tenant_id: ManagedTenantId,
         repository: ExternalRepositoryIdentity,
         provider_revision: ProviderConfigurationRevision,
         provider_configuration_digest: Sha256Digest,
@@ -464,7 +464,7 @@ impl ProviderConnectionConfiguration {
         adapter_policy: ProviderConnectionPolicyDocument,
     ) -> Self {
         let mut value = Self {
-            workspace_id,
+            tenant_id,
             repository,
             provider_revision,
             provider_configuration_digest,
@@ -481,10 +481,10 @@ impl ProviderConnectionConfiguration {
         value
     }
 
-    /// Returns the owning workspace.
+    /// Returns the owning tenant.
     #[must_use]
-    pub const fn workspace_id(&self) -> WorkspaceId {
-        self.workspace_id
+    pub const fn tenant_id(&self) -> ManagedTenantId {
+        self.tenant_id
     }
 
     /// Returns the instance-scoped provider repository identity.
@@ -556,7 +556,7 @@ impl ProviderConnectionConfiguration {
     fn compute_digest(&self) -> Sha256Digest {
         let mut hash = Sha256::new();
         hash.update(CONNECTION_CONFIGURATION_DIGEST_DOMAIN);
-        part(&mut hash, self.workspace_id.as_uuid().as_bytes());
+        part(&mut hash, self.tenant_id.as_uuid().as_bytes());
         part(
             &mut hash,
             self.repository.instance_id().as_uuid().as_bytes(),
@@ -609,7 +609,7 @@ pub struct ProviderConnectionDraft {
     connection_id: ProviderConnectionId,
     revision: ProviderConnectionRevision,
     state: ProviderLifecycleState,
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     external_repository_id: ExternalRepositoryId,
     visibility: RepositoryVisibility,
     default_branch: ProviderDefaultBranch,
@@ -633,7 +633,7 @@ impl ProviderConnectionDraft {
         connection_id: ProviderConnectionId,
         revision: ProviderConnectionRevision,
         state: ProviderLifecycleState,
-        workspace_id: WorkspaceId,
+        tenant_id: ManagedTenantId,
         external_repository_id: ExternalRepositoryId,
         visibility: RepositoryVisibility,
         default_branch: ProviderDefaultBranch,
@@ -651,7 +651,7 @@ impl ProviderConnectionDraft {
             connection_id,
             revision,
             state,
-            workspace_id,
+            tenant_id,
             external_repository_id,
             visibility,
             default_branch,
@@ -670,7 +670,7 @@ impl ProviderConnectionDraft {
         provider: &ProviderInstanceManifest,
     ) -> Result<ProviderConnectionManifest, ProviderConnectionError> {
         let configuration = ProviderConnectionConfiguration::new(
-            self.workspace_id,
+            self.tenant_id,
             ExternalRepositoryIdentity::new(provider.instance_id(), self.external_repository_id),
             provider.revision(),
             provider.configuration().digest(),
@@ -701,7 +701,7 @@ impl fmt::Debug for ProviderConnectionDraft {
             .field("connection_id", &self.connection_id)
             .field("revision", &self.revision)
             .field("state", &self.state)
-            .field("workspace_id", &self.workspace_id)
+            .field("tenant_id", &self.tenant_id)
             .field("external_repository_id", &self.external_repository_id)
             .field("visibility", &self.visibility)
             .field("default_branch", &self.default_branch)

--- a/crates/automata-ci-provider/tests/configuration.rs
+++ b/crates/automata-ci-provider/tests/configuration.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use automata_ci_core::{GitObjectAlgorithm, Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{GitObjectAlgorithm, ManagedTenantId, Sha256Digest, UnixMillis};
 use automata_ci_key_management::SecretBytes;
 use automata_ci_provider::{
     ExternalRepositoryId, ExternalRepositoryIdentity, MAX_PROVIDER_SCHEMA_VERSION,
@@ -176,7 +176,7 @@ fn connection_manifest(
     provider_configuration_digest: Sha256Digest,
 ) -> ProviderConnectionManifest {
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
         ExternalRepositoryIdentity::new(
             instance.instance_id(),
             ExternalRepositoryId::new("42").expect("repository"),
@@ -389,7 +389,7 @@ fn registry_materializes_capability_bound_records_without_caller_digest_authorit
                 ProviderConnectionId::from_uuid(Uuid::from_u128(72)).expect("connection ID"),
                 ProviderConnectionRevision::new(1).expect("connection revision"),
                 ProviderLifecycleState::Active,
-                WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+                ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
                 ExternalRepositoryId::new("repository-42").expect("repository ID"),
                 RepositoryVisibility::Private,
                 ProviderDefaultBranch::new("main").expect("branch"),

--- a/crates/automata-ci-provider/tests/connection.rs
+++ b/crates/automata-ci-provider/tests/connection.rs
@@ -1,4 +1,4 @@
-use automata_ci_core::{Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{ManagedTenantId, Sha256Digest, UnixMillis};
 use automata_ci_provider::{
     ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits,
     ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionError,
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 fn configuration(visibility: RepositoryVisibility) -> ProviderConnectionConfiguration {
     ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
         ExternalRepositoryIdentity::new(
             ProviderInstanceId::from_uuid(Uuid::from_u128(2)).expect("instance"),
             ExternalRepositoryId::new("repository-42").expect("repository"),

--- a/crates/automata-ci-provider/tests/credential_and_identity.rs
+++ b/crates/automata-ci-provider/tests/credential_and_identity.rs
@@ -1,6 +1,6 @@
 use automata_ci_core::{
     AttemptId, AttemptNumber, FencingToken, GitObjectAlgorithm, JobId, Lease, LeaseId,
-    PermissionLevel, RunnerId, Sha256Digest, TrustSourceClass, UnixMillis, WorkspaceId,
+    ManagedTenantId, PermissionLevel, RunnerId, Sha256Digest, TrustSourceClass, UnixMillis,
 };
 use automata_ci_provider::{
     AuthorizationCodeRequest, ControlCredential, ControlCredentialRequest,
@@ -35,7 +35,7 @@ fn instance(value: u128) -> ProviderInstanceId {
 
 fn connection() -> ProviderConnectionManifest {
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").unwrap(),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").unwrap(),
         ExternalRepositoryIdentity::new(instance(2), ExternalRepositoryId::new("repo-42").unwrap()),
         ProviderConfigurationRevision::new(3).unwrap(),
         Sha256Digest::from_bytes([3; 32]),

--- a/crates/automata-ci-provider/tests/delivery.rs
+++ b/crates/automata-ci-provider/tests/delivery.rs
@@ -6,7 +6,9 @@ use std::{
     },
 };
 
-use automata_ci_core::{GitObjectAlgorithm, GitObjectId, Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{
+    GitObjectAlgorithm, GitObjectId, ManagedTenantId, Sha256Digest, UnixMillis,
+};
 use automata_ci_key_management::SecretBytes;
 use automata_ci_provider::{
     AuthenticatedProviderWebhook, CompleteProviderProcessing, DeliveryAdapter,
@@ -231,7 +233,7 @@ fn connection_for(
     external_repository_id: &str,
 ) -> ProviderConnectionManifest {
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
         ExternalRepositoryIdentity::new(
             endpoint.instance_id(),
             ExternalRepositoryId::new(external_repository_id).expect("repository ID"),

--- a/crates/automata-ci-provider/tests/result.rs
+++ b/crates/automata-ci-provider/tests/result.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use automata_ci_core::{GitObjectId, RunId, Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{GitObjectId, ManagedTenantId, RunId, Sha256Digest, UnixMillis};
 use automata_ci_provider::{
     ClaimProviderResult, ClaimedProviderResult, CommitStatusCapability, CommitStatusState,
     CompleteProviderResult, DesiredProviderResult, ExternalRepositoryId,
@@ -26,7 +26,7 @@ use uuid::Uuid;
 
 fn connection() -> ProviderConnectionManifest {
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").unwrap(),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").unwrap(),
         ExternalRepositoryIdentity::new(
             "22222222-2222-4222-8222-222222222222".parse().unwrap(),
             ExternalRepositoryId::new("repository-42").unwrap(),

--- a/crates/automata-ci-provisioning-grpc/Cargo.toml
+++ b/crates/automata-ci-provisioning-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automata-ci-provisioning-grpc"
-description = "mTLS gRPC adapter for Automata Core workspace provisioning"
+description = "mTLS gRPC adapter for Automata Core tenant provisioning"
 publish.workspace = true
 version.workspace = true
 edition.workspace = true

--- a/crates/automata-ci-provisioning-grpc/README.md
+++ b/crates/automata-ci-provisioning-grpc/README.md
@@ -7,7 +7,7 @@ and
 schemas over gRPC/HTTP/2. The currently composed management service requires a
 client certificate at the TLS handshake, authenticates that verified
 certificate chain for every request, validates and scope-checks the domain
-command, and calls transport-neutral workspace provisioning or
+command, and calls transport-neutral tenant provisioning or
 entitlement/provider desired-state application ports.
 
 The server accepts a pre-bound listener so the product composition root retains
@@ -17,7 +17,7 @@ standalone self-hosted deployments expose no placeholder endpoint. The product
 maps a dedicated-CA-verified leaf certificate through an exact SHA-256 pin to a
 stable shard-scoped authority, and supplies the durable
 `automata-ci-provisioning-postgres` management transaction adapters.
-Entitlement snapshots are complete, monotonically revisioned workspace
+Entitlement snapshots are complete, monotonically revisioned tenant
 aggregates; the contract does not allocate rolling per-job budget slices.
 
 The usage-export schema defines an authority-scoped, cursor-paginated feed of
@@ -27,7 +27,7 @@ service atomically with Core accounting before capability discovery announces
 support.
 
 The management service also accepts a complete shard-wide GitHub App
-configuration and complete repository selection revisions per workspace. App
+configuration and complete repository selection revisions per tenant. App
 private-key and webhook-secret bytes travel only over the authenticated mTLS
 channel and are envelope-encrypted by the PostgreSQL adapter before commit.
 Once that configuration exists, a separate idempotent RPC can replace the

--- a/crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_management.proto
+++ b/crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_management.proto
@@ -9,17 +9,17 @@ import "google/protobuf/duration.proto";
 // control plane. This service is not exposed to browsers, runners, or human
 // sessions.
 service ShardManagementService {
-  // Atomically creates one workspace and its initial external owner mapping.
+  // Atomically creates one tenant and its initial external owner mapping.
   // Replaying the same operation and semantic request returns the original
   // stable response without repeating effects.
-  rpc ProvisionWorkspace(ProvisionWorkspaceRequest) returns (ProvisionWorkspaceResponse) {
+  rpc ProvisionTenant(ProvisionTenantRequest) returns (ProvisionTenantResponse) {
     option idempotency_level = IDEMPOTENT;
   }
 
   // Applies a complete, monotonically revisioned execution-entitlement
-  // snapshot to a workspace managed by this external authority. This is a
-  // workspace aggregate, not a per-job rolling execution lease.
-  rpc ApplyWorkspaceEntitlement(ApplyWorkspaceEntitlementRequest) returns (ApplyWorkspaceEntitlementResponse) {
+  // snapshot to a tenant managed by this external authority. This is a
+  // tenant aggregate, not a per-job rolling execution lease.
+  rpc ApplyTenantEntitlement(ApplyTenantEntitlementRequest) returns (ApplyTenantEntitlementResponse) {
     option idempotency_level = IDEMPOTENT;
   }
 
@@ -36,25 +36,25 @@ service ShardManagementService {
     option idempotency_level = IDEMPOTENT;
   }
 
-  // Replaces one workspace's complete selected GitHub repository set. Omitted
+  // Replaces one tenant's complete selected GitHub repository set. Omitted
   // repositories are disconnected by this revision.
-  rpc ApplyWorkspaceGithubRepositories(ApplyWorkspaceGithubRepositoriesRequest) returns (ApplyWorkspaceGithubRepositoriesResponse) {
+  rpc ApplyTenantGithubRepositories(ApplyTenantGithubRepositoriesRequest) returns (ApplyTenantGithubRepositoriesResponse) {
     option idempotency_level = IDEMPOTENT;
   }
 }
 
-// Identifies the workspace that Core must create.
-message WorkspaceProvisioningTarget {
+// Identifies the tenant that Core must create.
+message TenantProvisioningTarget {
   // External-control-plane-generated, non-nil canonical lower-case UUID. Core
   // persists this exact value as the tenant identity.
-  string workspace_id = 1;
+  string tenant_id = 1;
 
   // Non-authoritative, trimmed display label.
   string display_name = 2;
 }
 
 // Identifies the external human who receives the initial owner membership.
-message InitialWorkspaceOwner {
+message InitialTenantOwner {
   // Exact configured HTTPS issuer origin for delegated actor assertions.
   string issuer = 1;
 
@@ -65,8 +65,8 @@ message InitialWorkspaceOwner {
   string display_name = 3;
 }
 
-// Durable, idempotent request to provision one workspace.
-message ProvisionWorkspaceRequest {
+// Durable, idempotent request to provision one tenant.
+message ProvisionTenantRequest {
   // Stable non-nil canonical lower-case UUID generated before the first
   // network attempt and reused across every retry.
   string operation_id = 1;
@@ -75,23 +75,23 @@ message ProvisionWorkspaceRequest {
   // discovery.
   string shard_id = 2;
 
-  // Workspace identity and initial label.
-  WorkspaceProvisioningTarget workspace = 3;
+  // Tenant identity and initial label.
+  TenantProvisioningTarget tenant = 3;
 
   // External identity that receives Core's fixed initial-owner role.
-  InitialWorkspaceOwner initial_owner = 4;
+  InitialTenantOwner initial_owner = 4;
 }
 
 // Stable result stored by Core in the provisioning transaction.
-message ProvisionWorkspaceResponse {
+message ProvisionTenantResponse {
   // Operation identity from the request.
   string operation_id = 1;
 
   // Immutable identity of the shard that committed the operation.
   string shard_id = 2;
 
-  // Workspace identity from the request and resulting Core tenant.
-  string workspace_id = 3;
+  // Tenant identity from the request and resulting Core tenant.
+  string tenant_id = 3;
 
   // Core-owned, shard-local principal created or reused for the initial owner.
   string initial_owner_principal_id = 4;
@@ -101,24 +101,24 @@ message ProvisionWorkspaceResponse {
 }
 
 // Stable machine-readable reason attached to a failed provisioning RPC.
-enum ProvisionWorkspaceFailureReason {
-  PROVISION_WORKSPACE_FAILURE_REASON_UNSPECIFIED = 0;
-  PROVISION_WORKSPACE_FAILURE_REASON_INVALID_REQUEST = 1;
-  PROVISION_WORKSPACE_FAILURE_REASON_UNAUTHENTICATED = 2;
-  PROVISION_WORKSPACE_FAILURE_REASON_FORBIDDEN = 3;
-  PROVISION_WORKSPACE_FAILURE_REASON_OPERATION_CONFLICT = 4;
-  PROVISION_WORKSPACE_FAILURE_REASON_WORKSPACE_CONFLICT = 5;
-  PROVISION_WORKSPACE_FAILURE_REASON_PRINCIPAL_UNAVAILABLE = 6;
-  PROVISION_WORKSPACE_FAILURE_REASON_RATE_LIMITED = 7;
-  PROVISION_WORKSPACE_FAILURE_REASON_INTERNAL_ERROR = 8;
-  PROVISION_WORKSPACE_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 9;
+enum ProvisionTenantFailureReason {
+  PROVISION_TENANT_FAILURE_REASON_UNSPECIFIED = 0;
+  PROVISION_TENANT_FAILURE_REASON_INVALID_REQUEST = 1;
+  PROVISION_TENANT_FAILURE_REASON_UNAUTHENTICATED = 2;
+  PROVISION_TENANT_FAILURE_REASON_FORBIDDEN = 3;
+  PROVISION_TENANT_FAILURE_REASON_OPERATION_CONFLICT = 4;
+  PROVISION_TENANT_FAILURE_REASON_TENANT_CONFLICT = 5;
+  PROVISION_TENANT_FAILURE_REASON_PRINCIPAL_UNAVAILABLE = 6;
+  PROVISION_TENANT_FAILURE_REASON_RATE_LIMITED = 7;
+  PROVISION_TENANT_FAILURE_REASON_INTERNAL_ERROR = 8;
+  PROVISION_TENANT_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 9;
 }
 
 // Typed detail carried in google.rpc.Status.details when the failure occurs
 // after Core can safely construct contract-specific details. Authentication
 // and transport failures may contain only the ordinary gRPC status.
-message ProvisionWorkspaceFailure {
-  ProvisionWorkspaceFailureReason reason = 1;
+message ProvisionTenantFailure {
+  ProvisionTenantFailureReason reason = 1;
 
   // Opaque request correlation identifier safe to expose to the caller.
   string request_id = 2;
@@ -128,7 +128,7 @@ message ProvisionWorkspaceFailure {
 // may exceed the allowance by a small bounded amount while it observes the
 // threshold and delivers cancellation. That enforcement tolerance does not
 // increase the configured allowance.
-message CappedWorkspaceExecution {
+message CappedTenantExecution {
   // Positive aggregate compute allowance at whole-second API granularity.
   uint64 compute_seconds = 1;
 
@@ -138,23 +138,23 @@ message CappedWorkspaceExecution {
 }
 
 // Metered execution with no Core-enforced aggregate compute ceiling.
-message UncappedWorkspaceExecution {}
+message UncappedTenantExecution {}
 
 // Execution is disabled. Core rejects new work and cancels active work when
 // enforcement observes this policy.
-message PausedWorkspaceExecution {}
+message PausedTenantExecution {}
 
-// Complete execution policy for one workspace entitlement revision.
-message WorkspaceExecutionEntitlement {
+// Complete execution policy for one tenant entitlement revision.
+message TenantExecutionEntitlement {
   oneof policy {
-    CappedWorkspaceExecution capped = 1;
-    UncappedWorkspaceExecution uncapped = 2;
-    PausedWorkspaceExecution paused = 3;
+    CappedTenantExecution capped = 1;
+    UncappedTenantExecution uncapped = 2;
+    PausedTenantExecution paused = 3;
   }
 }
 
-// Durable, idempotent request to replace one workspace's entitlement snapshot.
-message ApplyWorkspaceEntitlementRequest {
+// Durable, idempotent request to replace one tenant's entitlement snapshot.
+message ApplyTenantEntitlementRequest {
   // Stable non-nil canonical lower-case UUID generated before the first
   // network attempt and reused across every retry.
   string operation_id = 1;
@@ -163,22 +163,22 @@ message ApplyWorkspaceEntitlementRequest {
   // discovery.
   string shard_id = 2;
 
-  // Externally managed workspace as a non-nil canonical lower-case UUID.
-  string workspace_id = 3;
+  // Externally managed tenant as a non-nil canonical lower-case UUID.
+  string tenant_id = 3;
 
-  // Positive, monotonically increasing workspace revision. Gaps are allowed;
+  // Positive, monotonically increasing tenant revision. Gaps are allowed;
   // a revision at or below the current value is stale.
   uint64 revision = 4;
 
   // Complete execution policy replacing the prior policy.
-  WorkspaceExecutionEntitlement execution = 5;
+  TenantExecutionEntitlement execution = 5;
 }
 
 // Stable result stored by Core in the entitlement transaction.
-message ApplyWorkspaceEntitlementResponse {
+message ApplyTenantEntitlementResponse {
   string operation_id = 1;
   string shard_id = 2;
-  string workspace_id = 3;
+  string tenant_id = 3;
   uint64 revision = 4;
 
   // Canonical Core database time. This value remains stable on replay.
@@ -189,23 +189,23 @@ message ApplyWorkspaceEntitlementResponse {
 }
 
 // Stable machine-readable reason attached to a failed entitlement RPC.
-enum ApplyWorkspaceEntitlementFailureReason {
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_UNSPECIFIED = 0;
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_INVALID_REQUEST = 1;
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_UNAUTHENTICATED = 2;
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_FORBIDDEN = 3;
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_OPERATION_CONFLICT = 4;
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_STALE_REVISION = 5;
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_WORKSPACE_UNAVAILABLE = 6;
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_RATE_LIMITED = 7;
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_INTERNAL_ERROR = 8;
-  APPLY_WORKSPACE_ENTITLEMENT_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 9;
+enum ApplyTenantEntitlementFailureReason {
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_UNSPECIFIED = 0;
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_INVALID_REQUEST = 1;
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_UNAUTHENTICATED = 2;
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_FORBIDDEN = 3;
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_OPERATION_CONFLICT = 4;
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_STALE_REVISION = 5;
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_TENANT_UNAVAILABLE = 6;
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_RATE_LIMITED = 7;
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_INTERNAL_ERROR = 8;
+  APPLY_TENANT_ENTITLEMENT_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 9;
 }
 
 // Typed detail carried in google.rpc.Status.details after Core can safely
 // construct contract-specific details.
-message ApplyWorkspaceEntitlementFailure {
-  ApplyWorkspaceEntitlementFailureReason reason = 1;
+message ApplyTenantEntitlementFailure {
+  ApplyTenantEntitlementFailureReason reason = 1;
 }
 
 enum GithubAppJwtIssuer {
@@ -321,35 +321,35 @@ message GithubRepositorySelection {
   GithubJobAuthorityProfile authority_profile = 7;
 }
 
-message ApplyWorkspaceGithubRepositoriesRequest {
+message ApplyTenantGithubRepositoriesRequest {
   string operation_id = 1;
   string shard_id = 2;
-  string workspace_id = 3;
+  string tenant_id = 3;
   uint64 revision = 4;
   repeated GithubRepositorySelection repositories = 5;
 }
 
-message ApplyWorkspaceGithubRepositoriesResponse {
+message ApplyTenantGithubRepositoriesResponse {
   string operation_id = 1;
   string shard_id = 2;
-  string workspace_id = 3;
+  string tenant_id = 3;
   uint64 revision = 4;
   google.protobuf.Timestamp applied_at = 5;
 }
 
-enum ApplyWorkspaceGithubRepositoriesFailureReason {
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_UNSPECIFIED = 0;
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_INVALID_REQUEST = 1;
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_UNAUTHENTICATED = 2;
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_FORBIDDEN = 3;
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_OPERATION_CONFLICT = 4;
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_STALE_REVISION = 5;
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_WORKSPACE_UNAVAILABLE = 6;
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_INTERNAL_ERROR = 7;
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 8;
-  APPLY_WORKSPACE_GITHUB_REPOSITORIES_FAILURE_REASON_SHARD_REGISTRY_CONFLICT = 9;
+enum ApplyTenantGithubRepositoriesFailureReason {
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_UNSPECIFIED = 0;
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_INVALID_REQUEST = 1;
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_UNAUTHENTICATED = 2;
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_FORBIDDEN = 3;
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_OPERATION_CONFLICT = 4;
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_STALE_REVISION = 5;
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_TENANT_UNAVAILABLE = 6;
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_INTERNAL_ERROR = 7;
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 8;
+  APPLY_TENANT_GITHUB_REPOSITORIES_FAILURE_REASON_SHARD_REGISTRY_CONFLICT = 9;
 }
 
-message ApplyWorkspaceGithubRepositoriesFailure {
-  ApplyWorkspaceGithubRepositoriesFailureReason reason = 1;
+message ApplyTenantGithubRepositoriesFailure {
+  ApplyTenantGithubRepositoriesFailureReason reason = 1;
 }

--- a/crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_usage.proto
+++ b/crates/automata-ci-provisioning-grpc/proto/automata/management/v1/shard_usage.proto
@@ -11,13 +11,13 @@ service ShardUsageExportService {
   // Returns a stable page after an opaque exclusive cursor. Retrying a page is
   // safe: consumers deduplicate by event_id and advance their stored cursor in
   // the same transaction that durably accepts the returned events.
-  rpc ListWorkspaceUsage(ListWorkspaceUsageRequest) returns (ListWorkspaceUsageResponse) {
+  rpc ListTenantUsage(ListTenantUsageRequest) returns (ListTenantUsageResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 }
 
 // Authority-scoped cursor-pull request for one shard.
-message ListWorkspaceUsageRequest {
+message ListTenantUsageRequest {
   // Expected immutable shard identity, already verified through capability
   // discovery and checked against the authenticated workload authority.
   string shard_id = 1;
@@ -33,15 +33,15 @@ message ListWorkspaceUsageRequest {
 
 // One immutable actual-execution fact. This is provider-neutral usage, not a
 // price, Stripe meter event, invoice line, or guarantee that usage is billable.
-message WorkspaceUsageEvent {
+message TenantUsageEvent {
   // Globally stable, non-nil canonical lower-case UUID used for idempotency.
   string event_id = 1;
 
   // Immutable identity of the shard that recorded the event.
   string shard_id = 2;
 
-  // Externally managed workspace as a non-nil canonical lower-case UUID.
-  string workspace_id = 3;
+  // Externally managed tenant as a non-nil canonical lower-case UUID.
+  string tenant_id = 3;
 
   // Core execution attempt as a non-nil canonical lower-case UUID. Several
   // events may cover non-overlapping intervals of one attempt.
@@ -61,28 +61,28 @@ message WorkspaceUsageEvent {
 
 // Stable feed page. An empty page is valid and retains a continuation cursor
 // from which a later poll can observe newly appended events.
-message ListWorkspaceUsageResponse {
+message ListTenantUsageResponse {
   // Events in stable append order after the request cursor.
-  repeated WorkspaceUsageEvent events = 1;
+  repeated TenantUsageEvent events = 1;
 
   // Opaque exclusive position after every event in this response.
   bytes next_cursor = 2;
 }
 
 // Stable machine-readable reason attached to a failed usage-export RPC.
-enum ListWorkspaceUsageFailureReason {
-  LIST_WORKSPACE_USAGE_FAILURE_REASON_UNSPECIFIED = 0;
-  LIST_WORKSPACE_USAGE_FAILURE_REASON_INVALID_REQUEST = 1;
-  LIST_WORKSPACE_USAGE_FAILURE_REASON_UNAUTHENTICATED = 2;
-  LIST_WORKSPACE_USAGE_FAILURE_REASON_FORBIDDEN = 3;
-  LIST_WORKSPACE_USAGE_FAILURE_REASON_INVALID_CURSOR = 4;
-  LIST_WORKSPACE_USAGE_FAILURE_REASON_RATE_LIMITED = 5;
-  LIST_WORKSPACE_USAGE_FAILURE_REASON_INTERNAL_ERROR = 6;
-  LIST_WORKSPACE_USAGE_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 7;
+enum ListTenantUsageFailureReason {
+  LIST_TENANT_USAGE_FAILURE_REASON_UNSPECIFIED = 0;
+  LIST_TENANT_USAGE_FAILURE_REASON_INVALID_REQUEST = 1;
+  LIST_TENANT_USAGE_FAILURE_REASON_UNAUTHENTICATED = 2;
+  LIST_TENANT_USAGE_FAILURE_REASON_FORBIDDEN = 3;
+  LIST_TENANT_USAGE_FAILURE_REASON_INVALID_CURSOR = 4;
+  LIST_TENANT_USAGE_FAILURE_REASON_RATE_LIMITED = 5;
+  LIST_TENANT_USAGE_FAILURE_REASON_INTERNAL_ERROR = 6;
+  LIST_TENANT_USAGE_FAILURE_REASON_TEMPORARILY_UNAVAILABLE = 7;
 }
 
 // Typed detail carried in google.rpc.Status.details after Core can safely
 // construct contract-specific details.
-message ListWorkspaceUsageFailure {
-  ListWorkspaceUsageFailureReason reason = 1;
+message ListTenantUsageFailure {
+  ListTenantUsageFailureReason reason = 1;
 }

--- a/crates/automata-ci-provisioning-grpc/src/lib.rs
+++ b/crates/automata-ci-provisioning-grpc/src/lib.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
-//! Canonical mTLS gRPC transport for shard management and workspace provisioning.
+//! Canonical mTLS gRPC transport for shard management and tenant provisioning.
 //!
 //! Protobuf remains a wire adapter. Callers cannot pass generated DTOs to the
 //! application port, and application implementations cannot observe TLS or
@@ -10,27 +10,26 @@
 use std::{fmt, sync::Arc};
 
 use automata_ci_core::JobAuthorityProfile;
-use automata_ci_core::WorkspaceId;
+use automata_ci_core::ManagedTenantId;
 use automata_ci_provisioning::{
     ApplyGithubProviderConfigurationCommand, ApplyGithubProviderConfigurationResult,
     ApplyGithubProviderRunnerPolicyCommand, ApplyGithubProviderRunnerPolicyResult,
-    ApplyWorkspaceEntitlementCommand, ApplyWorkspaceEntitlementResult,
-    ApplyWorkspaceGithubRepositoriesCommand, ApplyWorkspaceGithubRepositoriesResult,
+    ApplyTenantEntitlementCommand, ApplyTenantEntitlementResult,
+    ApplyTenantGithubRepositoriesCommand, ApplyTenantGithubRepositoriesResult,
     AuthorizedApplyGithubProviderConfiguration, AuthorizedApplyGithubProviderRunnerPolicy,
-    AuthorizedApplyWorkspaceEntitlement, AuthorizedApplyWorkspaceGithubRepositories,
-    AuthorizedProvisionWorkspace, ComputeSeconds, DelegatedActorIssuer, DisplayName,
+    AuthorizedApplyTenantEntitlement, AuthorizedApplyTenantGithubRepositories,
+    AuthorizedProvisionTenant, ComputeSeconds, DelegatedActorIssuer, DisplayName,
     EntitlementDurationSeconds, EntitlementFailure, EntitlementFailureKind, EntitlementRevision,
     ExternalAccountSubject, GithubProviderConfiguration, GithubProviderConfigurationApplier,
     GithubProviderConfigurationFailure, GithubProviderConfigurationFailureKind,
     GithubProviderConfigurationRevision, GithubProviderRepositorySelection,
     GithubProviderRunnerPolicyApplier, GithubProviderRunnerPolicyFailure,
     GithubProviderRunnerPolicyFailureKind, GithubProviderSchedulePolicy, GithubProviderSecret,
-    OperationId, ProvisionWorkspaceCommand, ProvisionWorkspaceResult,
-    ProvisioningAuthenticationError, ProvisioningFailure, ProvisioningFailureKind,
-    ProvisioningWorkloadAuthenticator, ShardId, WorkloadAuthenticationEvidence,
-    WorkspaceEntitlementApplier, WorkspaceExecutionEntitlement, WorkspaceGithubRepositoriesApplier,
-    WorkspaceGithubRepositoriesFailure, WorkspaceGithubRepositoriesFailureKind,
-    WorkspaceGithubRepositoriesRevision, WorkspaceProvisioner,
+    OperationId, ProvisionTenantCommand, ProvisionTenantResult, ProvisioningAuthenticationError,
+    ProvisioningFailure, ProvisioningFailureKind, ProvisioningWorkloadAuthenticator, ShardId,
+    TenantEntitlementApplier, TenantExecutionEntitlement, TenantGithubRepositoriesApplier,
+    TenantGithubRepositoriesFailure, TenantGithubRepositoriesFailureKind,
+    TenantGithubRepositoriesRevision, TenantProvisioner, WorkloadAuthenticationEvidence,
 };
 use automata_ci_store::{
     GithubCheckName, GithubRepositoryName, GithubServerServiceAppClientId,
@@ -59,16 +58,15 @@ pub const MAX_MANAGEMENT_MESSAGE_BYTES: usize = 256 * 1024;
 const MAX_CLIENT_CA_PEM_BYTES: usize = 4 * 1024 * 1024;
 const MAX_SERVER_CERTIFICATE_PEM_BYTES: usize = 4 * 1024 * 1024;
 const MAX_SERVER_PRIVATE_KEY_PEM_BYTES: usize = 1024 * 1024;
-const FAILURE_TYPE_URL: &str =
-    "type.googleapis.com/automata.management.v1.ProvisionWorkspaceFailure";
+const FAILURE_TYPE_URL: &str = "type.googleapis.com/automata.management.v1.ProvisionTenantFailure";
 const ENTITLEMENT_FAILURE_TYPE_URL: &str =
-    "type.googleapis.com/automata.management.v1.ApplyWorkspaceEntitlementFailure";
+    "type.googleapis.com/automata.management.v1.ApplyTenantEntitlementFailure";
 const PROVIDER_CONFIGURATION_FAILURE_TYPE_URL: &str =
     "type.googleapis.com/automata.management.v1.ApplyGithubProviderConfigurationFailure";
 const RUNNER_POLICY_FAILURE_TYPE_URL: &str =
     "type.googleapis.com/automata.management.v1.ApplyGithubProviderRunnerPolicyFailure";
-const WORKSPACE_REPOSITORIES_FAILURE_TYPE_URL: &str =
-    "type.googleapis.com/automata.management.v1.ApplyWorkspaceGithubRepositoriesFailure";
+const TENANT_REPOSITORIES_FAILURE_TYPE_URL: &str =
+    "type.googleapis.com/automata.management.v1.ApplyTenantGithubRepositoriesFailure";
 
 /// Bounded PEM inputs for an mTLS-only management listener.
 pub struct ManagementServerTlsConfig {
@@ -136,29 +134,29 @@ impl fmt::Debug for ManagementServerTlsConfig {
 
 /// Complete transport-neutral mutation ports served by the management listener.
 pub struct ManagementApplicationPorts {
-    provisioner: Arc<dyn WorkspaceProvisioner>,
-    entitlement_applier: Arc<dyn WorkspaceEntitlementApplier>,
+    provisioner: Arc<dyn TenantProvisioner>,
+    entitlement_applier: Arc<dyn TenantEntitlementApplier>,
     provider_configuration_applier: Arc<dyn GithubProviderConfigurationApplier>,
     runner_policy_applier: Arc<dyn GithubProviderRunnerPolicyApplier>,
-    workspace_repositories_applier: Arc<dyn WorkspaceGithubRepositoriesApplier>,
+    tenant_repositories_applier: Arc<dyn TenantGithubRepositoriesApplier>,
 }
 
 impl ManagementApplicationPorts {
     /// Collects the complete application surface without opening a listener.
     #[must_use]
     pub fn new(
-        provisioner: Arc<dyn WorkspaceProvisioner>,
-        entitlement_applier: Arc<dyn WorkspaceEntitlementApplier>,
+        provisioner: Arc<dyn TenantProvisioner>,
+        entitlement_applier: Arc<dyn TenantEntitlementApplier>,
         provider_configuration_applier: Arc<dyn GithubProviderConfigurationApplier>,
         runner_policy_applier: Arc<dyn GithubProviderRunnerPolicyApplier>,
-        workspace_repositories_applier: Arc<dyn WorkspaceGithubRepositoriesApplier>,
+        tenant_repositories_applier: Arc<dyn TenantGithubRepositoriesApplier>,
     ) -> Self {
         Self {
             provisioner,
             entitlement_applier,
             provider_configuration_applier,
             runner_policy_applier,
-            workspace_repositories_applier,
+            tenant_repositories_applier,
         }
     }
 }
@@ -175,8 +173,8 @@ impl fmt::Debug for ManagementApplicationPorts {
             )
             .field("runner_policy_applier", &self.runner_policy_applier)
             .field(
-                "workspace_repositories_applier",
-                &self.workspace_repositories_applier,
+                "tenant_repositories_applier",
+                &self.tenant_repositories_applier,
             )
             .finish()
     }
@@ -187,11 +185,11 @@ pub struct ManagementGrpcServer {
     listener: TcpListener,
     tls: ManagementServerTlsConfig,
     authenticator: Arc<dyn ProvisioningWorkloadAuthenticator>,
-    provisioner: Arc<dyn WorkspaceProvisioner>,
-    entitlement_applier: Arc<dyn WorkspaceEntitlementApplier>,
+    provisioner: Arc<dyn TenantProvisioner>,
+    entitlement_applier: Arc<dyn TenantEntitlementApplier>,
     provider_configuration_applier: Arc<dyn GithubProviderConfigurationApplier>,
     runner_policy_applier: Arc<dyn GithubProviderRunnerPolicyApplier>,
-    workspace_repositories_applier: Arc<dyn WorkspaceGithubRepositoriesApplier>,
+    tenant_repositories_applier: Arc<dyn TenantGithubRepositoriesApplier>,
 }
 
 impl ManagementGrpcServer {
@@ -210,7 +208,7 @@ impl ManagementGrpcServer {
             entitlement_applier: ports.entitlement_applier,
             provider_configuration_applier: ports.provider_configuration_applier,
             runner_policy_applier: ports.runner_policy_applier,
-            workspace_repositories_applier: ports.workspace_repositories_applier,
+            tenant_repositories_applier: ports.tenant_repositories_applier,
         }
     }
 
@@ -230,7 +228,7 @@ impl ManagementGrpcServer {
             entitlement_applier: self.entitlement_applier,
             provider_configuration_applier: self.provider_configuration_applier,
             runner_policy_applier: self.runner_policy_applier,
-            workspace_repositories_applier: self.workspace_repositories_applier,
+            tenant_repositories_applier: self.tenant_repositories_applier,
         };
         let service =
             wire::shard_management_service_server::ShardManagementServiceServer::new(adapter)
@@ -264,8 +262,8 @@ impl fmt::Debug for ManagementGrpcServer {
             )
             .field("runner_policy_applier", &self.runner_policy_applier)
             .field(
-                "workspace_repositories_applier",
-                &self.workspace_repositories_applier,
+                "tenant_repositories_applier",
+                &self.tenant_repositories_applier,
             )
             .finish_non_exhaustive()
     }
@@ -274,11 +272,11 @@ impl fmt::Debug for ManagementGrpcServer {
 #[derive(Clone)]
 struct ManagementGrpcAdapter {
     authenticator: Arc<dyn ProvisioningWorkloadAuthenticator>,
-    provisioner: Arc<dyn WorkspaceProvisioner>,
-    entitlement_applier: Arc<dyn WorkspaceEntitlementApplier>,
+    provisioner: Arc<dyn TenantProvisioner>,
+    entitlement_applier: Arc<dyn TenantEntitlementApplier>,
     provider_configuration_applier: Arc<dyn GithubProviderConfigurationApplier>,
     runner_policy_applier: Arc<dyn GithubProviderRunnerPolicyApplier>,
-    workspace_repositories_applier: Arc<dyn WorkspaceGithubRepositoriesApplier>,
+    tenant_repositories_applier: Arc<dyn TenantGithubRepositoriesApplier>,
 }
 
 impl fmt::Debug for ManagementGrpcAdapter {
@@ -294,8 +292,8 @@ impl fmt::Debug for ManagementGrpcAdapter {
             )
             .field("runner_policy_applier", &self.runner_policy_applier)
             .field(
-                "workspace_repositories_applier",
-                &self.workspace_repositories_applier,
+                "tenant_repositories_applier",
+                &self.tenant_repositories_applier,
             )
             .finish()
     }
@@ -303,10 +301,10 @@ impl fmt::Debug for ManagementGrpcAdapter {
 
 #[tonic::async_trait]
 impl wire::shard_management_service_server::ShardManagementService for ManagementGrpcAdapter {
-    async fn provision_workspace(
+    async fn provision_tenant(
         &self,
-        request: Request<wire::ProvisionWorkspaceRequest>,
-    ) -> Result<Response<wire::ProvisionWorkspaceResponse>, Status> {
+        request: Request<wire::ProvisionTenantRequest>,
+    ) -> Result<Response<wire::ProvisionTenantResponse>, Status> {
         let certificates = request
             .peer_certs()
             .ok_or_else(|| Status::unauthenticated("workload authentication is required"))?;
@@ -325,23 +323,23 @@ impl wire::shard_management_service_server::ShardManagementService for Managemen
         let command = decode_command(request.into_inner()).map_err(|()| {
             contract_status(
                 Code::InvalidArgument,
-                wire::ProvisionWorkspaceFailureReason::InvalidRequest,
-                "workspace provisioning request is invalid",
+                wire::ProvisionTenantFailureReason::InvalidRequest,
+                "tenant provisioning request is invalid",
                 None,
             )
         })?;
         let authorized =
-            AuthorizedProvisionWorkspace::authorize(authority, command).map_err(|_| {
+            AuthorizedProvisionTenant::authorize(authority, command).map_err(|_| {
                 contract_status(
                     Code::PermissionDenied,
-                    wire::ProvisionWorkspaceFailureReason::Forbidden,
-                    "workspace provisioning is outside the workload authority",
+                    wire::ProvisionTenantFailureReason::Forbidden,
+                    "tenant provisioning is outside the workload authority",
                     None,
                 )
             })?;
         let expected_operation_id = authorized.command().operation_id();
         let expected_shard_id = authorized.command().shard_id().clone();
-        let expected_workspace_id = authorized.command().workspace_id();
+        let expected_tenant_id = authorized.command().tenant_id();
         let result = self
             .provisioner
             .provision(authorized)
@@ -349,22 +347,22 @@ impl wire::shard_management_service_server::ShardManagementService for Managemen
             .map_err(|error| provisioning_status(&error))?;
         if result.operation_id() != expected_operation_id
             || result.shard_id() != &expected_shard_id
-            || result.workspace_id() != expected_workspace_id
+            || result.tenant_id() != expected_tenant_id
         {
             return Err(contract_status(
                 Code::Internal,
-                wire::ProvisionWorkspaceFailureReason::InternalError,
-                "workspace provisioning returned an inconsistent result",
+                wire::ProvisionTenantFailureReason::InternalError,
+                "tenant provisioning returned an inconsistent result",
                 None,
             ));
         }
         Ok(Response::new(encode_result(&result)))
     }
 
-    async fn apply_workspace_entitlement(
+    async fn apply_tenant_entitlement(
         &self,
-        request: Request<wire::ApplyWorkspaceEntitlementRequest>,
-    ) -> Result<Response<wire::ApplyWorkspaceEntitlementResponse>, Status> {
+        request: Request<wire::ApplyTenantEntitlementRequest>,
+    ) -> Result<Response<wire::ApplyTenantEntitlementResponse>, Status> {
         let certificates = request
             .peer_certs()
             .ok_or_else(|| Status::unauthenticated("workload authentication is required"))?;
@@ -383,21 +381,21 @@ impl wire::shard_management_service_server::ShardManagementService for Managemen
         let command = decode_entitlement_command(request.into_inner()).map_err(|()| {
             entitlement_contract_status(
                 Code::InvalidArgument,
-                wire::ApplyWorkspaceEntitlementFailureReason::InvalidRequest,
-                "workspace entitlement request is invalid",
+                wire::ApplyTenantEntitlementFailureReason::InvalidRequest,
+                "tenant entitlement request is invalid",
             )
         })?;
-        let authorized = AuthorizedApplyWorkspaceEntitlement::authorize(authority, command)
-            .map_err(|_| {
+        let authorized =
+            AuthorizedApplyTenantEntitlement::authorize(authority, command).map_err(|_| {
                 entitlement_contract_status(
                     Code::PermissionDenied,
-                    wire::ApplyWorkspaceEntitlementFailureReason::Forbidden,
-                    "workspace entitlement is outside the workload authority",
+                    wire::ApplyTenantEntitlementFailureReason::Forbidden,
+                    "tenant entitlement is outside the workload authority",
                 )
             })?;
         let expected_operation_id = authorized.command().operation_id();
         let expected_shard_id = authorized.command().shard_id().clone();
-        let expected_workspace_id = authorized.command().workspace_id();
+        let expected_tenant_id = authorized.command().tenant_id();
         let expected_revision = authorized.command().revision();
         let result = self
             .entitlement_applier
@@ -406,13 +404,13 @@ impl wire::shard_management_service_server::ShardManagementService for Managemen
             .map_err(entitlement_status)?;
         if result.operation_id() != expected_operation_id
             || result.shard_id() != &expected_shard_id
-            || result.workspace_id() != expected_workspace_id
+            || result.tenant_id() != expected_tenant_id
             || result.revision() != expected_revision
         {
             return Err(entitlement_contract_status(
                 Code::Internal,
-                wire::ApplyWorkspaceEntitlementFailureReason::InternalError,
-                "workspace entitlement application returned an inconsistent result",
+                wire::ApplyTenantEntitlementFailureReason::InternalError,
+                "tenant entitlement application returned an inconsistent result",
             ));
         }
         Ok(Response::new(encode_entitlement_result(&result)))
@@ -501,48 +499,47 @@ impl wire::shard_management_service_server::ShardManagementService for Managemen
         Ok(Response::new(encode_runner_policy_result(&result)))
     }
 
-    async fn apply_workspace_github_repositories(
+    async fn apply_tenant_github_repositories(
         &self,
-        request: Request<wire::ApplyWorkspaceGithubRepositoriesRequest>,
-    ) -> Result<Response<wire::ApplyWorkspaceGithubRepositoriesResponse>, Status> {
+        request: Request<wire::ApplyTenantGithubRepositoriesRequest>,
+    ) -> Result<Response<wire::ApplyTenantGithubRepositoriesResponse>, Status> {
         let authority = authenticate_management_request(&self.authenticator, &request).await?;
-        let command =
-            decode_workspace_repositories_command(request.into_inner()).map_err(|()| {
-                workspace_repositories_contract_status(
-                    Code::InvalidArgument,
-                    wire::ApplyWorkspaceGithubRepositoriesFailureReason::InvalidRequest,
-                    "workspace GitHub repositories request is invalid",
-                )
-            })?;
-        let authorized = AuthorizedApplyWorkspaceGithubRepositories::authorize(authority, command)
+        let command = decode_tenant_repositories_command(request.into_inner()).map_err(|()| {
+            tenant_repositories_contract_status(
+                Code::InvalidArgument,
+                wire::ApplyTenantGithubRepositoriesFailureReason::InvalidRequest,
+                "tenant GitHub repositories request is invalid",
+            )
+        })?;
+        let authorized = AuthorizedApplyTenantGithubRepositories::authorize(authority, command)
             .map_err(|_| {
-                workspace_repositories_contract_status(
+                tenant_repositories_contract_status(
                     Code::PermissionDenied,
-                    wire::ApplyWorkspaceGithubRepositoriesFailureReason::Forbidden,
-                    "workspace GitHub repositories are outside the workload authority",
+                    wire::ApplyTenantGithubRepositoriesFailureReason::Forbidden,
+                    "tenant GitHub repositories are outside the workload authority",
                 )
             })?;
         let expected_operation_id = authorized.command().operation_id();
         let expected_shard_id = authorized.command().shard_id().clone();
-        let expected_workspace_id = authorized.command().workspace_id();
+        let expected_tenant_id = authorized.command().tenant_id();
         let expected_revision = authorized.command().revision();
         let result = self
-            .workspace_repositories_applier
+            .tenant_repositories_applier
             .apply(authorized)
             .await
-            .map_err(|error| workspace_repositories_status(&error))?;
+            .map_err(|error| tenant_repositories_status(&error))?;
         if result.operation_id() != expected_operation_id
             || result.shard_id() != &expected_shard_id
-            || result.workspace_id() != expected_workspace_id
+            || result.tenant_id() != expected_tenant_id
             || result.revision() != expected_revision
         {
-            return Err(workspace_repositories_contract_status(
+            return Err(tenant_repositories_contract_status(
                 Code::Internal,
-                wire::ApplyWorkspaceGithubRepositoriesFailureReason::InternalError,
-                "workspace GitHub repositories returned an inconsistent result",
+                wire::ApplyTenantGithubRepositoriesFailureReason::InternalError,
+                "tenant GitHub repositories returned an inconsistent result",
             ));
         }
-        Ok(Response::new(encode_workspace_repositories_result(&result)))
+        Ok(Response::new(encode_tenant_repositories_result(&result)))
     }
 }
 
@@ -566,28 +563,26 @@ async fn authenticate_management_request<T>(
         .map_err(authentication_status)
 }
 
-fn decode_command(
-    request: wire::ProvisionWorkspaceRequest,
-) -> Result<ProvisionWorkspaceCommand, ()> {
-    let workspace = request.workspace.ok_or(())?;
+fn decode_command(request: wire::ProvisionTenantRequest) -> Result<ProvisionTenantCommand, ()> {
+    let tenant = request.tenant.ok_or(())?;
     let initial_owner = request.initial_owner.ok_or(())?;
-    Ok(ProvisionWorkspaceCommand::new(
+    Ok(ProvisionTenantCommand::new(
         OperationId::parse(&request.operation_id).map_err(|_| ())?,
         ShardId::new(request.shard_id).map_err(|_| ())?,
-        WorkspaceId::parse(&workspace.workspace_id).map_err(|_| ())?,
-        DisplayName::new(workspace.display_name).map_err(|_| ())?,
+        ManagedTenantId::parse(&tenant.tenant_id).map_err(|_| ())?,
+        DisplayName::new(tenant.display_name).map_err(|_| ())?,
         DelegatedActorIssuer::new(initial_owner.issuer).map_err(|_| ())?,
         ExternalAccountSubject::parse(&initial_owner.subject).map_err(|_| ())?,
         DisplayName::new(initial_owner.display_name).map_err(|_| ())?,
     ))
 }
 
-fn encode_result(result: &ProvisionWorkspaceResult) -> wire::ProvisionWorkspaceResponse {
+fn encode_result(result: &ProvisionTenantResult) -> wire::ProvisionTenantResponse {
     let provisioned_at = result.provisioned_at();
-    wire::ProvisionWorkspaceResponse {
+    wire::ProvisionTenantResponse {
         operation_id: result.operation_id().to_string(),
         shard_id: result.shard_id().as_str().to_owned(),
-        workspace_id: result.workspace_id().to_string(),
+        tenant_id: result.tenant_id().to_string(),
         initial_owner_principal_id: result.initial_owner_principal_id().to_string(),
         provisioned_at: Some(prost_types::Timestamp {
             seconds: provisioned_at.seconds(),
@@ -598,11 +593,11 @@ fn encode_result(result: &ProvisionWorkspaceResult) -> wire::ProvisionWorkspaceR
 }
 
 fn decode_entitlement_command(
-    request: wire::ApplyWorkspaceEntitlementRequest,
-) -> Result<ApplyWorkspaceEntitlementCommand, ()> {
+    request: wire::ApplyTenantEntitlementRequest,
+) -> Result<ApplyTenantEntitlementCommand, ()> {
     let execution = request.execution.ok_or(())?.policy.ok_or(())?;
     let execution = match execution {
-        wire::workspace_execution_entitlement::Policy::Capped(capped) => {
+        wire::tenant_execution_entitlement::Policy::Capped(capped) => {
             let compute_seconds = ComputeSeconds::new(capped.compute_seconds).map_err(|_| ())?;
             let valid_for = capped
                 .valid_for
@@ -616,36 +611,34 @@ fn decode_entitlement_command(
                     .map_err(|_| ())
                 })
                 .transpose()?;
-            WorkspaceExecutionEntitlement::capped(compute_seconds, valid_for)
+            TenantExecutionEntitlement::capped(compute_seconds, valid_for)
         }
-        wire::workspace_execution_entitlement::Policy::Uncapped(_) => {
-            WorkspaceExecutionEntitlement::Uncapped
+        wire::tenant_execution_entitlement::Policy::Uncapped(_) => {
+            TenantExecutionEntitlement::Uncapped
         }
-        wire::workspace_execution_entitlement::Policy::Paused(_) => {
-            WorkspaceExecutionEntitlement::Paused
-        }
+        wire::tenant_execution_entitlement::Policy::Paused(_) => TenantExecutionEntitlement::Paused,
     };
-    Ok(ApplyWorkspaceEntitlementCommand::new(
+    Ok(ApplyTenantEntitlementCommand::new(
         OperationId::parse(&request.operation_id).map_err(|_| ())?,
         ShardId::new(request.shard_id).map_err(|_| ())?,
-        WorkspaceId::parse(&request.workspace_id).map_err(|_| ())?,
+        ManagedTenantId::parse(&request.tenant_id).map_err(|_| ())?,
         EntitlementRevision::new(request.revision).map_err(|_| ())?,
         execution,
     ))
 }
 
 fn encode_entitlement_result(
-    result: &ApplyWorkspaceEntitlementResult,
-) -> wire::ApplyWorkspaceEntitlementResponse {
+    result: &ApplyTenantEntitlementResult,
+) -> wire::ApplyTenantEntitlementResponse {
     let timestamp =
         |value: automata_ci_provisioning::EntitlementTimestamp| prost_types::Timestamp {
             seconds: value.seconds(),
             nanos: i32::try_from(value.nanoseconds()).expect("validated nanoseconds fit i32"),
         };
-    wire::ApplyWorkspaceEntitlementResponse {
+    wire::ApplyTenantEntitlementResponse {
         operation_id: result.operation_id().to_string(),
         shard_id: result.shard_id().as_str().to_owned(),
-        workspace_id: result.workspace_id().to_string(),
+        tenant_id: result.tenant_id().to_string(),
         revision: result.revision().get(),
         applied_at: Some(timestamp(result.applied_at())),
         expires_at: result.expires_at().map(timestamp),
@@ -703,9 +696,9 @@ fn decode_runner_policy_command(
     ))
 }
 
-fn decode_workspace_repositories_command(
-    request: wire::ApplyWorkspaceGithubRepositoriesRequest,
-) -> Result<ApplyWorkspaceGithubRepositoriesCommand, ()> {
+fn decode_tenant_repositories_command(
+    request: wire::ApplyTenantGithubRepositoriesRequest,
+) -> Result<ApplyTenantGithubRepositoriesCommand, ()> {
     let repositories = request
         .repositories
         .into_iter()
@@ -740,11 +733,11 @@ fn decode_workspace_repositories_command(
             .map_err(|_| ())
         })
         .collect::<Result<Vec<_>, _>>()?;
-    ApplyWorkspaceGithubRepositoriesCommand::new(
+    ApplyTenantGithubRepositoriesCommand::new(
         OperationId::parse(&request.operation_id).map_err(|_| ())?,
         ShardId::new(request.shard_id).map_err(|_| ())?,
-        WorkspaceId::parse(&request.workspace_id).map_err(|_| ())?,
-        WorkspaceGithubRepositoriesRevision::new(request.revision).map_err(|_| ())?,
+        ManagedTenantId::parse(&request.tenant_id).map_err(|_| ())?,
+        TenantGithubRepositoriesRevision::new(request.revision).map_err(|_| ())?,
         repositories,
     )
     .map_err(|_| ())
@@ -780,14 +773,14 @@ fn encode_runner_policy_result(
     }
 }
 
-fn encode_workspace_repositories_result(
-    result: &ApplyWorkspaceGithubRepositoriesResult,
-) -> wire::ApplyWorkspaceGithubRepositoriesResponse {
+fn encode_tenant_repositories_result(
+    result: &ApplyTenantGithubRepositoriesResult,
+) -> wire::ApplyTenantGithubRepositoriesResponse {
     let applied_at = result.applied_at();
-    wire::ApplyWorkspaceGithubRepositoriesResponse {
+    wire::ApplyTenantGithubRepositoriesResponse {
         operation_id: result.operation_id().to_string(),
         shard_id: result.shard_id().as_str().to_owned(),
-        workspace_id: result.workspace_id().to_string(),
+        tenant_id: result.tenant_id().to_string(),
         revision: result.revision().get(),
         applied_at: Some(prost_types::Timestamp {
             seconds: applied_at.seconds(),
@@ -816,33 +809,33 @@ fn provisioning_status(error: &ProvisioningFailure) -> Status {
     let (code, reason, message) = match error.kind() {
         ProvisioningFailureKind::OperationConflict => (
             Code::Aborted,
-            wire::ProvisionWorkspaceFailureReason::OperationConflict,
+            wire::ProvisionTenantFailureReason::OperationConflict,
             "provisioning operation conflicts with its durable receipt",
         ),
-        ProvisioningFailureKind::WorkspaceConflict => (
+        ProvisioningFailureKind::TenantConflict => (
             Code::AlreadyExists,
-            wire::ProvisionWorkspaceFailureReason::WorkspaceConflict,
-            "workspace identity is already owned by another operation",
+            wire::ProvisionTenantFailureReason::TenantConflict,
+            "tenant identity is already owned by another operation",
         ),
         ProvisioningFailureKind::PrincipalUnavailable => (
             Code::FailedPrecondition,
-            wire::ProvisionWorkspaceFailureReason::PrincipalUnavailable,
+            wire::ProvisionTenantFailureReason::PrincipalUnavailable,
             "initial owner principal is unavailable",
         ),
         ProvisioningFailureKind::RateLimited => (
             Code::ResourceExhausted,
-            wire::ProvisionWorkspaceFailureReason::RateLimited,
-            "workspace provisioning rate is exhausted",
+            wire::ProvisionTenantFailureReason::RateLimited,
+            "tenant provisioning rate is exhausted",
         ),
         ProvisioningFailureKind::Internal => (
             Code::Internal,
-            wire::ProvisionWorkspaceFailureReason::InternalError,
-            "workspace provisioning failed internally",
+            wire::ProvisionTenantFailureReason::InternalError,
+            "tenant provisioning failed internally",
         ),
         ProvisioningFailureKind::TemporarilyUnavailable => (
             Code::Unavailable,
-            wire::ProvisionWorkspaceFailureReason::TemporarilyUnavailable,
-            "workspace provisioning is temporarily unavailable",
+            wire::ProvisionTenantFailureReason::TemporarilyUnavailable,
+            "tenant provisioning is temporarily unavailable",
         ),
     };
     contract_status(code, reason, message, request_id)
@@ -852,33 +845,33 @@ fn entitlement_status(error: EntitlementFailure) -> Status {
     let (code, reason, message) = match error.kind() {
         EntitlementFailureKind::OperationConflict => (
             Code::Aborted,
-            wire::ApplyWorkspaceEntitlementFailureReason::OperationConflict,
+            wire::ApplyTenantEntitlementFailureReason::OperationConflict,
             "entitlement operation conflicts with its durable receipt",
         ),
         EntitlementFailureKind::StaleRevision => (
             Code::FailedPrecondition,
-            wire::ApplyWorkspaceEntitlementFailureReason::StaleRevision,
+            wire::ApplyTenantEntitlementFailureReason::StaleRevision,
             "entitlement revision is stale",
         ),
-        EntitlementFailureKind::WorkspaceUnavailable => (
+        EntitlementFailureKind::TenantUnavailable => (
             Code::PermissionDenied,
-            wire::ApplyWorkspaceEntitlementFailureReason::WorkspaceUnavailable,
-            "workspace is unavailable to this management authority",
+            wire::ApplyTenantEntitlementFailureReason::TenantUnavailable,
+            "tenant is unavailable to this management authority",
         ),
         EntitlementFailureKind::RateLimited => (
             Code::ResourceExhausted,
-            wire::ApplyWorkspaceEntitlementFailureReason::RateLimited,
-            "workspace entitlement mutation rate is exhausted",
+            wire::ApplyTenantEntitlementFailureReason::RateLimited,
+            "tenant entitlement mutation rate is exhausted",
         ),
         EntitlementFailureKind::Internal => (
             Code::Internal,
-            wire::ApplyWorkspaceEntitlementFailureReason::InternalError,
-            "workspace entitlement application failed internally",
+            wire::ApplyTenantEntitlementFailureReason::InternalError,
+            "tenant entitlement application failed internally",
         ),
         EntitlementFailureKind::TemporarilyUnavailable => (
             Code::Unavailable,
-            wire::ApplyWorkspaceEntitlementFailureReason::TemporarilyUnavailable,
-            "workspace entitlement application is temporarily unavailable",
+            wire::ApplyTenantEntitlementFailureReason::TemporarilyUnavailable,
+            "tenant entitlement application is temporarily unavailable",
         ),
     };
     entitlement_contract_status(code, reason, message)
@@ -951,49 +944,49 @@ fn runner_policy_status(error: &GithubProviderRunnerPolicyFailure) -> Status {
     runner_policy_contract_status(code, reason, message)
 }
 
-fn workspace_repositories_status(error: &WorkspaceGithubRepositoriesFailure) -> Status {
+fn tenant_repositories_status(error: &TenantGithubRepositoriesFailure) -> Status {
     let (code, reason, message) = match error.kind() {
-        WorkspaceGithubRepositoriesFailureKind::OperationConflict => (
+        TenantGithubRepositoriesFailureKind::OperationConflict => (
             Code::Aborted,
-            wire::ApplyWorkspaceGithubRepositoriesFailureReason::OperationConflict,
-            "workspace repository operation conflicts with its durable receipt",
+            wire::ApplyTenantGithubRepositoriesFailureReason::OperationConflict,
+            "tenant repository operation conflicts with its durable receipt",
         ),
-        WorkspaceGithubRepositoriesFailureKind::StaleRevision => (
+        TenantGithubRepositoriesFailureKind::StaleRevision => (
             Code::FailedPrecondition,
-            wire::ApplyWorkspaceGithubRepositoriesFailureReason::StaleRevision,
-            "workspace repository revision is stale",
+            wire::ApplyTenantGithubRepositoriesFailureReason::StaleRevision,
+            "tenant repository revision is stale",
         ),
-        WorkspaceGithubRepositoriesFailureKind::WorkspaceUnavailable => (
+        TenantGithubRepositoriesFailureKind::TenantUnavailable => (
             Code::PermissionDenied,
-            wire::ApplyWorkspaceGithubRepositoriesFailureReason::WorkspaceUnavailable,
-            "workspace is unavailable to this management authority",
+            wire::ApplyTenantGithubRepositoriesFailureReason::TenantUnavailable,
+            "tenant is unavailable to this management authority",
         ),
-        WorkspaceGithubRepositoriesFailureKind::ShardRegistryConflict => (
+        TenantGithubRepositoriesFailureKind::ShardRegistryConflict => (
             Code::FailedPrecondition,
-            wire::ApplyWorkspaceGithubRepositoriesFailureReason::ShardRegistryConflict,
-            "workspace repositories conflict with the shard registry",
+            wire::ApplyTenantGithubRepositoriesFailureReason::ShardRegistryConflict,
+            "tenant repositories conflict with the shard registry",
         ),
-        WorkspaceGithubRepositoriesFailureKind::Internal => (
+        TenantGithubRepositoriesFailureKind::Internal => (
             Code::Internal,
-            wire::ApplyWorkspaceGithubRepositoriesFailureReason::InternalError,
-            "workspace repository configuration failed internally",
+            wire::ApplyTenantGithubRepositoriesFailureReason::InternalError,
+            "tenant repository configuration failed internally",
         ),
-        WorkspaceGithubRepositoriesFailureKind::TemporarilyUnavailable => (
+        TenantGithubRepositoriesFailureKind::TemporarilyUnavailable => (
             Code::Unavailable,
-            wire::ApplyWorkspaceGithubRepositoriesFailureReason::TemporarilyUnavailable,
-            "workspace repository configuration is temporarily unavailable",
+            wire::ApplyTenantGithubRepositoriesFailureReason::TemporarilyUnavailable,
+            "tenant repository configuration is temporarily unavailable",
         ),
     };
-    workspace_repositories_contract_status(code, reason, message)
+    tenant_repositories_contract_status(code, reason, message)
 }
 
 fn contract_status(
     code: Code,
-    reason: wire::ProvisionWorkspaceFailureReason,
+    reason: wire::ProvisionTenantFailureReason,
     message: &'static str,
     request_id: Option<&str>,
 ) -> Status {
-    let detail = wire::ProvisionWorkspaceFailure {
+    let detail = wire::ProvisionTenantFailure {
         reason: reason as i32,
         request_id: request_id.unwrap_or_default().to_owned(),
     };
@@ -1010,10 +1003,10 @@ fn contract_status(
 
 fn entitlement_contract_status(
     code: Code,
-    reason: wire::ApplyWorkspaceEntitlementFailureReason,
+    reason: wire::ApplyTenantEntitlementFailureReason,
     message: &'static str,
 ) -> Status {
-    let detail = wire::ApplyWorkspaceEntitlementFailure {
+    let detail = wire::ApplyTenantEntitlementFailure {
         reason: reason as i32,
     };
     let rich_status = tonic_types::pb::Status {
@@ -1065,19 +1058,19 @@ fn runner_policy_contract_status(
     Status::with_details(code, message, Bytes::from(rich_status.encode_to_vec()))
 }
 
-fn workspace_repositories_contract_status(
+fn tenant_repositories_contract_status(
     code: Code,
-    reason: wire::ApplyWorkspaceGithubRepositoriesFailureReason,
+    reason: wire::ApplyTenantGithubRepositoriesFailureReason,
     message: &'static str,
 ) -> Status {
-    let detail = wire::ApplyWorkspaceGithubRepositoriesFailure {
+    let detail = wire::ApplyTenantGithubRepositoriesFailure {
         reason: reason as i32,
     };
     let rich_status = tonic_types::pb::Status {
         code: code as i32,
         message: message.to_owned(),
         details: vec![prost_types::Any {
-            type_url: WORKSPACE_REPOSITORIES_FAILURE_TYPE_URL.to_owned(),
+            type_url: TENANT_REPOSITORIES_FAILURE_TYPE_URL.to_owned(),
             value: detail.encode_to_vec(),
         }],
     };
@@ -1122,7 +1115,7 @@ mod tests {
         EntitlementApplicationFuture, EntitlementTimestamp,
         GithubProviderConfigurationApplicationFuture, InitialOwnerPrincipalId, ProvisionedAt,
         ProvisioningAuthenticationFuture, ProvisioningAuthority,
-        WorkspaceGithubRepositoriesApplicationFuture, WorkspaceProvisioningFuture,
+        TenantGithubRepositoriesApplicationFuture, TenantProvisioningFuture,
     };
     use rcgen::{
         BasicConstraints, CertificateParams, CertifiedIssuer, DnType, ExtendedKeyUsagePurpose,
@@ -1240,17 +1233,17 @@ mod tests {
     #[derive(Debug)]
     struct RecordingProvisioner {
         calls: AtomicUsize,
-        result: ProvisionWorkspaceResult,
+        result: ProvisionTenantResult,
     }
 
     impl RecordingProvisioner {
         fn new() -> Self {
             Self {
                 calls: AtomicUsize::new(0),
-                result: ProvisionWorkspaceResult::new(
+                result: ProvisionTenantResult::new(
                     OperationId::parse("55555555-5555-4555-8555-555555555555").unwrap(),
                     ShardId::new("prod-us-east-1-001").unwrap(),
-                    WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+                    ManagedTenantId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
                     InitialOwnerPrincipalId::parse("66666666-6666-4666-8666-666666666666").unwrap(),
                     ProvisionedAt::new(1_786_500_000, 0).unwrap(),
                 ),
@@ -1258,18 +1251,15 @@ mod tests {
         }
     }
 
-    impl WorkspaceProvisioner for RecordingProvisioner {
-        fn provision(
-            &self,
-            request: AuthorizedProvisionWorkspace,
-        ) -> WorkspaceProvisioningFuture<'_> {
+    impl TenantProvisioner for RecordingProvisioner {
+        fn provision(&self, request: AuthorizedProvisionTenant) -> TenantProvisioningFuture<'_> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             assert_eq!(
                 request.authority().id().as_str(),
                 "automata-cloud-production"
             );
             assert_eq!(
-                request.command().workspace_id().to_string(),
+                request.command().tenant_id().to_string(),
                 "22222222-2222-4222-8222-222222222222"
             );
             Box::pin(future::ready(Ok(self.result.clone())))
@@ -1279,17 +1269,17 @@ mod tests {
     #[derive(Debug)]
     struct RecordingEntitlementApplier {
         calls: AtomicUsize,
-        result: ApplyWorkspaceEntitlementResult,
+        result: ApplyTenantEntitlementResult,
     }
 
     impl RecordingEntitlementApplier {
         fn new() -> Self {
             Self {
                 calls: AtomicUsize::new(0),
-                result: ApplyWorkspaceEntitlementResult::new(
+                result: ApplyTenantEntitlementResult::new(
                     OperationId::parse("77777777-7777-4777-8777-777777777777").unwrap(),
                     ShardId::new("prod-us-east-1-001").unwrap(),
-                    WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+                    ManagedTenantId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
                     EntitlementRevision::new(1).unwrap(),
                     EntitlementTimestamp::new(1_786_500_100, 0).unwrap(),
                     Some(EntitlementTimestamp::new(1_787_104_900, 0).unwrap()),
@@ -1298,16 +1288,16 @@ mod tests {
         }
     }
 
-    impl WorkspaceEntitlementApplier for RecordingEntitlementApplier {
+    impl TenantEntitlementApplier for RecordingEntitlementApplier {
         fn apply(
             &self,
-            request: AuthorizedApplyWorkspaceEntitlement,
+            request: AuthorizedApplyTenantEntitlement,
         ) -> EntitlementApplicationFuture<'_> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             assert_eq!(request.command().revision().get(), 1);
             assert_eq!(
                 request.command().execution(),
-                WorkspaceExecutionEntitlement::capped(
+                TenantExecutionEntitlement::capped(
                     ComputeSeconds::new(6_000).unwrap(),
                     Some(EntitlementDurationSeconds::new(604_800).unwrap())
                 )
@@ -1363,28 +1353,28 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct UnusedWorkspaceRepositoriesApplier;
+    struct UnusedTenantRepositoriesApplier;
 
-    impl WorkspaceGithubRepositoriesApplier for UnusedWorkspaceRepositoriesApplier {
+    impl TenantGithubRepositoriesApplier for UnusedTenantRepositoriesApplier {
         fn apply(
             &self,
-            _request: AuthorizedApplyWorkspaceGithubRepositories,
-        ) -> WorkspaceGithubRepositoriesApplicationFuture<'_> {
-            Box::pin(future::ready(Err(WorkspaceGithubRepositoriesFailure::new(
-                WorkspaceGithubRepositoriesFailureKind::Internal,
+            _request: AuthorizedApplyTenantGithubRepositories,
+        ) -> TenantGithubRepositoriesApplicationFuture<'_> {
+            Box::pin(future::ready(Err(TenantGithubRepositoriesFailure::new(
+                TenantGithubRepositoriesFailureKind::Internal,
             ))))
         }
     }
 
-    fn valid_wire_request() -> wire::ProvisionWorkspaceRequest {
-        wire::ProvisionWorkspaceRequest {
+    fn valid_wire_request() -> wire::ProvisionTenantRequest {
+        wire::ProvisionTenantRequest {
             operation_id: "55555555-5555-4555-8555-555555555555".to_owned(),
             shard_id: "prod-us-east-1-001".to_owned(),
-            workspace: Some(wire::WorkspaceProvisioningTarget {
-                workspace_id: "22222222-2222-4222-8222-222222222222".to_owned(),
+            tenant: Some(wire::TenantProvisioningTarget {
+                tenant_id: "22222222-2222-4222-8222-222222222222".to_owned(),
                 display_name: "Acme Engineering".to_owned(),
             }),
-            initial_owner: Some(wire::InitialWorkspaceOwner {
+            initial_owner: Some(wire::InitialTenantOwner {
                 issuer: "https://cloud.automata.example".to_owned(),
                 subject: "11111111-1111-4111-8111-111111111111".to_owned(),
                 display_name: "The Octocat".to_owned(),
@@ -1392,15 +1382,15 @@ mod tests {
         }
     }
 
-    fn valid_entitlement_wire_request() -> wire::ApplyWorkspaceEntitlementRequest {
-        wire::ApplyWorkspaceEntitlementRequest {
+    fn valid_entitlement_wire_request() -> wire::ApplyTenantEntitlementRequest {
+        wire::ApplyTenantEntitlementRequest {
             operation_id: "77777777-7777-4777-8777-777777777777".to_owned(),
             shard_id: "prod-us-east-1-001".to_owned(),
-            workspace_id: "22222222-2222-4222-8222-222222222222".to_owned(),
+            tenant_id: "22222222-2222-4222-8222-222222222222".to_owned(),
             revision: 1,
-            execution: Some(wire::WorkspaceExecutionEntitlement {
-                policy: Some(wire::workspace_execution_entitlement::Policy::Capped(
-                    wire::CappedWorkspaceExecution {
+            execution: Some(wire::TenantExecutionEntitlement {
+                policy: Some(wire::tenant_execution_entitlement::Policy::Capped(
+                    wire::CappedTenantExecution {
                         compute_seconds: 6_000,
                         valid_for: Some(prost_types::Duration {
                             seconds: 604_800,
@@ -1414,7 +1404,7 @@ mod tests {
 
     fn valid_runner_policy() -> Vec<u8> {
         serde_json::to_vec(&serde_json::json!({
-            "workspace": {"derivation": 1, "root": "/__w", "schema": 1},
+            "workspace":{"derivation": 1, "root": "/__w", "schema": 1},
             "mappings": [{
                 "runner_features": {
                     "schema": 1,
@@ -1496,12 +1486,11 @@ mod tests {
         }
     }
 
-    fn valid_workspace_repositories_wire_request() -> wire::ApplyWorkspaceGithubRepositoriesRequest
-    {
-        wire::ApplyWorkspaceGithubRepositoriesRequest {
+    fn valid_tenant_repositories_wire_request() -> wire::ApplyTenantGithubRepositoriesRequest {
+        wire::ApplyTenantGithubRepositoriesRequest {
             operation_id: "99999999-9999-4999-8999-999999999999".to_owned(),
             shard_id: "prod-us-east-1-001".to_owned(),
-            workspace_id: "22222222-2222-4222-8222-222222222222".to_owned(),
+            tenant_id: "22222222-2222-4222-8222-222222222222".to_owned(),
             revision: 2,
             repositories: vec![wire::GithubRepositorySelection {
                 installation_id: 100,
@@ -1523,16 +1512,13 @@ mod tests {
             "55555555-5555-4555-8555-555555555555"
         );
         assert_eq!(command.shard_id().as_str(), "prod-us-east-1-001");
-        assert_eq!(
-            command.workspace_display_name().as_str(),
-            "Acme Engineering"
-        );
+        assert_eq!(command.tenant_display_name().as_str(), "Acme Engineering");
     }
 
     #[test]
     fn missing_nested_message_and_noncanonical_uuid_are_invalid() {
         let mut request = valid_wire_request();
-        request.workspace = None;
+        request.tenant = None;
         assert!(decode_command(request).is_err());
 
         let mut request = valid_wire_request();
@@ -1541,12 +1527,12 @@ mod tests {
     }
 
     #[test]
-    fn entitlement_wire_request_decodes_a_workspace_aggregate() {
+    fn entitlement_wire_request_decodes_a_tenant_aggregate() {
         let command = decode_entitlement_command(valid_entitlement_wire_request()).unwrap();
         assert_eq!(command.revision().get(), 1);
         assert_eq!(
             command.execution(),
-            WorkspaceExecutionEntitlement::capped(
+            TenantExecutionEntitlement::capped(
                 ComputeSeconds::new(6_000).unwrap(),
                 Some(EntitlementDurationSeconds::new(604_800).unwrap())
             )
@@ -1556,7 +1542,7 @@ mod tests {
     #[test]
     fn entitlement_rejects_fractional_or_missing_policy() {
         let mut request = valid_entitlement_wire_request();
-        let Some(wire::workspace_execution_entitlement::Policy::Capped(capped)) = request
+        let Some(wire::tenant_execution_entitlement::Policy::Capped(capped)) = request
             .execution
             .as_mut()
             .and_then(|value| value.policy.as_mut())
@@ -1588,8 +1574,8 @@ mod tests {
         assert_eq!(policy.runner_policy().runtime_policy().mappings().len(), 1);
 
         let repositories =
-            decode_workspace_repositories_command(valid_workspace_repositories_wire_request())
-                .expect("workspace repositories");
+            decode_tenant_repositories_command(valid_tenant_repositories_wire_request())
+                .expect("tenant repositories");
         assert_eq!(repositories.revision().get(), 2);
         assert_eq!(repositories.repositories().len(), 1);
         assert_eq!(repositories.repositories()[0].repository_id().get(), 200);
@@ -1609,17 +1595,17 @@ mod tests {
         policy.runner_policy.clear();
         assert!(decode_runner_policy_command(policy).is_err());
 
-        let mut repositories = valid_workspace_repositories_wire_request();
+        let mut repositories = valid_tenant_repositories_wire_request();
         repositories.repositories[0].visibility = wire::GithubRepositoryVisibility::Private as i32;
-        assert!(decode_workspace_repositories_command(repositories).is_err());
+        assert!(decode_tenant_repositories_command(repositories).is_err());
     }
 
     #[test]
     fn result_encodes_stable_contract_fields() {
-        let result = ProvisionWorkspaceResult::new(
+        let result = ProvisionTenantResult::new(
             OperationId::parse("55555555-5555-4555-8555-555555555555").unwrap(),
             ShardId::new("prod-us-east-1-001").unwrap(),
-            WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+            ManagedTenantId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
             InitialOwnerPrincipalId::parse("66666666-6666-4666-8666-666666666666").unwrap(),
             ProvisionedAt::new(1_786_500_000, 123_000_000).unwrap(),
         );
@@ -1640,7 +1626,7 @@ mod tests {
     #[test]
     fn application_failure_uses_the_richer_error_model() {
         let error = ProvisioningFailure::new(
-            ProvisioningFailureKind::WorkspaceConflict,
+            ProvisioningFailureKind::TenantConflict,
             Some(automata_ci_provisioning::ProvisioningRequestId::new("request-123").unwrap()),
         );
         let status = provisioning_status(&error);
@@ -1651,10 +1637,10 @@ mod tests {
         assert_eq!(rich.details.len(), 1);
         assert_eq!(rich.details[0].type_url, FAILURE_TYPE_URL);
         let detail =
-            wire::ProvisionWorkspaceFailure::decode(rich.details[0].value.as_slice()).unwrap();
+            wire::ProvisionTenantFailure::decode(rich.details[0].value.as_slice()).unwrap();
         assert_eq!(
             detail.reason,
-            wire::ProvisionWorkspaceFailureReason::WorkspaceConflict as i32
+            wire::ProvisionTenantFailureReason::TenantConflict as i32
         );
         assert_eq!(detail.request_id, "request-123");
     }
@@ -1715,7 +1701,7 @@ mod tests {
                 entitlement_applier.clone(),
                 Arc::new(UnusedProviderConfigurationApplier),
                 runner_policy_applier.clone(),
-                Arc::new(UnusedWorkspaceRepositoriesApplier),
+                Arc::new(UnusedTenantRepositoriesApplier),
             ),
         );
         let cancellation = CancellationToken::new();
@@ -1736,19 +1722,18 @@ mod tests {
             if anonymous.ready().await.is_err() {
                 true
             } else {
-                let response: Result<Response<wire::ProvisionWorkspaceResponse>, Status> =
-                    anonymous
-                        .unary(
-                            Request::new(valid_wire_request()),
-                            tonic::codegen::http::uri::PathAndQuery::from_static(
-                                "/automata.management.v1.ShardManagementService/ProvisionWorkspace",
-                            ),
-                            tonic_prost::ProstCodec::<
-                                wire::ProvisionWorkspaceRequest,
-                                wire::ProvisionWorkspaceResponse,
-                            >::default(),
-                        )
-                        .await;
+                let response: Result<Response<wire::ProvisionTenantResponse>, Status> = anonymous
+                    .unary(
+                        Request::new(valid_wire_request()),
+                        tonic::codegen::http::uri::PathAndQuery::from_static(
+                            "/automata.management.v1.ShardManagementService/ProvisionTenant",
+                        ),
+                        tonic_prost::ProstCodec::<
+                            wire::ProvisionTenantRequest,
+                            wire::ProvisionTenantResponse,
+                        >::default(),
+                    )
+                    .await;
                 response.is_err()
             }
         } else {
@@ -1774,15 +1759,15 @@ mod tests {
         let mut client = tonic::client::Grpc::new(channel);
         client.ready().await.expect("ready gRPC client");
         let path = tonic::codegen::http::uri::PathAndQuery::from_static(
-            "/automata.management.v1.ShardManagementService/ProvisionWorkspace",
+            "/automata.management.v1.ShardManagementService/ProvisionTenant",
         );
-        let response: Response<wire::ProvisionWorkspaceResponse> = client
+        let response: Response<wire::ProvisionTenantResponse> = client
             .unary(
                 Request::new(valid_wire_request()),
                 path,
                 tonic_prost::ProstCodec::<
-                    wire::ProvisionWorkspaceRequest,
-                    wire::ProvisionWorkspaceResponse,
+                    wire::ProvisionTenantRequest,
+                    wire::ProvisionTenantResponse,
                 >::default(),
             )
             .await
@@ -1794,15 +1779,15 @@ mod tests {
         assert_eq!(provisioner.calls.load(Ordering::SeqCst), 1);
 
         client.ready().await.expect("ready entitlement client");
-        let entitlement: Response<wire::ApplyWorkspaceEntitlementResponse> = client
+        let entitlement: Response<wire::ApplyTenantEntitlementResponse> = client
             .unary(
                 Request::new(valid_entitlement_wire_request()),
                 tonic::codegen::http::uri::PathAndQuery::from_static(
-                    "/automata.management.v1.ShardManagementService/ApplyWorkspaceEntitlement",
+                    "/automata.management.v1.ShardManagementService/ApplyTenantEntitlement",
                 ),
                 tonic_prost::ProstCodec::<
-                    wire::ApplyWorkspaceEntitlementRequest,
-                    wire::ApplyWorkspaceEntitlementResponse,
+                    wire::ApplyTenantEntitlementRequest,
+                    wire::ApplyTenantEntitlementResponse,
                 >::default(),
             )
             .await

--- a/crates/automata-ci-provisioning-postgres/Cargo.toml
+++ b/crates/automata-ci-provisioning-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automata-ci-provisioning-postgres"
-description = "PostgreSQL workspace provisioning adapters for Automata"
+description = "PostgreSQL tenant provisioning adapters for Automata"
 publish.workspace = true
 version.workspace = true
 edition.workspace = true

--- a/crates/automata-ci-provisioning-postgres/README.md
+++ b/crates/automata-ci-provisioning-postgres/README.md
@@ -1,6 +1,6 @@
 # automata-ci-provisioning-postgres
 
-PostgreSQL adapters for atomic Automata workspace provisioning, entitlement
+PostgreSQL adapters for atomic Automata tenant provisioning, entitlement
 application, database-backed GitHub provider desired state, and
 authority-scoped usage export. Provider credentials use the mandatory
 control-plane envelope key provider; readers return one repeatable-read current

--- a/crates/automata-ci-provisioning-postgres/src/entitlement.rs
+++ b/crates/automata-ci-provisioning-postgres/src/entitlement.rs
@@ -1,27 +1,27 @@
 use std::fmt;
 
 use automata_ci_provisioning::{
-    ApplyWorkspaceEntitlementResult, AuthorizedApplyWorkspaceEntitlement, EntitlementFailure,
-    EntitlementFailureKind, EntitlementTimestamp, WorkspaceEntitlementApplier,
-    WorkspaceExecutionEntitlement,
+    ApplyTenantEntitlementResult, AuthorizedApplyTenantEntitlement, EntitlementFailure,
+    EntitlementFailureKind, EntitlementTimestamp, TenantEntitlementApplier,
+    TenantExecutionEntitlement,
 };
 use sqlx::{FromRow, PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
-const WORKSPACE_ENTITLEMENT_APPLIED_AUDIT_ACTION: &str = "workspace.entitlement.applied";
+const TENANT_ENTITLEMENT_APPLIED_AUDIT_ACTION: &str = "tenant.entitlement.applied";
 
-/// Replica-safe `PostgreSQL` implementation of workspace entitlement application.
+/// Replica-safe `PostgreSQL` implementation of tenant entitlement application.
 ///
-/// The adapter serializes mutations through the immutable workspace management
+/// The adapter serializes mutations through the immutable tenant management
 /// binding, verifies its exact authority and shard, and atomically stores both
 /// the current snapshot and stable operation receipt. It deliberately performs
 /// no per-job budget allocation.
 #[derive(Clone)]
-pub struct PostgresWorkspaceEntitlementApplier {
+pub struct PostgresTenantEntitlementApplier {
     pool: PgPool,
 }
 
-impl PostgresWorkspaceEntitlementApplier {
+impl PostgresTenantEntitlementApplier {
     /// Binds entitlement application to `pool`.
     #[must_use]
     pub const fn new(pool: PgPool) -> Self {
@@ -31,43 +31,43 @@ impl PostgresWorkspaceEntitlementApplier {
     #[allow(clippy::too_many_lines)] // One ordered transaction owns every entitlement effect.
     async fn apply_inner(
         &self,
-        request: AuthorizedApplyWorkspaceEntitlement,
-    ) -> Result<ApplyWorkspaceEntitlementResult, EntitlementFailure> {
+        request: AuthorizedApplyTenantEntitlement,
+    ) -> Result<ApplyTenantEntitlementResult, EntitlementFailure> {
         let (authority, command) = request.into_parts();
         let authority_id = authority.id().as_str();
         let operation_id = command.operation_id();
         let shard_id = command.shard_id();
-        let workspace_id = command.workspace_id();
-        let workspace_text = workspace_id.to_string();
+        let tenant_id = command.tenant_id();
+        let tenant_text = tenant_id.to_string();
         let revision = i64::try_from(command.revision().get())
             .map_err(|_| failure(EntitlementFailureKind::Internal))?;
         let policy = PolicyFields::from(command.execution())?;
 
         let mut transaction = self.pool.begin().await.map_err(database_failure)?;
-        let binding = lock_management_binding(&mut transaction, &workspace_text).await?;
+        let binding = lock_management_binding(&mut transaction, &tenant_text).await?;
         if binding.as_ref().is_none_or(|binding| {
             binding.authority_id != authority_id || binding.shard_id != shard_id.as_str()
         }) {
-            return Err(failure(EntitlementFailureKind::WorkspaceUnavailable));
+            return Err(failure(EntitlementFailureKind::TenantUnavailable));
         }
 
         if let Some(stored) =
             load_operation(&mut transaction, authority_id, operation_id.as_uuid()).await?
         {
-            if !stored.matches(shard_id.as_str(), &workspace_text, revision, policy) {
+            if !stored.matches(shard_id.as_str(), &tenant_text, revision, policy) {
                 return Err(failure(EntitlementFailureKind::OperationConflict));
             }
-            return stored.result(operation_id, shard_id.clone(), workspace_id);
+            return stored.result(operation_id, shard_id.clone(), tenant_id);
         }
 
         let current_revision: Option<i64> = sqlx::query_scalar(
             r"
-            SELECT revision FROM workspace_execution_entitlements
-            WHERE workspace_id=$1
+            SELECT revision FROM tenant_execution_entitlements
+            WHERE tenant_id=$1
             FOR UPDATE
             ",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .fetch_optional(&mut *transaction)
         .await
         .map_err(database_failure)?;
@@ -86,8 +86,8 @@ impl PostgresWorkspaceEntitlementApplier {
             .transpose()?;
         let inserted = sqlx::query(
             r"
-            INSERT INTO workspace_entitlement_operations (
-                authority_id, operation_id, shard_id, workspace_id, revision,
+            INSERT INTO tenant_entitlement_operations (
+                authority_id, operation_id, shard_id, tenant_id, revision,
                 policy_kind, compute_limit_ms, valid_for_ms, applied_at_ms,
                 expires_at_ms
             ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
@@ -97,7 +97,7 @@ impl PostgresWorkspaceEntitlementApplier {
         .bind(authority_id)
         .bind(operation_id.as_uuid())
         .bind(shard_id.as_str())
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(revision)
         .bind(policy.kind)
         .bind(policy.compute_limit_ms)
@@ -112,10 +112,10 @@ impl PostgresWorkspaceEntitlementApplier {
             let stored = load_operation(&mut transaction, authority_id, operation_id.as_uuid())
                 .await?
                 .ok_or_else(|| failure(EntitlementFailureKind::Internal))?;
-            if !stored.matches(shard_id.as_str(), &workspace_text, revision, policy) {
+            if !stored.matches(shard_id.as_str(), &tenant_text, revision, policy) {
                 return Err(failure(EntitlementFailureKind::OperationConflict));
             }
-            return stored.result(operation_id, shard_id.clone(), workspace_id);
+            return stored.result(operation_id, shard_id.clone(), tenant_id);
         }
 
         let state = if policy.kind == "paused" {
@@ -125,13 +125,13 @@ impl PostgresWorkspaceEntitlementApplier {
         };
         let updated = sqlx::query(
             r"
-            INSERT INTO workspace_execution_entitlements (
-                workspace_id, authority_id, shard_id, revision, operation_id,
+            INSERT INTO tenant_execution_entitlements (
+                tenant_id, authority_id, shard_id, revision, operation_id,
                 policy_kind, compute_limit_ms, valid_for_ms,
                 consumed_compute_ms, state, applied_at_ms, expires_at_ms,
                 exhausted_at_ms
             ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,0,$9,$10,$11,NULL)
-            ON CONFLICT (workspace_id) DO UPDATE SET
+            ON CONFLICT (tenant_id) DO UPDATE SET
                 authority_id=EXCLUDED.authority_id,
                 shard_id=EXCLUDED.shard_id,
                 revision=EXCLUDED.revision,
@@ -144,10 +144,10 @@ impl PostgresWorkspaceEntitlementApplier {
                 applied_at_ms=EXCLUDED.applied_at_ms,
                 expires_at_ms=EXCLUDED.expires_at_ms,
                 exhausted_at_ms=NULL
-            WHERE workspace_execution_entitlements.revision < EXCLUDED.revision
+            WHERE tenant_execution_entitlements.revision < EXCLUDED.revision
             ",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(authority_id)
         .bind(shard_id.as_str())
         .bind(revision)
@@ -170,13 +170,13 @@ impl PostgresWorkspaceEntitlementApplier {
             INSERT INTO security_audit_events (
                 event_id, tenant_id, occurred_at_ms, actor_kind, action,
                 outcome, resource_kind, resource_id
-            ) VALUES ($1,$2,$3,'system',$4,'succeeded','workspace',$2)
+            ) VALUES ($1,$2,$3,'system',$4,'succeeded','tenant',$2)
             ",
         )
         .bind(Uuid::new_v4())
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(applied_at_ms)
-        .bind(WORKSPACE_ENTITLEMENT_APPLIED_AUDIT_ACTION)
+        .bind(TENANT_ENTITLEMENT_APPLIED_AUDIT_ACTION)
         .execute(&mut *transaction)
         .await
         .map_err(database_failure)?;
@@ -185,7 +185,7 @@ impl PostgresWorkspaceEntitlementApplier {
         result(
             operation_id,
             shard_id.clone(),
-            workspace_id,
+            tenant_id,
             command.revision(),
             applied_at_ms,
             expires_at_ms,
@@ -193,18 +193,18 @@ impl PostgresWorkspaceEntitlementApplier {
     }
 }
 
-impl fmt::Debug for PostgresWorkspaceEntitlementApplier {
+impl fmt::Debug for PostgresTenantEntitlementApplier {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("PostgresWorkspaceEntitlementApplier")
+            .debug_struct("PostgresTenantEntitlementApplier")
             .finish_non_exhaustive()
     }
 }
 
-impl WorkspaceEntitlementApplier for PostgresWorkspaceEntitlementApplier {
+impl TenantEntitlementApplier for PostgresTenantEntitlementApplier {
     fn apply(
         &self,
-        request: AuthorizedApplyWorkspaceEntitlement,
+        request: AuthorizedApplyTenantEntitlement,
     ) -> automata_ci_provisioning::EntitlementApplicationFuture<'_> {
         Box::pin(self.apply_inner(request))
     }
@@ -218,9 +218,9 @@ struct PolicyFields {
 }
 
 impl PolicyFields {
-    fn from(value: WorkspaceExecutionEntitlement) -> Result<Self, EntitlementFailure> {
+    fn from(value: TenantExecutionEntitlement) -> Result<Self, EntitlementFailure> {
         match value {
-            WorkspaceExecutionEntitlement::Capped {
+            TenantExecutionEntitlement::Capped {
                 compute_seconds,
                 valid_for,
             } => Ok(Self {
@@ -230,12 +230,12 @@ impl PolicyFields {
                     .map(|duration| seconds_to_milliseconds(duration.get()))
                     .transpose()?,
             }),
-            WorkspaceExecutionEntitlement::Uncapped => Ok(Self {
+            TenantExecutionEntitlement::Uncapped => Ok(Self {
                 kind: "uncapped",
                 compute_limit_ms: None,
                 valid_for_ms: None,
             }),
-            WorkspaceExecutionEntitlement::Paused => Ok(Self {
+            TenantExecutionEntitlement::Paused => Ok(Self {
                 kind: "paused",
                 compute_limit_ms: None,
                 valid_for_ms: None,
@@ -252,16 +252,16 @@ struct ManagementBinding {
 
 async fn lock_management_binding(
     transaction: &mut Transaction<'_, Postgres>,
-    workspace_id: &str,
+    tenant_id: &str,
 ) -> Result<Option<ManagementBinding>, EntitlementFailure> {
     sqlx::query_as::<_, ManagementBinding>(
         r"
-        SELECT authority_id, shard_id FROM workspace_management_bindings
-        WHERE workspace_id=$1
+        SELECT authority_id, shard_id FROM tenant_management_bindings
+        WHERE tenant_id=$1
         FOR UPDATE
         ",
     )
-    .bind(workspace_id)
+    .bind(tenant_id)
     .fetch_optional(&mut **transaction)
     .await
     .map_err(database_failure)
@@ -270,7 +270,7 @@ async fn lock_management_binding(
 #[derive(FromRow)]
 struct StoredOperation {
     shard_id: String,
-    workspace_id: String,
+    tenant_id: String,
     revision: i64,
     policy_kind: String,
     compute_limit_ms: Option<i64>,
@@ -283,12 +283,12 @@ impl StoredOperation {
     fn matches(
         &self,
         shard_id: &str,
-        workspace_id: &str,
+        tenant_id: &str,
         revision: i64,
         policy: PolicyFields,
     ) -> bool {
         self.shard_id == shard_id
-            && self.workspace_id == workspace_id
+            && self.tenant_id == tenant_id
             && self.revision == revision
             && self.policy_kind == policy.kind
             && self.compute_limit_ms == policy.compute_limit_ms
@@ -299,12 +299,12 @@ impl StoredOperation {
         self,
         operation_id: automata_ci_provisioning::OperationId,
         shard_id: automata_ci_provisioning::ShardId,
-        workspace_id: automata_ci_core::WorkspaceId,
-    ) -> Result<ApplyWorkspaceEntitlementResult, EntitlementFailure> {
+        tenant_id: automata_ci_core::ManagedTenantId,
+    ) -> Result<ApplyTenantEntitlementResult, EntitlementFailure> {
         result(
             operation_id,
             shard_id,
-            workspace_id,
+            tenant_id,
             automata_ci_provisioning::EntitlementRevision::new(
                 u64::try_from(self.revision)
                     .map_err(|_| failure(EntitlementFailureKind::Internal))?,
@@ -323,9 +323,9 @@ async fn load_operation(
 ) -> Result<Option<StoredOperation>, EntitlementFailure> {
     sqlx::query_as::<_, StoredOperation>(
         r"
-        SELECT shard_id, workspace_id, revision, policy_kind,
+        SELECT shard_id, tenant_id, revision, policy_kind,
                compute_limit_ms, valid_for_ms, applied_at_ms, expires_at_ms
-        FROM workspace_entitlement_operations
+        FROM tenant_entitlement_operations
         WHERE authority_id=$1 AND operation_id=$2
         FOR UPDATE
         ",
@@ -340,15 +340,15 @@ async fn load_operation(
 fn result(
     operation_id: automata_ci_provisioning::OperationId,
     shard_id: automata_ci_provisioning::ShardId,
-    workspace_id: automata_ci_core::WorkspaceId,
+    tenant_id: automata_ci_core::ManagedTenantId,
     revision: automata_ci_provisioning::EntitlementRevision,
     applied_at_ms: i64,
     expires_at_ms: Option<i64>,
-) -> Result<ApplyWorkspaceEntitlementResult, EntitlementFailure> {
-    Ok(ApplyWorkspaceEntitlementResult::new(
+) -> Result<ApplyTenantEntitlementResult, EntitlementFailure> {
+    Ok(ApplyTenantEntitlementResult::new(
         operation_id,
         shard_id,
-        workspace_id,
+        tenant_id,
         revision,
         timestamp(applied_at_ms)?,
         expires_at_ms.map(timestamp).transpose()?,

--- a/crates/automata-ci-provisioning-postgres/src/github_provider.rs
+++ b/crates/automata-ci-provisioning-postgres/src/github_provider.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use automata_ci_core::JobAuthorityProfile;
-use automata_ci_core::WorkspaceId;
+use automata_ci_core::ManagedTenantId;
 use automata_ci_key_management::{
     EncryptedEnvelope, EnvelopeCodec, EnvelopeError, KeyEncryptionContext, KeyEncryptionProvider,
     KeyId, KeyPurpose, SecretBytes, WrappedDataKey,
@@ -9,9 +9,9 @@ use automata_ci_key_management::{
 use automata_ci_provisioning::{
     ApplyGithubProviderConfigurationCommand, ApplyGithubProviderConfigurationResult,
     ApplyGithubProviderRunnerPolicyCommand, ApplyGithubProviderRunnerPolicyResult,
-    ApplyWorkspaceGithubRepositoriesCommand, ApplyWorkspaceGithubRepositoriesResult,
+    ApplyTenantGithubRepositoriesCommand, ApplyTenantGithubRepositoriesResult,
     AuthorizedApplyGithubProviderConfiguration, AuthorizedApplyGithubProviderRunnerPolicy,
-    AuthorizedApplyWorkspaceGithubRepositories, GithubProviderConfigurationApplicationFuture,
+    AuthorizedApplyTenantGithubRepositories, GithubProviderConfigurationApplicationFuture,
     GithubProviderConfigurationApplier, GithubProviderConfigurationFailure,
     GithubProviderConfigurationFailureKind, GithubProviderConfigurationRevision,
     GithubProviderDesiredState, GithubProviderDesiredStateFailure,
@@ -21,9 +21,9 @@ use automata_ci_provisioning::{
     GithubProviderRunnerPolicyApplier, GithubProviderRunnerPolicyFailure,
     GithubProviderRunnerPolicyFailureKind, GithubProviderSchedulePolicy, GithubProviderSecret,
     GithubProviderTimestamp, MAX_GITHUB_PROVIDER_REPOSITORIES, ShardId,
-    WorkspaceGithubRepositoriesApplicationFuture, WorkspaceGithubRepositoriesApplier,
-    WorkspaceGithubRepositoriesDesiredState, WorkspaceGithubRepositoriesFailure,
-    WorkspaceGithubRepositoriesFailureKind, WorkspaceGithubRepositoriesRevision,
+    TenantGithubRepositoriesApplicationFuture, TenantGithubRepositoriesApplier,
+    TenantGithubRepositoriesDesiredState, TenantGithubRepositoriesFailure,
+    TenantGithubRepositoriesFailureKind, TenantGithubRepositoriesRevision,
 };
 use automata_ci_store::{
     GithubCheckName, GithubRepositoryName, GithubServerServiceAppClientId,
@@ -446,14 +446,14 @@ impl GithubProviderRunnerPolicyApplier for PostgresGithubProviderRunnerPolicyApp
     }
 }
 
-/// Replica-safe `PostgreSQL` implementation of complete workspace repository sets.
+/// Replica-safe `PostgreSQL` implementation of complete tenant repository sets.
 #[derive(Clone)]
-pub struct PostgresWorkspaceGithubRepositoriesApplier {
+pub struct PostgresTenantGithubRepositoriesApplier {
     pool: PgPool,
 }
 
-impl PostgresWorkspaceGithubRepositoriesApplier {
-    /// Binds workspace GitHub repository desired state to `pool`.
+impl PostgresTenantGithubRepositoriesApplier {
+    /// Binds tenant GitHub repository desired state to `pool`.
     #[must_use]
     pub const fn new(pool: PgPool) -> Self {
         Self { pool }
@@ -465,91 +465,87 @@ impl PostgresWorkspaceGithubRepositoriesApplier {
     )]
     async fn apply_inner(
         &self,
-        request: AuthorizedApplyWorkspaceGithubRepositories,
-    ) -> Result<ApplyWorkspaceGithubRepositoriesResult, WorkspaceGithubRepositoriesFailure> {
+        request: AuthorizedApplyTenantGithubRepositories,
+    ) -> Result<ApplyTenantGithubRepositoriesResult, TenantGithubRepositoriesFailure> {
         let (authority, command) = request.into_parts();
-        let digest = workspace_repositories_digest(&command);
+        let digest = tenant_repositories_digest(&command);
         let authority_id = authority.id().as_str();
         let operation_id = command.operation_id();
         let shard_id = command.shard_id();
-        let workspace_id = command.workspace_id();
-        let workspace_text = workspace_id.to_string();
+        let tenant_id = command.tenant_id();
+        let tenant_text = tenant_id.to_string();
         let revision = command.revision();
-        let revision_i64 = i64::try_from(revision.get()).map_err(|_| workspace_internal())?;
-        let mut transaction = self
-            .pool
-            .begin()
-            .await
-            .map_err(workspace_database_failure)?;
+        let revision_i64 = i64::try_from(revision.get()).map_err(|_| tenant_internal())?;
+        let mut transaction = self.pool.begin().await.map_err(tenant_database_failure)?;
 
-        let binding = sqlx::query_as::<_, WorkspaceBinding>(
+        let binding = sqlx::query_as::<_, TenantBinding>(
             r"
-            SELECT authority_id, shard_id FROM workspace_management_bindings
-            WHERE workspace_id=$1 FOR UPDATE
+            SELECT authority_id, shard_id FROM tenant_management_bindings
+            WHERE tenant_id=$1 FOR UPDATE
             ",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .fetch_optional(&mut *transaction)
         .await
-        .map_err(workspace_database_failure)?;
+        .map_err(tenant_database_failure)?;
         if binding.as_ref().is_none_or(|binding| {
             binding.authority_id != authority_id || binding.shard_id != shard_id.as_str()
         }) {
-            return Err(workspace_failure(
-                WorkspaceGithubRepositoriesFailureKind::WorkspaceUnavailable,
+            return Err(tenant_failure(
+                TenantGithubRepositoriesFailureKind::TenantUnavailable,
             ));
         }
 
         if let Some(stored) =
-            load_workspace_operation(&mut transaction, authority_id, operation_id.as_uuid()).await?
+            load_tenant_operation(&mut transaction, authority_id, operation_id.as_uuid()).await?
         {
             if stored.shard_id != shard_id.as_str()
-                || stored.workspace_id != workspace_text
+                || stored.tenant_id != tenant_text
                 || stored.revision != revision_i64
                 || stored.request_digest.as_slice() != digest.as_slice()
             {
-                return Err(workspace_failure(
-                    WorkspaceGithubRepositoriesFailureKind::OperationConflict,
+                return Err(tenant_failure(
+                    TenantGithubRepositoriesFailureKind::OperationConflict,
                 ));
             }
-            return workspace_result(
+            return tenant_result(
                 operation_id,
                 shard_id.clone(),
-                workspace_id,
+                tenant_id,
                 revision,
                 stored.applied_at_ms,
             );
         }
         let current_revision: Option<i64> = sqlx::query_scalar(
-            "SELECT revision FROM workspace_github_repository_current WHERE workspace_id=$1",
+            "SELECT revision FROM tenant_github_repository_current WHERE tenant_id=$1",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .fetch_optional(&mut *transaction)
         .await
-        .map_err(workspace_database_failure)?;
+        .map_err(tenant_database_failure)?;
         if current_revision.is_some_and(|current| revision_i64 <= current) {
-            return Err(workspace_failure(
-                WorkspaceGithubRepositoriesFailureKind::StaleRevision,
+            return Err(tenant_failure(
+                TenantGithubRepositoriesFailureKind::StaleRevision,
             ));
         }
         lock_provider_registry(&mut transaction)
             .await
-            .map_err(workspace_database_failure)?;
+            .map_err(tenant_database_failure)?;
         validate_shard_registry(
             &mut transaction,
             shard_id,
-            workspace_id,
+            tenant_id,
             command.repositories(),
         )
         .await?;
         let applied_at_ms = database_time_milliseconds(&mut transaction)
             .await
-            .map_err(workspace_database_failure)?;
+            .map_err(tenant_database_failure)?;
 
         sqlx::query(
             r"
-            INSERT INTO workspace_github_repository_operations (
-                authority_id, operation_id, shard_id, workspace_id, revision,
+            INSERT INTO tenant_github_repository_operations (
+                authority_id, operation_id, shard_id, tenant_id, revision,
                 request_digest, applied_at_ms
             ) VALUES ($1,$2,$3,$4,$5,$6,$7)
             ",
@@ -557,26 +553,26 @@ impl PostgresWorkspaceGithubRepositoriesApplier {
         .bind(authority_id)
         .bind(operation_id.as_uuid())
         .bind(shard_id.as_str())
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(revision_i64)
         .bind(digest.as_slice())
         .bind(applied_at_ms)
         .execute(&mut *transaction)
         .await
-        .map_err(workspace_database_failure)?;
-        sqlx::query("DELETE FROM workspace_github_repository_current WHERE workspace_id=$1")
-            .bind(&workspace_text)
+        .map_err(tenant_database_failure)?;
+        sqlx::query("DELETE FROM tenant_github_repository_current WHERE tenant_id=$1")
+            .bind(&tenant_text)
             .execute(&mut *transaction)
             .await
-            .map_err(workspace_database_failure)?;
+            .map_err(tenant_database_failure)?;
         sqlx::query(
             r"
-            INSERT INTO workspace_github_repository_current (
-                workspace_id, shard_id, revision, authority_id, operation_id, applied_at_ms
+            INSERT INTO tenant_github_repository_current (
+                tenant_id, shard_id, revision, authority_id, operation_id, applied_at_ms
             ) VALUES ($1,$2,$3,$4,$5,$6)
             ",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(shard_id.as_str())
         .bind(revision_i64)
         .bind(authority_id)
@@ -584,21 +580,21 @@ impl PostgresWorkspaceGithubRepositoriesApplier {
         .bind(applied_at_ms)
         .execute(&mut *transaction)
         .await
-        .map_err(workspace_database_failure)?;
+        .map_err(tenant_database_failure)?;
         for (ordinal, repository) in command.repositories().iter().enumerate() {
             let installation_binding_generation = advance_installation_binding(
                 &mut transaction,
-                &workspace_text,
+                &tenant_text,
                 revision_i64,
                 repository,
             )
             .await?;
             insert_repository_selection(
                 &mut transaction,
-                &workspace_text,
+                &tenant_text,
                 shard_id,
                 revision_i64,
-                i32::try_from(ordinal).map_err(|_| workspace_internal())?,
+                i32::try_from(ordinal).map_err(|_| tenant_internal())?,
                 repository,
                 installation_binding_generation,
             )
@@ -609,43 +605,43 @@ impl PostgresWorkspaceGithubRepositoriesApplier {
             INSERT INTO security_audit_events (
                 event_id, tenant_id, occurred_at_ms, actor_kind, action,
                 outcome, resource_kind, resource_id
-            ) VALUES ($1,$2,$3,'system','workspace.github.repositories.applied',
-                      'succeeded','workspace',$2)
+            ) VALUES ($1,$2,$3,'system','tenant.github.repositories.applied',
+                      'succeeded','tenant',$2)
             ",
         )
         .bind(Uuid::new_v4())
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(applied_at_ms)
         .execute(&mut *transaction)
         .await
-        .map_err(workspace_database_failure)?;
+        .map_err(tenant_database_failure)?;
         transaction
             .commit()
             .await
-            .map_err(workspace_database_failure)?;
-        workspace_result(
+            .map_err(tenant_database_failure)?;
+        tenant_result(
             operation_id,
             shard_id.clone(),
-            workspace_id,
+            tenant_id,
             revision,
             applied_at_ms,
         )
     }
 }
 
-impl fmt::Debug for PostgresWorkspaceGithubRepositoriesApplier {
+impl fmt::Debug for PostgresTenantGithubRepositoriesApplier {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("PostgresWorkspaceGithubRepositoriesApplier")
+            .debug_struct("PostgresTenantGithubRepositoriesApplier")
             .finish_non_exhaustive()
     }
 }
 
-impl WorkspaceGithubRepositoriesApplier for PostgresWorkspaceGithubRepositoriesApplier {
+impl TenantGithubRepositoriesApplier for PostgresTenantGithubRepositoriesApplier {
     fn apply(
         &self,
-        request: AuthorizedApplyWorkspaceGithubRepositories,
-    ) -> WorkspaceGithubRepositoriesApplicationFuture<'_> {
+        request: AuthorizedApplyTenantGithubRepositories,
+    ) -> TenantGithubRepositoriesApplicationFuture<'_> {
         Box::pin(self.apply_inner(request))
     }
 }
@@ -692,12 +688,12 @@ impl PostgresGithubProviderDesiredStateReader {
                 .map_err(desired_database_failure)?;
             return Ok(None);
         };
-        let workspace_states = sqlx::query_as::<_, WorkspaceCurrentRow>(
+        let tenant_states = sqlx::query_as::<_, TenantCurrentRow>(
             r"
-            SELECT current.workspace_id, current.revision, current.applied_at_ms
-            FROM workspace_github_repository_current AS current
+            SELECT current.tenant_id, current.revision, current.applied_at_ms
+            FROM tenant_github_repository_current AS current
             WHERE current.shard_id=$1
-            ORDER BY current.workspace_id
+            ORDER BY current.tenant_id
             ",
         )
         .bind(&provider.shard_id)
@@ -706,20 +702,20 @@ impl PostgresGithubProviderDesiredStateReader {
         .map_err(desired_database_failure)?;
         let selections = sqlx::query_as::<_, RepositorySelectionRow>(
             r"
-            SELECT selections.workspace_id, selections.revision,
+            SELECT selections.tenant_id, selections.revision,
                    selections.provider_installation_id,
                    selections.installation_binding_generation,
                    selections.provider_repository_id,
                    selections.provider_repository_owner_id,
                    selections.repository_name, selections.default_branch,
                    selections.repository_visibility, selections.authority_profile
-            FROM workspace_github_repository_current AS current
-            JOIN workspace_github_repository_selections AS selections
-              ON selections.workspace_id=current.workspace_id
+            FROM tenant_github_repository_current AS current
+            JOIN tenant_github_repository_selections AS selections
+              ON selections.tenant_id=current.tenant_id
              AND selections.shard_id=current.shard_id
              AND selections.revision=current.revision
             WHERE current.shard_id=$1
-            ORDER BY selections.workspace_id, selections.ordinal
+            ORDER BY selections.tenant_id, selections.ordinal
             ",
         )
         .bind(&provider.shard_id)
@@ -730,7 +726,7 @@ impl PostgresGithubProviderDesiredStateReader {
             .commit()
             .await
             .map_err(desired_database_failure)?;
-        self.decode_desired_state(provider, workspace_states, selections)
+        self.decode_desired_state(provider, tenant_states, selections)
             .await
             .map(Some)
     }
@@ -738,7 +734,7 @@ impl PostgresGithubProviderDesiredStateReader {
     async fn decode_desired_state(
         &self,
         provider: ProviderDesiredStateRow,
-        workspace_states: Vec<WorkspaceCurrentRow>,
+        tenant_states: Vec<TenantCurrentRow>,
         selections: Vec<RepositorySelectionRow>,
     ) -> Result<GithubProviderDesiredState, GithubProviderDesiredStateFailure> {
         let revision = positive_u64(provider.revision)?;
@@ -793,24 +789,24 @@ impl PostgresGithubProviderDesiredStateReader {
 
         let mut repositories = BTreeMap::<(String, i64), Vec<_>>::new();
         for selection in selections {
-            let key = (selection.workspace_id.clone(), selection.revision);
+            let key = (selection.tenant_id.clone(), selection.revision);
             repositories
                 .entry(key)
                 .or_default()
                 .push(selection.decode()?);
         }
-        let mut workspaces = Vec::with_capacity(workspace_states.len());
-        for state in workspace_states {
-            let workspace_id =
-                WorkspaceId::parse(&state.workspace_id).map_err(|_| desired_corrupt())?;
-            let revision = WorkspaceGithubRepositoriesRevision::new(positive_u64(state.revision)?)
+        let mut tenants = Vec::with_capacity(tenant_states.len());
+        for state in tenant_states {
+            let tenant_id =
+                ManagedTenantId::parse(&state.tenant_id).map_err(|_| desired_corrupt())?;
+            let revision = TenantGithubRepositoriesRevision::new(positive_u64(state.revision)?)
                 .map_err(|_| desired_corrupt())?;
             let selected = repositories
-                .remove(&(state.workspace_id, state.revision))
+                .remove(&(state.tenant_id, state.revision))
                 .unwrap_or_default();
-            workspaces.push(
-                WorkspaceGithubRepositoriesDesiredState::new(
-                    workspace_id,
+            tenants.push(
+                TenantGithubRepositoriesDesiredState::new(
+                    tenant_id,
                     revision,
                     timestamp(state.applied_at_ms).map_err(|()| desired_corrupt())?,
                     selected,
@@ -834,7 +830,7 @@ impl PostgresGithubProviderDesiredStateReader {
             )
             .map_err(|_| desired_corrupt())?,
             configuration,
-            workspaces,
+            tenants,
         )
         .map_err(|_| desired_corrupt())
     }
@@ -915,15 +911,15 @@ impl ProviderDesiredStateRow {
 }
 
 #[derive(FromRow)]
-struct WorkspaceCurrentRow {
-    workspace_id: String,
+struct TenantCurrentRow {
+    tenant_id: String,
     revision: i64,
     applied_at_ms: i64,
 }
 
 #[derive(FromRow)]
 struct RepositorySelectionRow {
-    workspace_id: String,
+    tenant_id: String,
     revision: i64,
     provider_installation_id: i64,
     installation_binding_generation: i64,
@@ -1254,29 +1250,29 @@ fn next_runner_policy_revision(
 }
 
 #[derive(FromRow)]
-struct WorkspaceBinding {
+struct TenantBinding {
     authority_id: String,
     shard_id: String,
 }
 
 #[derive(FromRow)]
-struct WorkspaceOperationRow {
+struct TenantOperationRow {
     shard_id: String,
-    workspace_id: String,
+    tenant_id: String,
     revision: i64,
     request_digest: Vec<u8>,
     applied_at_ms: i64,
 }
 
-async fn load_workspace_operation(
+async fn load_tenant_operation(
     transaction: &mut Transaction<'_, Postgres>,
     authority_id: &str,
     operation_id: Uuid,
-) -> Result<Option<WorkspaceOperationRow>, WorkspaceGithubRepositoriesFailure> {
+) -> Result<Option<TenantOperationRow>, TenantGithubRepositoriesFailure> {
     sqlx::query_as(
         r"
-        SELECT shard_id, workspace_id, revision, request_digest, applied_at_ms
-        FROM workspace_github_repository_operations
+        SELECT shard_id, tenant_id, revision, request_digest, applied_at_ms
+        FROM tenant_github_repository_operations
         WHERE authority_id=$1 AND operation_id=$2
         ",
     )
@@ -1284,7 +1280,7 @@ async fn load_workspace_operation(
     .bind(operation_id)
     .fetch_optional(&mut **transaction)
     .await
-    .map_err(workspace_database_failure)
+    .map_err(tenant_database_failure)
 }
 
 async fn lock_provider_registry(
@@ -1301,33 +1297,33 @@ async fn lock_provider_registry(
 async fn validate_shard_registry(
     transaction: &mut Transaction<'_, Postgres>,
     shard_id: &ShardId,
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     repositories: &[GithubProviderRepositorySelection],
-) -> Result<(), WorkspaceGithubRepositoriesFailure> {
-    let workspace_text = workspace_id.to_string();
+) -> Result<(), TenantGithubRepositoriesFailure> {
+    let tenant_text = tenant_id.to_string();
     let existing_count: i64 = sqlx::query_scalar(
         r"
-        SELECT count(*) FROM workspace_github_repository_selections
-        WHERE shard_id=$1 AND workspace_id<>$2
+        SELECT count(*) FROM tenant_github_repository_selections
+        WHERE shard_id=$1 AND tenant_id<>$2
         ",
     )
     .bind(shard_id.as_str())
-    .bind(&workspace_text)
+    .bind(&tenant_text)
     .fetch_one(&mut **transaction)
     .await
-    .map_err(workspace_database_failure)?;
-    let existing_count = usize::try_from(existing_count).map_err(|_| workspace_internal())?;
+    .map_err(tenant_database_failure)?;
+    let existing_count = usize::try_from(existing_count).map_err(|_| tenant_internal())?;
     if existing_count
         .checked_add(repositories.len())
         .is_none_or(|count| count > MAX_GITHUB_PROVIDER_REPOSITORIES)
     {
-        return Err(workspace_registry_conflict());
+        return Err(tenant_registry_conflict());
     }
 
     let repository_ids = repositories
         .iter()
         .map(|repository| {
-            i64::try_from(repository.repository_id().get()).map_err(|_| workspace_internal())
+            i64::try_from(repository.repository_id().get()).map_err(|_| tenant_internal())
         })
         .collect::<Result<Vec<_>, _>>()?;
     let repository_names = repositories
@@ -1337,8 +1333,8 @@ async fn validate_shard_registry(
     let conflicts: bool = sqlx::query_scalar(
         r"
         SELECT EXISTS (
-            SELECT 1 FROM workspace_github_repository_selections
-            WHERE shard_id=$1 AND workspace_id<>$2
+            SELECT 1 FROM tenant_github_repository_selections
+            WHERE shard_id=$1 AND tenant_id<>$2
               AND (
                   provider_repository_id=ANY($3::bigint[])
                   OR lower(repository_name)=ANY($4::text[])
@@ -1347,27 +1343,27 @@ async fn validate_shard_registry(
         ",
     )
     .bind(shard_id.as_str())
-    .bind(&workspace_text)
+    .bind(&tenant_text)
     .bind(repository_ids)
     .bind(repository_names)
     .fetch_one(&mut **transaction)
     .await
-    .map_err(workspace_database_failure)?;
+    .map_err(tenant_database_failure)?;
     if conflicts {
-        return Err(workspace_registry_conflict());
+        return Err(tenant_registry_conflict());
     }
     Ok(())
 }
 
 async fn insert_repository_selection(
     transaction: &mut Transaction<'_, Postgres>,
-    workspace_id: &str,
+    tenant_id: &str,
     shard_id: &ShardId,
     revision: i64,
     ordinal: i32,
     repository: &GithubProviderRepositorySelection,
     installation_binding_generation: i64,
-) -> Result<(), WorkspaceGithubRepositoriesFailure> {
+) -> Result<(), TenantGithubRepositoriesFailure> {
     let visibility = match repository.visibility() {
         ProviderRepositoryVisibility::Public => "public",
         ProviderRepositoryVisibility::Private => "private",
@@ -1378,8 +1374,8 @@ async fn insert_repository_selection(
     };
     sqlx::query(
         r"
-        INSERT INTO workspace_github_repository_selections (
-            workspace_id, shard_id, revision, ordinal, provider_installation_id,
+        INSERT INTO tenant_github_repository_selections (
+            tenant_id, shard_id, revision, ordinal, provider_installation_id,
             installation_binding_generation,
             provider_repository_id, provider_repository_owner_id,
             repository_name, default_branch, repository_visibility,
@@ -1387,21 +1383,21 @@ async fn insert_repository_selection(
         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
         ",
     )
-    .bind(workspace_id)
+    .bind(tenant_id)
     .bind(shard_id.as_str())
     .bind(revision)
     .bind(ordinal)
-    .bind(i64::try_from(repository.installation_id().get()).map_err(|_| workspace_internal())?)
+    .bind(i64::try_from(repository.installation_id().get()).map_err(|_| tenant_internal())?)
     .bind(installation_binding_generation)
-    .bind(i64::try_from(repository.repository_id().get()).map_err(|_| workspace_internal())?)
-    .bind(i64::try_from(repository.repository_owner_id().get()).map_err(|_| workspace_internal())?)
+    .bind(i64::try_from(repository.repository_id().get()).map_err(|_| tenant_internal())?)
+    .bind(i64::try_from(repository.repository_owner_id().get()).map_err(|_| tenant_internal())?)
     .bind(repository.repository_name().as_str())
     .bind(repository.default_branch())
     .bind(visibility)
     .bind(authority_profile)
     .execute(&mut **transaction)
     .await
-    .map_err(workspace_database_failure)?;
+    .map_err(tenant_database_failure)?;
     Ok(())
 }
 
@@ -1413,43 +1409,43 @@ struct InstallationBindingRow {
 
 async fn advance_installation_binding(
     transaction: &mut Transaction<'_, Postgres>,
-    workspace_id: &str,
-    workspace_revision: i64,
+    tenant_id: &str,
+    tenant_revision: i64,
     repository: &GithubProviderRepositorySelection,
-) -> Result<i64, WorkspaceGithubRepositoriesFailure> {
+) -> Result<i64, TenantGithubRepositoriesFailure> {
     let repository_id =
-        i64::try_from(repository.repository_id().get()).map_err(|_| workspace_internal())?;
+        i64::try_from(repository.repository_id().get()).map_err(|_| tenant_internal())?;
     let installation_id =
-        i64::try_from(repository.installation_id().get()).map_err(|_| workspace_internal())?;
+        i64::try_from(repository.installation_id().get()).map_err(|_| tenant_internal())?;
     let current = sqlx::query_as::<_, InstallationBindingRow>(
         r"
         SELECT provider_installation_id, binding_generation
-        FROM workspace_github_repository_installation_bindings
-        WHERE workspace_id=$1 AND provider_repository_id=$2
+        FROM tenant_github_repository_installation_bindings
+        WHERE tenant_id=$1 AND provider_repository_id=$2
         FOR UPDATE
         ",
     )
-    .bind(workspace_id)
+    .bind(tenant_id)
     .bind(repository_id)
     .fetch_optional(&mut **transaction)
     .await
-    .map_err(workspace_database_failure)?;
+    .map_err(tenant_database_failure)?;
     let Some(current) = current else {
         sqlx::query(
             r"
-            INSERT INTO workspace_github_repository_installation_bindings (
-                workspace_id, provider_repository_id, provider_installation_id,
+            INSERT INTO tenant_github_repository_installation_bindings (
+                tenant_id, provider_repository_id, provider_installation_id,
                 binding_generation, updated_at_revision
             ) VALUES ($1,$2,$3,1,$4)
             ",
         )
-        .bind(workspace_id)
+        .bind(tenant_id)
         .bind(repository_id)
         .bind(installation_id)
-        .bind(workspace_revision)
+        .bind(tenant_revision)
         .execute(&mut **transaction)
         .await
-        .map_err(workspace_database_failure)?;
+        .map_err(tenant_database_failure)?;
         return Ok(1);
     };
     if current.provider_installation_id == installation_id {
@@ -1458,31 +1454,31 @@ async fn advance_installation_binding(
     let next_generation = current
         .binding_generation
         .checked_add(1)
-        .ok_or_else(workspace_internal)?;
+        .ok_or_else(tenant_internal)?;
     let updated = sqlx::query(
         r"
-        UPDATE workspace_github_repository_installation_bindings
+        UPDATE tenant_github_repository_installation_bindings
         SET provider_installation_id=$3,
             binding_generation=$4,
             updated_at_revision=$5
-        WHERE workspace_id=$1
+        WHERE tenant_id=$1
           AND provider_repository_id=$2
           AND provider_installation_id=$6
           AND binding_generation=$7
         ",
     )
-    .bind(workspace_id)
+    .bind(tenant_id)
     .bind(repository_id)
     .bind(installation_id)
     .bind(next_generation)
-    .bind(workspace_revision)
+    .bind(tenant_revision)
     .bind(current.provider_installation_id)
     .bind(current.binding_generation)
     .execute(&mut **transaction)
     .await
-    .map_err(workspace_database_failure)?;
+    .map_err(tenant_database_failure)?;
     if updated.rows_affected() != 1 {
-        return Err(workspace_internal());
+        return Err(tenant_internal());
     }
     Ok(next_generation)
 }
@@ -1542,11 +1538,11 @@ fn runner_policy_digest(
     digest.finalize().into()
 }
 
-fn workspace_repositories_digest(command: &ApplyWorkspaceGithubRepositoriesCommand) -> [u8; 32] {
+fn tenant_repositories_digest(command: &ApplyTenantGithubRepositoriesCommand) -> [u8; 32] {
     let mut digest = Sha256::new();
     digest.update(REPOSITORY_DIGEST_DOMAIN);
     digest_part(&mut digest, command.shard_id().as_str().as_bytes());
-    digest_part(&mut digest, command.workspace_id().as_uuid().as_bytes());
+    digest_part(&mut digest, command.tenant_id().as_uuid().as_bytes());
     digest_part(&mut digest, &command.revision().get().to_be_bytes());
     for repository in command.repositories() {
         digest_part(
@@ -1624,18 +1620,18 @@ fn runner_policy_result(
     ))
 }
 
-fn workspace_result(
+fn tenant_result(
     operation_id: automata_ci_provisioning::OperationId,
     shard_id: automata_ci_provisioning::ShardId,
-    workspace_id: WorkspaceId,
-    revision: WorkspaceGithubRepositoriesRevision,
+    tenant_id: ManagedTenantId,
+    revision: TenantGithubRepositoriesRevision,
     applied_at_ms: i64,
-) -> Result<ApplyWorkspaceGithubRepositoriesResult, WorkspaceGithubRepositoriesFailure> {
-    let applied_at = timestamp(applied_at_ms).map_err(|()| workspace_internal())?;
-    Ok(ApplyWorkspaceGithubRepositoriesResult::new(
+) -> Result<ApplyTenantGithubRepositoriesResult, TenantGithubRepositoriesFailure> {
+    let applied_at = timestamp(applied_at_ms).map_err(|()| tenant_internal())?;
+    Ok(ApplyTenantGithubRepositoriesResult::new(
         operation_id,
         shard_id,
-        workspace_id,
+        tenant_id,
         revision,
         applied_at,
     ))
@@ -1680,20 +1676,18 @@ fn runner_policy_database_failure(_: sqlx::Error) -> GithubProviderRunnerPolicyF
     runner_policy_failure(GithubProviderRunnerPolicyFailureKind::TemporarilyUnavailable)
 }
 
-fn workspace_failure(
-    kind: WorkspaceGithubRepositoriesFailureKind,
-) -> WorkspaceGithubRepositoriesFailure {
-    WorkspaceGithubRepositoriesFailure::new(kind)
+fn tenant_failure(kind: TenantGithubRepositoriesFailureKind) -> TenantGithubRepositoriesFailure {
+    TenantGithubRepositoriesFailure::new(kind)
 }
 
-fn workspace_internal() -> WorkspaceGithubRepositoriesFailure {
-    workspace_failure(WorkspaceGithubRepositoriesFailureKind::Internal)
+fn tenant_internal() -> TenantGithubRepositoriesFailure {
+    tenant_failure(TenantGithubRepositoriesFailureKind::Internal)
 }
 
-fn workspace_registry_conflict() -> WorkspaceGithubRepositoriesFailure {
-    workspace_failure(WorkspaceGithubRepositoriesFailureKind::ShardRegistryConflict)
+fn tenant_registry_conflict() -> TenantGithubRepositoriesFailure {
+    tenant_failure(TenantGithubRepositoriesFailureKind::ShardRegistryConflict)
 }
 
-fn workspace_database_failure(_: sqlx::Error) -> WorkspaceGithubRepositoriesFailure {
-    workspace_failure(WorkspaceGithubRepositoriesFailureKind::TemporarilyUnavailable)
+fn tenant_database_failure(_: sqlx::Error) -> TenantGithubRepositoriesFailure {
+    tenant_failure(TenantGithubRepositoriesFailureKind::TemporarilyUnavailable)
 }

--- a/crates/automata-ci-provisioning-postgres/src/lib.rs
+++ b/crates/automata-ci-provisioning-postgres/src/lib.rs
@@ -5,9 +5,8 @@
 use std::fmt;
 
 use automata_ci_provisioning::{
-    AuthorizedProvisionWorkspace, InitialOwnerPrincipalId, ProvisionWorkspaceResult, ProvisionedAt,
-    ProvisioningFailure, ProvisioningFailureKind, WorkspaceProvisioner,
-    WorkspaceProvisioningFuture,
+    AuthorizedProvisionTenant, InitialOwnerPrincipalId, ProvisionTenantResult, ProvisionedAt,
+    ProvisioningFailure, ProvisioningFailureKind, TenantProvisioner, TenantProvisioningFuture,
 };
 use sqlx::{FromRow, PgPool, Postgres, Transaction};
 use uuid::Uuid;
@@ -16,30 +15,30 @@ mod entitlement;
 mod github_provider;
 mod usage;
 
-pub use entitlement::PostgresWorkspaceEntitlementApplier;
+pub use entitlement::PostgresTenantEntitlementApplier;
 pub use github_provider::{
     PostgresGithubProviderConfigurationApplier, PostgresGithubProviderDesiredStateReader,
-    PostgresGithubProviderRunnerPolicyApplier, PostgresWorkspaceGithubRepositoriesApplier,
+    PostgresGithubProviderRunnerPolicyApplier, PostgresTenantGithubRepositoriesApplier,
 };
-pub use usage::PostgresWorkspaceUsageExporter;
+pub use usage::PostgresTenantUsageExporter;
 
-const WORKSPACE_OWNER_ROLE_NAME: &str = "workspace-owner";
-const WORKSPACE_OWNER_ROLE_DISPLAY_NAME: &str = "Workspace owner";
-const WORKSPACE_PROVISIONED_AUDIT_ACTION: &str = "workspace.provisioned";
+const TENANT_OWNER_ROLE_NAME: &str = "tenant-owner";
+const TENANT_OWNER_ROLE_DISPLAY_NAME: &str = "Tenant owner";
+const TENANT_PROVISIONED_AUDIT_ACTION: &str = "tenant.provisioned";
 
-/// Replica-safe `PostgreSQL` implementation of the workspace provisioning port.
+/// Replica-safe `PostgreSQL` implementation of the tenant provisioning port.
 ///
-/// The adapter stores the idempotency receipt and every workspace, identity,
+/// The adapter stores the idempotency receipt and every tenant, identity,
 /// membership, authorization, and audit effect in one transaction. An exact
-/// retry returns the original stable result; a reused operation or workspace
+/// retry returns the original stable result; a reused operation or tenant
 /// identity fails without changing durable state.
 #[derive(Clone)]
-pub struct PostgresWorkspaceProvisioner {
+pub struct PostgresTenantProvisioner {
     pool: PgPool,
 }
 
-impl PostgresWorkspaceProvisioner {
-    /// Binds workspace provisioning to `pool`.
+impl PostgresTenantProvisioner {
+    /// Binds tenant provisioning to `pool`.
     #[must_use]
     pub const fn new(pool: PgPool) -> Self {
         Self { pool }
@@ -48,15 +47,15 @@ impl PostgresWorkspaceProvisioner {
     #[allow(clippy::too_many_lines)] // The ordered statements intentionally form one transaction.
     async fn provision_inner(
         &self,
-        request: AuthorizedProvisionWorkspace,
-    ) -> Result<ProvisionWorkspaceResult, ProvisioningFailure> {
+        request: AuthorizedProvisionTenant,
+    ) -> Result<ProvisionTenantResult, ProvisioningFailure> {
         let (authority, command) = request.into_parts();
         let authority_id = authority.id().as_str();
         let operation_id = command.operation_id();
         let shard_id = command.shard_id();
-        let workspace_id = command.workspace_id();
-        let workspace_text = workspace_id.to_string();
-        let workspace_display_name = command.workspace_display_name().as_str();
+        let tenant_id = command.tenant_id();
+        let tenant_text = tenant_id.to_string();
+        let tenant_display_name = command.tenant_display_name().as_str();
         let owner_issuer = command.initial_owner_issuer().as_str();
         let owner_subject = command.initial_owner_subject();
         let owner_display_name = command.initial_owner_display_name().as_str();
@@ -65,9 +64,9 @@ impl PostgresWorkspaceProvisioner {
         let created_at_ms = database_time_milliseconds(&mut transaction).await?;
         let inserted = sqlx::query(
             r"
-            INSERT INTO workspace_provisioning_operations (
-                authority_id, operation_id, shard_id, workspace_id,
-                workspace_display_name, initial_owner_issuer,
+            INSERT INTO tenant_provisioning_operations (
+                authority_id, operation_id, shard_id, tenant_id,
+                tenant_display_name, initial_owner_issuer,
                 initial_owner_subject, initial_owner_display_name, state,
                 created_at_ms
             ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'pending',$9)
@@ -77,8 +76,8 @@ impl PostgresWorkspaceProvisioner {
         .bind(authority_id)
         .bind(operation_id.as_uuid())
         .bind(shard_id.as_str())
-        .bind(&workspace_text)
-        .bind(workspace_display_name)
+        .bind(&tenant_text)
+        .bind(tenant_display_name)
         .bind(owner_issuer)
         .bind(owner_subject.as_uuid())
         .bind(owner_display_name)
@@ -92,15 +91,15 @@ impl PostgresWorkspaceProvisioner {
                 load_operation(&mut transaction, authority_id, operation_id.as_uuid()).await?;
             if !stored.matches(
                 shard_id.as_str(),
-                &workspace_text,
-                workspace_display_name,
+                &tenant_text,
+                tenant_display_name,
                 owner_issuer,
                 owner_subject.as_uuid(),
                 owner_display_name,
             ) {
                 return Err(failure(ProvisioningFailureKind::OperationConflict));
             }
-            return stored.result(operation_id, shard_id.clone(), workspace_id);
+            return stored.result(operation_id, shard_id.clone(), tenant_id);
         }
 
         let tenant_inserted = sqlx::query(
@@ -109,23 +108,23 @@ impl PostgresWorkspaceProvisioner {
             VALUES ($1,$2,$3,$3) ON CONFLICT (id) DO NOTHING
             ",
         )
-        .bind(&workspace_text)
-        .bind(workspace_display_name)
+        .bind(&tenant_text)
+        .bind(tenant_display_name)
         .bind(created_at_ms)
         .execute(&mut *transaction)
         .await
         .map_err(database_failure)?;
         if tenant_inserted.rows_affected() != 1 {
-            return Err(failure(ProvisioningFailureKind::WorkspaceConflict));
+            return Err(failure(ProvisioningFailureKind::TenantConflict));
         }
         sqlx::query(
             r"
-            INSERT INTO workspace_management_bindings (
-                workspace_id, authority_id, shard_id, created_at_ms
+            INSERT INTO tenant_management_bindings (
+                tenant_id, authority_id, shard_id, created_at_ms
             ) VALUES ($1,$2,$3,$4)
             ",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(authority_id)
         .bind(shard_id.as_str())
         .bind(created_at_ms)
@@ -152,7 +151,7 @@ impl PostgresWorkspaceProvisioner {
             ) VALUES ($1,$2,'active',1,1,$3,$3)
             ",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(principal_id)
         .bind(created_at_ms)
         .execute(&mut *transaction)
@@ -166,10 +165,10 @@ impl PostgresWorkspaceProvisioner {
             ) VALUES ($1,$2,$3,$4,'built_in',TRUE,1,$5,$6,$6)
             ",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(role_id)
-        .bind(WORKSPACE_OWNER_ROLE_NAME)
-        .bind(WORKSPACE_OWNER_ROLE_DISPLAY_NAME)
+        .bind(TENANT_OWNER_ROLE_NAME)
+        .bind(TENANT_OWNER_ROLE_DISPLAY_NAME)
         .bind(principal_id)
         .bind(created_at_ms)
         .execute(&mut *transaction)
@@ -188,7 +187,7 @@ impl PostgresWorkspaceProvisioner {
             SELECT count(*) FROM granted
             ",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(role_id)
         .bind(principal_id)
         .bind(created_at_ms)
@@ -207,7 +206,7 @@ impl PostgresWorkspaceProvisioner {
             ) VALUES ($1,$2,$3,$4,'tenant','bootstrap','active',$3,$5,1)
             ",
         )
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(binding_id)
         .bind(principal_id)
         .bind(role_id)
@@ -222,19 +221,19 @@ impl PostgresWorkspaceProvisioner {
             INSERT INTO security_audit_events (
                 event_id, tenant_id, occurred_at_ms, actor_kind, action,
                 outcome, resource_kind, resource_id
-            ) VALUES ($1,$2,$3,'system',$4,'succeeded','workspace',$2)
+            ) VALUES ($1,$2,$3,'system',$4,'succeeded','tenant',$2)
             ",
         )
         .bind(Uuid::new_v4())
-        .bind(&workspace_text)
+        .bind(&tenant_text)
         .bind(provisioned_at_ms)
-        .bind(WORKSPACE_PROVISIONED_AUDIT_ACTION)
+        .bind(TENANT_PROVISIONED_AUDIT_ACTION)
         .execute(&mut *transaction)
         .await
         .map_err(database_failure)?;
         let completed = sqlx::query(
             r"
-            UPDATE workspace_provisioning_operations
+            UPDATE tenant_provisioning_operations
             SET state='completed', initial_owner_principal_id=$3,
                 provisioned_at_ms=$4
             WHERE authority_id=$1 AND operation_id=$2 AND state='pending'
@@ -254,26 +253,26 @@ impl PostgresWorkspaceProvisioner {
 
         let initial_owner_principal_id = InitialOwnerPrincipalId::from_uuid(principal_id)
             .map_err(|_| failure(ProvisioningFailureKind::Internal))?;
-        Ok(ProvisionWorkspaceResult::new(
+        Ok(ProvisionTenantResult::new(
             operation_id,
             shard_id.clone(),
-            workspace_id,
+            tenant_id,
             initial_owner_principal_id,
             provisioned_at(provisioned_at_ms)?,
         ))
     }
 }
 
-impl fmt::Debug for PostgresWorkspaceProvisioner {
+impl fmt::Debug for PostgresTenantProvisioner {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("PostgresWorkspaceProvisioner")
+            .debug_struct("PostgresTenantProvisioner")
             .finish_non_exhaustive()
     }
 }
 
-impl WorkspaceProvisioner for PostgresWorkspaceProvisioner {
-    fn provision(&self, request: AuthorizedProvisionWorkspace) -> WorkspaceProvisioningFuture<'_> {
+impl TenantProvisioner for PostgresTenantProvisioner {
+    fn provision(&self, request: AuthorizedProvisionTenant) -> TenantProvisioningFuture<'_> {
         Box::pin(self.provision_inner(request))
     }
 }
@@ -281,8 +280,8 @@ impl WorkspaceProvisioner for PostgresWorkspaceProvisioner {
 #[derive(FromRow)]
 struct StoredOperation {
     shard_id: String,
-    workspace_id: String,
-    workspace_display_name: String,
+    tenant_id: String,
+    tenant_display_name: String,
     initial_owner_issuer: String,
     initial_owner_subject: Uuid,
     initial_owner_display_name: String,
@@ -296,15 +295,15 @@ impl StoredOperation {
     fn matches(
         &self,
         shard_id: &str,
-        workspace_id: &str,
-        workspace_display_name: &str,
+        tenant_id: &str,
+        tenant_display_name: &str,
         owner_issuer: &str,
         owner_subject: Uuid,
         owner_display_name: &str,
     ) -> bool {
         self.shard_id == shard_id
-            && self.workspace_id == workspace_id
-            && self.workspace_display_name == workspace_display_name
+            && self.tenant_id == tenant_id
+            && self.tenant_display_name == tenant_display_name
             && self.initial_owner_issuer == owner_issuer
             && self.initial_owner_subject == owner_subject
             && self.initial_owner_display_name == owner_display_name
@@ -314,8 +313,8 @@ impl StoredOperation {
         self,
         operation_id: automata_ci_provisioning::OperationId,
         shard_id: automata_ci_provisioning::ShardId,
-        workspace_id: automata_ci_core::WorkspaceId,
-    ) -> Result<ProvisionWorkspaceResult, ProvisioningFailure> {
+        tenant_id: automata_ci_core::ManagedTenantId,
+    ) -> Result<ProvisionTenantResult, ProvisioningFailure> {
         if self.state != "completed" {
             return Err(failure(ProvisioningFailureKind::Internal));
         }
@@ -325,10 +324,10 @@ impl StoredOperation {
         let provisioned_at_ms = self
             .provisioned_at_ms
             .ok_or_else(|| failure(ProvisioningFailureKind::Internal))?;
-        Ok(ProvisionWorkspaceResult::new(
+        Ok(ProvisionTenantResult::new(
             operation_id,
             shard_id,
-            workspace_id,
+            tenant_id,
             InitialOwnerPrincipalId::from_uuid(principal_id)
                 .map_err(|_| failure(ProvisioningFailureKind::Internal))?,
             provisioned_at(provisioned_at_ms)?,
@@ -349,11 +348,11 @@ async fn load_operation(
 ) -> Result<StoredOperation, ProvisioningFailure> {
     sqlx::query_as::<_, StoredOperation>(
         r"
-        SELECT shard_id, workspace_id, workspace_display_name,
+        SELECT shard_id, tenant_id, tenant_display_name,
                initial_owner_issuer, initial_owner_subject,
                initial_owner_display_name, state,
                initial_owner_principal_id, provisioned_at_ms
-        FROM workspace_provisioning_operations
+        FROM tenant_provisioning_operations
         WHERE authority_id=$1 AND operation_id=$2
         FOR UPDATE
         ",

--- a/crates/automata-ci-provisioning-postgres/src/usage.rs
+++ b/crates/automata-ci-provisioning-postgres/src/usage.rs
@@ -1,28 +1,28 @@
 use std::fmt;
 
-use automata_ci_core::WorkspaceId;
+use automata_ci_core::ManagedTenantId;
 use automata_ci_provisioning::{
-    AuthorizedListWorkspaceUsage, ConsumedComputeMilliseconds, EntitlementRevision, ShardId,
-    UsageAttemptId, UsageEventId, UsageExportCursor, UsageExportFailure, UsageExportFailureKind,
-    UsageExportFuture, UsageTimestamp, WorkspaceUsageEvent, WorkspaceUsageExporter,
-    WorkspaceUsagePage,
+    AuthorizedListTenantUsage, ConsumedComputeMilliseconds, EntitlementRevision, ShardId,
+    TenantUsageEvent, TenantUsageExporter, TenantUsagePage, UsageAttemptId, UsageEventId,
+    UsageExportCursor, UsageExportFailure, UsageExportFailureKind, UsageExportFuture,
+    UsageTimestamp,
 };
 use sqlx::{FromRow, PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
 const CURSOR_BYTES: usize = 16;
 
-/// Replica-safe `PostgreSQL` reader for an authority-scoped workspace usage feed.
+/// Replica-safe `PostgreSQL` reader for an authority-scoped tenant usage feed.
 ///
 /// The cursor is the raw UUID of the last event in a returned page. Resolving it
 /// through the authority and shard columns makes a cursor from another export
 /// namespace invalid without exposing the internal append sequence.
 #[derive(Clone)]
-pub struct PostgresWorkspaceUsageExporter {
+pub struct PostgresTenantUsageExporter {
     pool: PgPool,
 }
 
-impl PostgresWorkspaceUsageExporter {
+impl PostgresTenantUsageExporter {
     /// Binds usage export to `pool`.
     #[must_use]
     pub const fn new(pool: PgPool) -> Self {
@@ -31,8 +31,8 @@ impl PostgresWorkspaceUsageExporter {
 
     async fn list_inner(
         &self,
-        request: AuthorizedListWorkspaceUsage,
-    ) -> Result<WorkspaceUsagePage, UsageExportFailure> {
+        request: AuthorizedListTenantUsage,
+    ) -> Result<TenantUsagePage, UsageExportFailure> {
         let (authority, command) = request.into_parts();
         let authority_id = authority.id().as_str();
         let shard_id = command.shard_id();
@@ -43,10 +43,10 @@ impl PostgresWorkspaceUsageExporter {
             resolve_cursor(&mut transaction, authority_id, shard_id.as_str(), &cursor).await?;
         let rows = sqlx::query_as::<_, StoredUsageEvent>(
             r"
-            SELECT event_id, shard_id, workspace_id, attempt_id,
+            SELECT event_id, shard_id, tenant_id, attempt_id,
                    entitlement_revision, interval_start_ms, interval_end_ms,
                    consumed_compute_ms
-            FROM workspace_usage_events
+            FROM tenant_usage_events
             WHERE authority_id=$1 AND shard_id=$2 AND sequence > $3
             ORDER BY sequence
             LIMIT $4
@@ -71,21 +71,21 @@ impl PostgresWorkspaceUsageExporter {
             .map(StoredUsageEvent::decode)
             .collect::<Result<Vec<_>, _>>()?;
         transaction.commit().await.map_err(database_failure)?;
-        WorkspaceUsagePage::new(events, next_cursor)
+        TenantUsagePage::new(events, next_cursor)
             .map_err(|_| failure(UsageExportFailureKind::Internal))
     }
 }
 
-impl fmt::Debug for PostgresWorkspaceUsageExporter {
+impl fmt::Debug for PostgresTenantUsageExporter {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("PostgresWorkspaceUsageExporter")
+            .debug_struct("PostgresTenantUsageExporter")
             .finish_non_exhaustive()
     }
 }
 
-impl WorkspaceUsageExporter for PostgresWorkspaceUsageExporter {
-    fn list(&self, request: AuthorizedListWorkspaceUsage) -> UsageExportFuture<'_> {
+impl TenantUsageExporter for PostgresTenantUsageExporter {
+    fn list(&self, request: AuthorizedListTenantUsage) -> UsageExportFuture<'_> {
         Box::pin(self.list_inner(request))
     }
 }
@@ -94,7 +94,7 @@ impl WorkspaceUsageExporter for PostgresWorkspaceUsageExporter {
 struct StoredUsageEvent {
     event_id: Uuid,
     shard_id: String,
-    workspace_id: String,
+    tenant_id: String,
     attempt_id: Uuid,
     entitlement_revision: i64,
     interval_start_ms: i64,
@@ -103,11 +103,11 @@ struct StoredUsageEvent {
 }
 
 impl StoredUsageEvent {
-    fn decode(self) -> Result<WorkspaceUsageEvent, UsageExportFailure> {
-        WorkspaceUsageEvent::new(
+    fn decode(self) -> Result<TenantUsageEvent, UsageExportFailure> {
+        TenantUsageEvent::new(
             UsageEventId::from_uuid(self.event_id).map_err(corrupt)?,
             ShardId::new(self.shard_id).map_err(corrupt)?,
-            WorkspaceId::parse(&self.workspace_id).map_err(corrupt)?,
+            ManagedTenantId::parse(&self.tenant_id).map_err(corrupt)?,
             UsageAttemptId::from_uuid(self.attempt_id).map_err(corrupt)?,
             EntitlementRevision::new(u64::try_from(self.entitlement_revision).map_err(corrupt)?)
                 .map_err(corrupt)?,
@@ -138,7 +138,7 @@ async fn resolve_cursor(
         .map_err(|_| failure(UsageExportFailureKind::InvalidCursor))?;
     sqlx::query_scalar(
         r"
-        SELECT sequence FROM workspace_usage_events
+        SELECT sequence FROM tenant_usage_events
         WHERE event_id=$1 AND authority_id=$2 AND shard_id=$3
         ",
     )

--- a/crates/automata-ci-provisioning/Cargo.toml
+++ b/crates/automata-ci-provisioning/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automata-ci-provisioning"
-description = "Transport-neutral workspace provisioning boundary for Automata Core"
+description = "Transport-neutral tenant provisioning boundary for Automata Core"
 publish.workspace = true
 version.workspace = true
 edition.workspace = true

--- a/crates/automata-ci-provisioning/README.md
+++ b/crates/automata-ci-provisioning/README.md
@@ -1,7 +1,7 @@
 # automata-ci-provisioning
 
 This crate owns the transport-neutral application boundary for an authorized
-external control plane to provision workspaces, apply execution-entitlement
+external control plane to provision tenants, apply execution-entitlement
 snapshots, apply database-backed GitHub provider desired state, and pull
 immutable usage events from one Automata Core shard. It
 validates the public contract's domain values and keeps workload authority,
@@ -17,7 +17,7 @@ prices, invoices, or Stripe objects. A consumer deduplicates stable event IDs
 and commits its continuation cursor with the accepted events.
 
 Provider desired state separates the encrypted shard-wide GitHub App
-configuration from each workspace's complete repository set. It contains no
+configuration from each tenant's complete repository set. It contains no
 Cloud billing or GitHub OAuth installation ownership policy.
 
 After the initial complete provider configuration exists, the same shard

--- a/crates/automata-ci-provisioning/src/entitlement.rs
+++ b/crates/automata-ci-provisioning/src/entitlement.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use automata_ci_core::WorkspaceId;
+use automata_ci_core::ManagedTenantId;
 use thiserror::Error;
 
 use crate::{OperationId, ProvisioningAuthority, ShardId};
@@ -12,7 +12,7 @@ const PROTOBUF_TIMESTAMP_MIN_SECONDS: i64 = -62_135_596_800;
 const PROTOBUF_TIMESTAMP_MAX_SECONDS: i64 = 253_402_300_799;
 const NANOS_PER_SECOND: u32 = 1_000_000_000;
 
-/// Monotonically increasing version of one workspace entitlement snapshot.
+/// Monotonically increasing version of one tenant entitlement snapshot.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct EntitlementRevision(u64);
 
@@ -36,7 +36,7 @@ impl EntitlementRevision {
     }
 }
 
-/// Positive workspace compute allowance measured at whole-second granularity.
+/// Positive tenant compute allowance measured at whole-second granularity.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ComputeSeconds(u64);
 
@@ -84,24 +84,24 @@ impl EntitlementDurationSeconds {
     }
 }
 
-/// Complete execution policy installed for one workspace revision.
+/// Complete execution policy installed for one tenant revision.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum WorkspaceExecutionEntitlement {
-    /// Execution is bounded by aggregate workspace compute, optionally until a deadline.
+pub enum TenantExecutionEntitlement {
+    /// Execution is bounded by aggregate tenant compute, optionally until a deadline.
     Capped {
         /// Total compute available to this entitlement revision.
         compute_seconds: ComputeSeconds,
         /// Optional validity period anchored by Core when the revision commits.
         valid_for: Option<EntitlementDurationSeconds>,
     },
-    /// Execution is metered but has no Core-enforced workspace compute ceiling.
+    /// Execution is metered but has no Core-enforced tenant compute ceiling.
     Uncapped,
     /// New and running execution is not permitted.
     Paused,
 }
 
-impl WorkspaceExecutionEntitlement {
-    /// Creates a capped aggregate workspace allowance.
+impl TenantExecutionEntitlement {
+    /// Creates a capped aggregate tenant allowance.
     #[must_use]
     pub const fn capped(
         compute_seconds: ComputeSeconds,
@@ -114,30 +114,30 @@ impl WorkspaceExecutionEntitlement {
     }
 }
 
-/// Complete validated semantic input for one workspace entitlement revision.
+/// Complete validated semantic input for one tenant entitlement revision.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ApplyWorkspaceEntitlementCommand {
+pub struct ApplyTenantEntitlementCommand {
     operation_id: OperationId,
     shard_id: ShardId,
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     revision: EntitlementRevision,
-    execution: WorkspaceExecutionEntitlement,
+    execution: TenantExecutionEntitlement,
 }
 
-impl ApplyWorkspaceEntitlementCommand {
+impl ApplyTenantEntitlementCommand {
     /// Creates a complete entitlement snapshot command.
     #[must_use]
     pub const fn new(
         operation_id: OperationId,
         shard_id: ShardId,
-        workspace_id: WorkspaceId,
+        tenant_id: ManagedTenantId,
         revision: EntitlementRevision,
-        execution: WorkspaceExecutionEntitlement,
+        execution: TenantExecutionEntitlement,
     ) -> Self {
         Self {
             operation_id,
             shard_id,
-            workspace_id,
+            tenant_id,
             revision,
             execution,
         }
@@ -155,13 +155,13 @@ impl ApplyWorkspaceEntitlementCommand {
         &self.shard_id
     }
 
-    /// Returns the workspace receiving this snapshot.
+    /// Returns the tenant receiving this snapshot.
     #[must_use]
-    pub const fn workspace_id(&self) -> WorkspaceId {
-        self.workspace_id
+    pub const fn tenant_id(&self) -> ManagedTenantId {
+        self.tenant_id
     }
 
-    /// Returns the monotonic workspace revision.
+    /// Returns the monotonic tenant revision.
     #[must_use]
     pub const fn revision(&self) -> EntitlementRevision {
         self.revision
@@ -169,30 +169,30 @@ impl ApplyWorkspaceEntitlementCommand {
 
     /// Returns the complete execution policy.
     #[must_use]
-    pub const fn execution(&self) -> WorkspaceExecutionEntitlement {
+    pub const fn execution(&self) -> TenantExecutionEntitlement {
         self.execution
     }
 }
 
 /// Entitlement command proven to target the authority's configured shard.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AuthorizedApplyWorkspaceEntitlement {
+pub struct AuthorizedApplyTenantEntitlement {
     authority: ProvisioningAuthority,
-    command: ApplyWorkspaceEntitlementCommand,
+    command: ApplyTenantEntitlementCommand,
 }
 
-impl AuthorizedApplyWorkspaceEntitlement {
+impl AuthorizedApplyTenantEntitlement {
     /// Authorizes a command against the server-derived shard binding.
     ///
     /// Durable persistence additionally requires the same authority to own the
-    /// workspace's external-management binding.
+    /// tenant's external-management binding.
     ///
     /// # Errors
     ///
     /// Rejects a command for another shard.
     pub fn authorize(
         authority: ProvisioningAuthority,
-        command: ApplyWorkspaceEntitlementCommand,
+        command: ApplyTenantEntitlementCommand,
     ) -> Result<Self, EntitlementAuthorizationError> {
         if authority.shard_id() != command.shard_id() {
             return Err(EntitlementAuthorizationError::Forbidden);
@@ -208,13 +208,13 @@ impl AuthorizedApplyWorkspaceEntitlement {
 
     /// Returns the validated semantic command.
     #[must_use]
-    pub const fn command(&self) -> &ApplyWorkspaceEntitlementCommand {
+    pub const fn command(&self) -> &ApplyTenantEntitlementCommand {
         &self.command
     }
 
     /// Consumes the request into its authority and command.
     #[must_use]
-    pub fn into_parts(self) -> (ProvisioningAuthority, ApplyWorkspaceEntitlementCommand) {
+    pub fn into_parts(self) -> (ProvisioningAuthority, ApplyTenantEntitlementCommand) {
         (self.authority, self.command)
     }
 }
@@ -260,22 +260,22 @@ impl EntitlementTimestamp {
 
 /// Stable result committed atomically with one entitlement revision.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ApplyWorkspaceEntitlementResult {
+pub struct ApplyTenantEntitlementResult {
     operation_id: OperationId,
     shard_id: ShardId,
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     revision: EntitlementRevision,
     applied_at: EntitlementTimestamp,
     expires_at: Option<EntitlementTimestamp>,
 }
 
-impl ApplyWorkspaceEntitlementResult {
+impl ApplyTenantEntitlementResult {
     /// Creates a durable first-attempt or replay result.
     #[must_use]
     pub const fn new(
         operation_id: OperationId,
         shard_id: ShardId,
-        workspace_id: WorkspaceId,
+        tenant_id: ManagedTenantId,
         revision: EntitlementRevision,
         applied_at: EntitlementTimestamp,
         expires_at: Option<EntitlementTimestamp>,
@@ -283,7 +283,7 @@ impl ApplyWorkspaceEntitlementResult {
         Self {
             operation_id,
             shard_id,
-            workspace_id,
+            tenant_id,
             revision,
             applied_at,
             expires_at,
@@ -302,13 +302,13 @@ impl ApplyWorkspaceEntitlementResult {
         &self.shard_id
     }
 
-    /// Returns the workspace receiving the snapshot.
+    /// Returns the tenant receiving the snapshot.
     #[must_use]
-    pub const fn workspace_id(&self) -> WorkspaceId {
-        self.workspace_id
+    pub const fn tenant_id(&self) -> ManagedTenantId {
+        self.tenant_id
     }
 
-    /// Returns the committed workspace revision.
+    /// Returns the committed tenant revision.
     #[must_use]
     pub const fn revision(&self) -> EntitlementRevision {
         self.revision
@@ -332,10 +332,10 @@ impl ApplyWorkspaceEntitlementResult {
 pub enum EntitlementFailureKind {
     /// The operation identity is already bound to different semantic input.
     OperationConflict,
-    /// The revision is not newer than the workspace's current revision.
+    /// The revision is not newer than the tenant's current revision.
     StaleRevision,
-    /// The workspace is not managed by this exact external authority.
-    WorkspaceUnavailable,
+    /// The tenant is not managed by this exact external authority.
+    TenantUnavailable,
     /// The authority exceeded a bounded mutation rate.
     RateLimited,
     /// Core failed without a safer specific result.
@@ -346,7 +346,7 @@ pub enum EntitlementFailureKind {
 
 /// Sanitized durable entitlement failure.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-#[error("workspace entitlement application failed: {kind:?}")]
+#[error("tenant entitlement application failed: {kind:?}")]
 pub struct EntitlementFailure {
     kind: EntitlementFailureKind,
 }
@@ -409,13 +409,13 @@ mod tests {
         )
     }
 
-    fn command() -> ApplyWorkspaceEntitlementCommand {
-        ApplyWorkspaceEntitlementCommand::new(
+    fn command() -> ApplyTenantEntitlementCommand {
+        ApplyTenantEntitlementCommand::new(
             OperationId::parse("55555555-5555-4555-8555-555555555555").unwrap(),
             ShardId::new("prod-us-east-1-001").unwrap(),
-            WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+            ManagedTenantId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
             EntitlementRevision::new(1).unwrap(),
-            WorkspaceExecutionEntitlement::capped(
+            TenantExecutionEntitlement::capped(
                 ComputeSeconds::new(6_000).unwrap(),
                 Some(EntitlementDurationSeconds::new(7 * 24 * 60 * 60).unwrap()),
             ),
@@ -425,11 +425,11 @@ mod tests {
     #[test]
     fn capped_snapshot_authorizes_for_exact_shard() {
         let authorized =
-            AuthorizedApplyWorkspaceEntitlement::authorize(authority(), command()).unwrap();
+            AuthorizedApplyTenantEntitlement::authorize(authority(), command()).unwrap();
         assert_eq!(authorized.command().revision().get(), 1);
         assert_eq!(
             authorized.command().execution(),
-            WorkspaceExecutionEntitlement::capped(
+            TenantExecutionEntitlement::capped(
                 ComputeSeconds::new(6_000).unwrap(),
                 Some(EntitlementDurationSeconds::new(604_800).unwrap())
             )
@@ -441,7 +441,7 @@ mod tests {
         let mut command = command();
         command.shard_id = ShardId::new("prod-eu-west-1-001").unwrap();
         assert_eq!(
-            AuthorizedApplyWorkspaceEntitlement::authorize(authority(), command),
+            AuthorizedApplyTenantEntitlement::authorize(authority(), command),
             Err(EntitlementAuthorizationError::Forbidden)
         );
     }

--- a/crates/automata-ci-provisioning/src/github_provider.rs
+++ b/crates/automata-ci-provisioning/src/github_provider.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, fmt, num::NonZeroU64};
 
-use automata_ci_core::{JobAuthorityProfile, WorkspaceId};
+use automata_ci_core::{JobAuthorityProfile, ManagedTenantId};
 use automata_ci_provider_github::GithubWebhookVerifier;
 use automata_ci_store::{
     GithubCheckName, GithubRepositoryName, GithubServerServiceAppClientId,
@@ -18,8 +18,8 @@ use crate::{OperationId, ProvisioningAuthority, ShardId};
 pub const MAX_GITHUB_PROVIDER_PRIVATE_KEY_BYTES: usize = 32 * 1_024;
 /// Maximum repositories served by one shard-wide GitHub provider runtime.
 pub const MAX_GITHUB_PROVIDER_REPOSITORIES: usize = 256;
-/// Maximum repositories in one workspace desired-set revision.
-pub const MAX_WORKSPACE_GITHUB_REPOSITORIES: usize = MAX_GITHUB_PROVIDER_REPOSITORIES;
+/// Maximum repositories in one tenant desired-set revision.
+pub const MAX_TENANT_GITHUB_REPOSITORIES: usize = MAX_GITHUB_PROVIDER_REPOSITORIES;
 
 const PROTOBUF_TIMESTAMP_MIN_SECONDS: i64 = -62_135_596_800;
 const PROTOBUF_TIMESTAMP_MAX_SECONDS: i64 = 253_402_300_799;
@@ -64,9 +64,9 @@ positive_revision!(
     InvalidProviderRevision
 );
 positive_revision!(
-    /// Monotonic complete GitHub repository desired-set revision for one workspace.
-    WorkspaceGithubRepositoriesRevision,
-    InvalidWorkspaceRevision
+    /// Monotonic complete GitHub repository desired-set revision for one tenant.
+    TenantGithubRepositoriesRevision,
+    InvalidTenantRevision
 );
 
 /// Owned GitHub provider credential accepted only at a secret-handling boundary.
@@ -613,7 +613,7 @@ impl fmt::Debug for AuthorizedApplyGithubProviderRunnerPolicy {
     }
 }
 
-/// One selected GitHub repository in a complete workspace desired set.
+/// One selected GitHub repository in a complete tenant desired set.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GithubProviderRepositorySelection {
     installation_id: ProviderInstallationId,
@@ -731,20 +731,20 @@ impl GithubProviderRepositorySelection {
     }
 }
 
-/// Complete validated repository desired-set command for one workspace.
+/// Complete validated repository desired-set command for one tenant.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ApplyWorkspaceGithubRepositoriesCommand {
+pub struct ApplyTenantGithubRepositoriesCommand {
     operation_id: OperationId,
     shard_id: ShardId,
-    workspace_id: WorkspaceId,
-    revision: WorkspaceGithubRepositoriesRevision,
+    tenant_id: ManagedTenantId,
+    revision: TenantGithubRepositoriesRevision,
     repositories: Vec<GithubProviderRepositorySelection>,
 }
 
-impl ApplyWorkspaceGithubRepositoriesCommand {
+impl ApplyTenantGithubRepositoriesCommand {
     /// Creates a complete, stably ordered repository desired set.
     ///
-    /// An empty set is valid and disconnects every repository from the workspace.
+    /// An empty set is valid and disconnects every repository from the tenant.
     ///
     /// # Errors
     ///
@@ -752,15 +752,15 @@ impl ApplyWorkspaceGithubRepositoriesCommand {
     pub fn new(
         operation_id: OperationId,
         shard_id: ShardId,
-        workspace_id: WorkspaceId,
-        revision: WorkspaceGithubRepositoriesRevision,
+        tenant_id: ManagedTenantId,
+        revision: TenantGithubRepositoriesRevision,
         repositories: Vec<GithubProviderRepositorySelection>,
     ) -> Result<Self, GithubProviderValueError> {
         let repositories = normalize_repositories(repositories)?;
         Ok(Self {
             operation_id,
             shard_id,
-            workspace_id,
+            tenant_id,
             revision,
             repositories,
         })
@@ -778,15 +778,15 @@ impl ApplyWorkspaceGithubRepositoriesCommand {
         &self.shard_id
     }
 
-    /// Returns the workspace receiving this desired set.
+    /// Returns the tenant receiving this desired set.
     #[must_use]
-    pub const fn workspace_id(&self) -> WorkspaceId {
-        self.workspace_id
+    pub const fn tenant_id(&self) -> ManagedTenantId {
+        self.tenant_id
     }
 
-    /// Returns the monotonic workspace desired-set revision.
+    /// Returns the monotonic tenant desired-set revision.
     #[must_use]
-    pub const fn revision(&self) -> WorkspaceGithubRepositoriesRevision {
+    pub const fn revision(&self) -> TenantGithubRepositoriesRevision {
         self.revision
     }
 
@@ -797,24 +797,24 @@ impl ApplyWorkspaceGithubRepositoriesCommand {
     }
 }
 
-/// Workspace desired-set command proven to target the caller's configured shard.
+/// Tenant desired-set command proven to target the caller's configured shard.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AuthorizedApplyWorkspaceGithubRepositories {
+pub struct AuthorizedApplyTenantGithubRepositories {
     authority: ProvisioningAuthority,
-    command: ApplyWorkspaceGithubRepositoriesCommand,
+    command: ApplyTenantGithubRepositoriesCommand,
 }
 
-impl AuthorizedApplyWorkspaceGithubRepositories {
+impl AuthorizedApplyTenantGithubRepositories {
     /// Authorizes the requested shard against authenticated workload authority.
     ///
-    /// Durable persistence additionally verifies that the authority owns the workspace.
+    /// Durable persistence additionally verifies that the authority owns the tenant.
     ///
     /// # Errors
     ///
     /// Rejects a command addressed to another shard.
     pub fn authorize(
         authority: ProvisioningAuthority,
-        command: ApplyWorkspaceGithubRepositoriesCommand,
+        command: ApplyTenantGithubRepositoriesCommand,
     ) -> Result<Self, GithubProviderValueError> {
         if authority.shard_id() != command.shard_id() {
             return Err(GithubProviderValueError::Forbidden);
@@ -830,60 +830,55 @@ impl AuthorizedApplyWorkspaceGithubRepositories {
 
     /// Returns the validated command.
     #[must_use]
-    pub const fn command(&self) -> &ApplyWorkspaceGithubRepositoriesCommand {
+    pub const fn command(&self) -> &ApplyTenantGithubRepositoriesCommand {
         &self.command
     }
 
     /// Consumes the authorized request.
     #[must_use]
-    pub fn into_parts(
-        self,
-    ) -> (
-        ProvisioningAuthority,
-        ApplyWorkspaceGithubRepositoriesCommand,
-    ) {
+    pub fn into_parts(self) -> (ProvisioningAuthority, ApplyTenantGithubRepositoriesCommand) {
         (self.authority, self.command)
     }
 }
 
-/// Current complete repository desired set for one workspace.
+/// Current complete repository desired set for one tenant.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct WorkspaceGithubRepositoriesDesiredState {
-    workspace_id: WorkspaceId,
-    revision: WorkspaceGithubRepositoriesRevision,
+pub struct TenantGithubRepositoriesDesiredState {
+    tenant_id: ManagedTenantId,
+    revision: TenantGithubRepositoriesRevision,
     applied_at: GithubProviderTimestamp,
     repositories: Vec<GithubProviderRepositorySelection>,
 }
 
-impl WorkspaceGithubRepositoriesDesiredState {
-    /// Creates one already-validated, stably ordered workspace desired set.
+impl TenantGithubRepositoriesDesiredState {
+    /// Creates one already-validated, stably ordered tenant desired set.
     ///
     /// # Errors
     ///
     /// Rejects excessive or duplicate repository identities.
     pub fn new(
-        workspace_id: WorkspaceId,
-        revision: WorkspaceGithubRepositoriesRevision,
+        tenant_id: ManagedTenantId,
+        revision: TenantGithubRepositoriesRevision,
         applied_at: GithubProviderTimestamp,
         repositories: Vec<GithubProviderRepositorySelection>,
     ) -> Result<Self, GithubProviderValueError> {
         Ok(Self {
-            workspace_id,
+            tenant_id,
             revision,
             applied_at,
             repositories: normalize_repositories(repositories)?,
         })
     }
 
-    /// Returns the workspace owning this desired set.
+    /// Returns the tenant owning this desired set.
     #[must_use]
-    pub const fn workspace_id(&self) -> WorkspaceId {
-        self.workspace_id
+    pub const fn tenant_id(&self) -> ManagedTenantId {
+        self.tenant_id
     }
 
     /// Returns its monotonic complete-set revision.
     #[must_use]
-    pub const fn revision(&self) -> WorkspaceGithubRepositoriesRevision {
+    pub const fn revision(&self) -> TenantGithubRepositoriesRevision {
         self.revision
     }
 
@@ -903,7 +898,7 @@ impl WorkspaceGithubRepositoriesDesiredState {
 fn normalize_repositories(
     mut repositories: Vec<GithubProviderRepositorySelection>,
 ) -> Result<Vec<GithubProviderRepositorySelection>, GithubProviderValueError> {
-    if repositories.len() > MAX_WORKSPACE_GITHUB_REPOSITORIES {
+    if repositories.len() > MAX_TENANT_GITHUB_REPOSITORIES {
         return Err(GithubProviderValueError::TooManyRepositories);
     }
     let mut ids = BTreeSet::new();
@@ -965,7 +960,7 @@ pub struct GithubProviderDesiredState {
     shard_id: ShardId,
     version: GithubProviderDesiredStateVersion,
     configuration: GithubProviderConfiguration,
-    workspaces: Vec<WorkspaceGithubRepositoriesDesiredState>,
+    tenants: Vec<TenantGithubRepositoriesDesiredState>,
 }
 
 impl GithubProviderDesiredState {
@@ -973,25 +968,25 @@ impl GithubProviderDesiredState {
     ///
     /// # Errors
     ///
-    /// Rejects zero runtime revisions or duplicate workspace identities.
+    /// Rejects zero runtime revisions or duplicate tenant identities.
     pub fn new(
         shard_id: ShardId,
         version: GithubProviderDesiredStateVersion,
         configuration: GithubProviderConfiguration,
-        mut workspaces: Vec<WorkspaceGithubRepositoriesDesiredState>,
+        mut tenants: Vec<TenantGithubRepositoriesDesiredState>,
     ) -> Result<Self, GithubProviderValueError> {
-        workspaces.sort_unstable_by_key(WorkspaceGithubRepositoriesDesiredState::workspace_id);
-        if workspaces
+        tenants.sort_unstable_by_key(TenantGithubRepositoriesDesiredState::tenant_id);
+        if tenants
             .windows(2)
-            .any(|pair| pair[0].workspace_id == pair[1].workspace_id)
+            .any(|pair| pair[0].tenant_id == pair[1].tenant_id)
         {
-            return Err(GithubProviderValueError::DuplicateWorkspace);
+            return Err(GithubProviderValueError::DuplicateTenant);
         }
         Ok(Self {
             shard_id,
             version,
             configuration,
-            workspaces,
+            tenants,
         })
     }
 
@@ -1037,10 +1032,10 @@ impl GithubProviderDesiredState {
         &self.configuration
     }
 
-    /// Returns current workspace sets in stable workspace order.
+    /// Returns current tenant sets in stable tenant order.
     #[must_use]
-    pub fn workspaces(&self) -> &[WorkspaceGithubRepositoriesDesiredState] {
-        &self.workspaces
+    pub fn tenants(&self) -> &[TenantGithubRepositoriesDesiredState] {
+        &self.tenants
     }
 
     /// Consumes the snapshot into runtime projection parts.
@@ -1055,7 +1050,7 @@ impl GithubProviderDesiredState {
         u64,
         u64,
         GithubProviderConfiguration,
-        Vec<WorkspaceGithubRepositoriesDesiredState>,
+        Vec<TenantGithubRepositoriesDesiredState>,
     ) {
         (
             self.shard_id,
@@ -1065,7 +1060,7 @@ impl GithubProviderDesiredState {
             self.version.webhook_verifier_revision,
             self.version.runner_policy_revision,
             self.configuration,
-            self.workspaces,
+            self.tenants,
         )
     }
 }
@@ -1093,13 +1088,13 @@ impl fmt::Debug for GithubProviderDesiredState {
                 &self.version.runner_policy_revision,
             )
             .field("configuration", &self.configuration)
-            .field("workspace_count", &self.workspaces.len())
+            .field("tenant_count", &self.tenants.len())
             .field(
                 "repository_count",
                 &self
-                    .workspaces
+                    .tenants
                     .iter()
-                    .map(|workspace| workspace.repositories.len())
+                    .map(|tenant| tenant.repositories.len())
                     .sum::<usize>(),
             )
             .finish()
@@ -1247,30 +1242,30 @@ impl ApplyGithubProviderRunnerPolicyResult {
     }
 }
 
-/// Stable result of applying one workspace repository desired-set revision.
+/// Stable result of applying one tenant repository desired-set revision.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ApplyWorkspaceGithubRepositoriesResult {
+pub struct ApplyTenantGithubRepositoriesResult {
     operation_id: OperationId,
     shard_id: ShardId,
-    workspace_id: WorkspaceId,
-    revision: WorkspaceGithubRepositoriesRevision,
+    tenant_id: ManagedTenantId,
+    revision: TenantGithubRepositoriesRevision,
     applied_at: GithubProviderTimestamp,
 }
 
-impl ApplyWorkspaceGithubRepositoriesResult {
+impl ApplyTenantGithubRepositoriesResult {
     /// Creates a stable durable result.
     #[must_use]
     pub const fn new(
         operation_id: OperationId,
         shard_id: ShardId,
-        workspace_id: WorkspaceId,
-        revision: WorkspaceGithubRepositoriesRevision,
+        tenant_id: ManagedTenantId,
+        revision: TenantGithubRepositoriesRevision,
         applied_at: GithubProviderTimestamp,
     ) -> Self {
         Self {
             operation_id,
             shard_id,
-            workspace_id,
+            tenant_id,
             revision,
             applied_at,
         }
@@ -1288,15 +1283,15 @@ impl ApplyWorkspaceGithubRepositoriesResult {
         &self.shard_id
     }
 
-    /// Returns the affected workspace identity.
+    /// Returns the affected tenant identity.
     #[must_use]
-    pub const fn workspace_id(&self) -> WorkspaceId {
-        self.workspace_id
+    pub const fn tenant_id(&self) -> ManagedTenantId {
+        self.tenant_id
     }
 
     /// Returns the committed desired-set revision.
     #[must_use]
-    pub const fn revision(&self) -> WorkspaceGithubRepositoriesRevision {
+    pub const fn revision(&self) -> TenantGithubRepositoriesRevision {
         self.revision
     }
 
@@ -1381,15 +1376,15 @@ impl GithubProviderConfigurationFailure {
     }
 }
 
-/// Closed workspace repository desired-set failure classification.
+/// Closed tenant repository desired-set failure classification.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum WorkspaceGithubRepositoriesFailureKind {
+pub enum TenantGithubRepositoriesFailureKind {
     /// An operation ID was reused for different input.
     OperationConflict,
-    /// The revision did not advance the current workspace desired set.
+    /// The revision did not advance the current tenant desired set.
     StaleRevision,
-    /// The workspace is absent or managed by another authority.
-    WorkspaceUnavailable,
+    /// The tenant is absent or managed by another authority.
+    TenantUnavailable,
     /// The resulting shard registry would duplicate a repository or exceed capacity.
     ShardRegistryConflict,
     /// Durable storage is temporarily unavailable.
@@ -1398,23 +1393,23 @@ pub enum WorkspaceGithubRepositoriesFailureKind {
     Internal,
 }
 
-/// Sanitized workspace repository desired-set application failure.
+/// Sanitized tenant repository desired-set application failure.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
-#[error("workspace GitHub repository configuration failed: {kind:?}")]
-pub struct WorkspaceGithubRepositoriesFailure {
-    kind: WorkspaceGithubRepositoriesFailureKind,
+#[error("tenant GitHub repository configuration failed: {kind:?}")]
+pub struct TenantGithubRepositoriesFailure {
+    kind: TenantGithubRepositoriesFailureKind,
 }
 
-impl WorkspaceGithubRepositoriesFailure {
+impl TenantGithubRepositoriesFailure {
     /// Creates one closed failure.
     #[must_use]
-    pub const fn new(kind: WorkspaceGithubRepositoriesFailureKind) -> Self {
+    pub const fn new(kind: TenantGithubRepositoriesFailureKind) -> Self {
         Self { kind }
     }
 
     /// Returns the machine-readable failure kind.
     #[must_use]
-    pub const fn kind(&self) -> WorkspaceGithubRepositoriesFailureKind {
+    pub const fn kind(&self) -> TenantGithubRepositoriesFailureKind {
         self.kind
     }
 }
@@ -1455,9 +1450,9 @@ pub enum GithubProviderValueError {
     /// The shard-wide configuration revision is invalid.
     #[error("GitHub provider configuration revision is invalid")]
     InvalidProviderRevision,
-    /// The workspace repository desired-set revision is invalid.
-    #[error("workspace GitHub repository revision is invalid")]
-    InvalidWorkspaceRevision,
+    /// The tenant repository desired-set revision is invalid.
+    #[error("tenant GitHub repository revision is invalid")]
+    InvalidTenantRevision,
     /// The dashboard URL is not a canonical HTTPS base origin.
     #[error("GitHub provider dashboard URL is invalid")]
     InvalidDashboardUrl,
@@ -1476,11 +1471,11 @@ pub enum GithubProviderValueError {
     /// A complete desired set contains duplicate repository identity.
     #[error("GitHub provider repository selection is duplicated")]
     DuplicateRepository,
-    /// A desired-state snapshot contains a duplicate workspace identity.
-    #[error("GitHub provider workspace desired state is duplicated")]
-    DuplicateWorkspace,
+    /// A desired-state snapshot contains a duplicate tenant identity.
+    #[error("GitHub provider tenant desired state is duplicated")]
+    DuplicateTenant,
     /// A complete desired set exceeds the hard repository bound.
-    #[error("workspace GitHub repository selection is excessive")]
+    #[error("tenant GitHub repository selection is excessive")]
     TooManyRepositories,
     /// A management command targets another shard.
     #[error("GitHub provider management is outside the workload authority")]
@@ -1558,22 +1553,22 @@ mod tests {
 
     #[test]
     fn repository_desired_set_is_complete_sorted_and_unique() {
-        let command = ApplyWorkspaceGithubRepositoriesCommand::new(
+        let command = ApplyTenantGithubRepositoriesCommand::new(
             OperationId::parse("11111111-1111-4111-8111-111111111111").unwrap(),
             ShardId::new("local").unwrap(),
-            WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
-            WorkspaceGithubRepositoriesRevision::new(1).unwrap(),
+            ManagedTenantId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+            TenantGithubRepositoriesRevision::new(1).unwrap(),
             vec![repository(2, "owner/two"), repository(1, "owner/one")],
         )
         .unwrap();
         assert_eq!(command.repositories()[0].repository_id().get(), 1);
 
         assert_eq!(
-            ApplyWorkspaceGithubRepositoriesCommand::new(
+            ApplyTenantGithubRepositoriesCommand::new(
                 OperationId::parse("11111111-1111-4111-8111-111111111111").unwrap(),
                 ShardId::new("local").unwrap(),
-                WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
-                WorkspaceGithubRepositoriesRevision::new(1).unwrap(),
+                ManagedTenantId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+                TenantGithubRepositoriesRevision::new(1).unwrap(),
                 vec![repository(1, "owner/one"), repository(1, "owner/two")],
             )
             .unwrap_err(),

--- a/crates/automata-ci-provisioning/src/lib.rs
+++ b/crates/automata-ci-provisioning/src/lib.rs
@@ -4,13 +4,13 @@
 //!
 //! The external control plane authenticates independently of the human it is
 //! installing. A transport maps verified workload evidence to a stable
-//! [`ProvisioningAuthority`], validates a [`ProvisionWorkspaceCommand`], and
-//! constructs an [`AuthorizedProvisionWorkspace`] before calling the durable
-//! [`WorkspaceProvisioner`] port.
+//! [`ProvisioningAuthority`], validates a [`ProvisionTenantCommand`], and
+//! constructs an [`AuthorizedProvisionTenant`] before calling the durable
+//! [`TenantProvisioner`] port.
 //!
 //! Certificate rotations do not alter the authority ID. Durable adapters must
 //! namespace idempotency by that stable authority and the operation ID, never by
-//! a certificate, connection, pod, or replica. Workspace entitlement snapshots
+//! a certificate, connection, pod, or replica. Tenant entitlement snapshots
 //! and usage-export cursors use the same authority and remain independent of
 //! Cloud billing concepts.
 
@@ -21,17 +21,17 @@ mod port;
 mod usage;
 
 pub use entitlement::{
-    ApplyWorkspaceEntitlementCommand, ApplyWorkspaceEntitlementResult,
-    AuthorizedApplyWorkspaceEntitlement, ComputeSeconds, EntitlementAuthorizationError,
-    EntitlementDurationSeconds, EntitlementFailure, EntitlementFailureKind, EntitlementRevision,
-    EntitlementTimestamp, EntitlementValueError, WorkspaceExecutionEntitlement,
+    ApplyTenantEntitlementCommand, ApplyTenantEntitlementResult, AuthorizedApplyTenantEntitlement,
+    ComputeSeconds, EntitlementAuthorizationError, EntitlementDurationSeconds, EntitlementFailure,
+    EntitlementFailureKind, EntitlementRevision, EntitlementTimestamp, EntitlementValueError,
+    TenantExecutionEntitlement,
 };
 pub use github_provider::{
     ApplyGithubProviderConfigurationCommand, ApplyGithubProviderConfigurationResult,
     ApplyGithubProviderRunnerPolicyCommand, ApplyGithubProviderRunnerPolicyResult,
-    ApplyWorkspaceGithubRepositoriesCommand, ApplyWorkspaceGithubRepositoriesResult,
+    ApplyTenantGithubRepositoriesCommand, ApplyTenantGithubRepositoriesResult,
     AuthorizedApplyGithubProviderConfiguration, AuthorizedApplyGithubProviderRunnerPolicy,
-    AuthorizedApplyWorkspaceGithubRepositories, GithubProviderConfiguration,
+    AuthorizedApplyTenantGithubRepositories, GithubProviderConfiguration,
     GithubProviderConfigurationFailure, GithubProviderConfigurationFailureKind,
     GithubProviderConfigurationRevision, GithubProviderDesiredState,
     GithubProviderDesiredStateFailure, GithubProviderDesiredStateFailureKind,
@@ -39,12 +39,12 @@ pub use github_provider::{
     GithubProviderRunnerPolicyFailure, GithubProviderRunnerPolicyFailureKind,
     GithubProviderSchedulePolicy, GithubProviderSecret, GithubProviderTimestamp,
     GithubProviderValueError, MAX_GITHUB_PROVIDER_REPOSITORIES,
-    WorkspaceGithubRepositoriesDesiredState, WorkspaceGithubRepositoriesFailure,
-    WorkspaceGithubRepositoriesFailureKind, WorkspaceGithubRepositoriesRevision,
+    TenantGithubRepositoriesDesiredState, TenantGithubRepositoriesFailure,
+    TenantGithubRepositoriesFailureKind, TenantGithubRepositoriesRevision,
 };
 pub use model::{
-    AuthorizedProvisionWorkspace, DelegatedActorIssuer, DisplayName, ExternalAccountSubject,
-    InitialOwnerPrincipalId, OperationId, ProvisionWorkspaceCommand, ProvisionWorkspaceResult,
+    AuthorizedProvisionTenant, DelegatedActorIssuer, DisplayName, ExternalAccountSubject,
+    InitialOwnerPrincipalId, OperationId, ProvisionTenantCommand, ProvisionTenantResult,
     ProvisionedAt, ProvisioningAuthority, ProvisioningAuthorityId, ProvisioningAuthorizationError,
     ProvisioningFailure, ProvisioningFailureKind, ProvisioningRequestId, ProvisioningValueError,
     ShardId,
@@ -55,14 +55,14 @@ pub use port::{
     GithubProviderConfigurationApplier, GithubProviderDesiredStateLoadFuture,
     GithubProviderDesiredStateReader, GithubProviderRunnerPolicyApplicationFuture,
     GithubProviderRunnerPolicyApplier, ProvisioningAuthenticationError,
-    ProvisioningAuthenticationFuture, ProvisioningWorkloadAuthenticator, UsageExportFuture,
-    WorkloadAuthenticationEvidence, WorkspaceEntitlementApplier,
-    WorkspaceGithubRepositoriesApplicationFuture, WorkspaceGithubRepositoriesApplier,
-    WorkspaceProvisioner, WorkspaceProvisioningFuture, WorkspaceUsageExporter,
+    ProvisioningAuthenticationFuture, ProvisioningWorkloadAuthenticator, TenantEntitlementApplier,
+    TenantGithubRepositoriesApplicationFuture, TenantGithubRepositoriesApplier, TenantProvisioner,
+    TenantProvisioningFuture, TenantUsageExporter, UsageExportFuture,
+    WorkloadAuthenticationEvidence,
 };
 pub use usage::{
-    AuthorizedListWorkspaceUsage, ConsumedComputeMilliseconds, ListWorkspaceUsageCommand,
-    UsageAttemptId, UsageAuthorizationError, UsageEventId, UsageExportCursor, UsageExportFailure,
-    UsageExportFailureKind, UsageExportPageSize, UsageTimestamp, UsageValueError,
-    WorkspaceUsageEvent, WorkspaceUsagePage,
+    AuthorizedListTenantUsage, ConsumedComputeMilliseconds, ListTenantUsageCommand,
+    TenantUsageEvent, TenantUsagePage, UsageAttemptId, UsageAuthorizationError, UsageEventId,
+    UsageExportCursor, UsageExportFailure, UsageExportFailureKind, UsageExportPageSize,
+    UsageTimestamp, UsageValueError,
 };

--- a/crates/automata-ci-provisioning/src/model.rs
+++ b/crates/automata-ci-provisioning/src/model.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use automata_ci_core::WorkspaceId;
+use automata_ci_core::ManagedTenantId;
 use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
@@ -108,7 +108,7 @@ impl ShardId {
 pub struct DisplayName(String);
 
 impl DisplayName {
-    /// Validates one workspace or human display label.
+    /// Validates one tenant or human display label.
     ///
     /// # Errors
     ///
@@ -230,26 +230,26 @@ impl ProvisioningAuthority {
     }
 }
 
-/// Complete validated semantic input for workspace provisioning.
+/// Complete validated semantic input for tenant provisioning.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProvisionWorkspaceCommand {
+pub struct ProvisionTenantCommand {
     operation_id: OperationId,
     shard_id: ShardId,
-    workspace_id: WorkspaceId,
-    workspace_display_name: DisplayName,
+    tenant_id: ManagedTenantId,
+    tenant_display_name: DisplayName,
     initial_owner_issuer: DelegatedActorIssuer,
     initial_owner_subject: ExternalAccountSubject,
     initial_owner_display_name: DisplayName,
 }
 
-impl ProvisionWorkspaceCommand {
+impl ProvisionTenantCommand {
     /// Creates one fully validated provisioning command.
     #[allow(clippy::too_many_arguments)]
     pub const fn new(
         operation_id: OperationId,
         shard_id: ShardId,
-        workspace_id: WorkspaceId,
-        workspace_display_name: DisplayName,
+        tenant_id: ManagedTenantId,
+        tenant_display_name: DisplayName,
         initial_owner_issuer: DelegatedActorIssuer,
         initial_owner_subject: ExternalAccountSubject,
         initial_owner_display_name: DisplayName,
@@ -257,8 +257,8 @@ impl ProvisionWorkspaceCommand {
         Self {
             operation_id,
             shard_id,
-            workspace_id,
-            workspace_display_name,
+            tenant_id,
+            tenant_display_name,
             initial_owner_issuer,
             initial_owner_subject,
             initial_owner_display_name,
@@ -275,14 +275,14 @@ impl ProvisionWorkspaceCommand {
         &self.shard_id
     }
 
-    /// Returns the exact workspace/Core tenant identity.
-    pub const fn workspace_id(&self) -> WorkspaceId {
-        self.workspace_id
+    /// Returns the exact tenant/Core tenant identity.
+    pub const fn tenant_id(&self) -> ManagedTenantId {
+        self.tenant_id
     }
 
-    /// Returns the initial workspace label.
-    pub const fn workspace_display_name(&self) -> &DisplayName {
-        &self.workspace_display_name
+    /// Returns the initial tenant label.
+    pub const fn tenant_display_name(&self) -> &DisplayName {
+        &self.tenant_display_name
     }
 
     /// Returns the exact external identity issuer.
@@ -303,12 +303,12 @@ impl ProvisionWorkspaceCommand {
 
 /// Provisioning command proven to be within a workload authority's scope.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AuthorizedProvisionWorkspace {
+pub struct AuthorizedProvisionTenant {
     authority: ProvisioningAuthority,
-    command: ProvisionWorkspaceCommand,
+    command: ProvisionTenantCommand,
 }
 
-impl AuthorizedProvisionWorkspace {
+impl AuthorizedProvisionTenant {
     /// Authorizes a command against the server-derived shard and issuer bindings.
     ///
     /// # Errors
@@ -316,7 +316,7 @@ impl AuthorizedProvisionWorkspace {
     /// Rejects a command for any other shard or delegated actor issuer.
     pub fn authorize(
         authority: ProvisioningAuthority,
-        command: ProvisionWorkspaceCommand,
+        command: ProvisionTenantCommand,
     ) -> Result<Self, ProvisioningAuthorizationError> {
         if authority.shard_id != command.shard_id
             || authority.delegated_actor_issuer != command.initial_owner_issuer
@@ -332,12 +332,12 @@ impl AuthorizedProvisionWorkspace {
     }
 
     /// Returns the validated semantic command.
-    pub const fn command(&self) -> &ProvisionWorkspaceCommand {
+    pub const fn command(&self) -> &ProvisionTenantCommand {
         &self.command
     }
 
     /// Consumes the request into its authority and command.
-    pub fn into_parts(self) -> (ProvisioningAuthority, ProvisionWorkspaceCommand) {
+    pub fn into_parts(self) -> (ProvisioningAuthority, ProvisionTenantCommand) {
         (self.authority, self.command)
     }
 }
@@ -381,27 +381,27 @@ impl ProvisionedAt {
 
 /// Stable result committed atomically with the provisioning operation.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProvisionWorkspaceResult {
+pub struct ProvisionTenantResult {
     operation_id: OperationId,
     shard_id: ShardId,
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     initial_owner_principal_id: InitialOwnerPrincipalId,
     provisioned_at: ProvisionedAt,
 }
 
-impl ProvisionWorkspaceResult {
+impl ProvisionTenantResult {
     /// Creates a durable first-attempt or replay result.
     pub const fn new(
         operation_id: OperationId,
         shard_id: ShardId,
-        workspace_id: WorkspaceId,
+        tenant_id: ManagedTenantId,
         initial_owner_principal_id: InitialOwnerPrincipalId,
         provisioned_at: ProvisionedAt,
     ) -> Self {
         Self {
             operation_id,
             shard_id,
-            workspace_id,
+            tenant_id,
             initial_owner_principal_id,
             provisioned_at,
         }
@@ -417,9 +417,9 @@ impl ProvisionWorkspaceResult {
         &self.shard_id
     }
 
-    /// Returns the resulting workspace/Core tenant identity.
-    pub const fn workspace_id(&self) -> WorkspaceId {
-        self.workspace_id
+    /// Returns the resulting tenant/Core tenant identity.
+    pub const fn tenant_id(&self) -> ManagedTenantId {
+        self.tenant_id
     }
 
     /// Returns the Core-owned initial owner principal.
@@ -465,8 +465,8 @@ impl ProvisioningRequestId {
 pub enum ProvisioningFailureKind {
     /// The operation ID is already bound to different semantic input.
     OperationConflict,
-    /// Another operation already owns the workspace identity.
-    WorkspaceConflict,
+    /// Another operation already owns the tenant identity.
+    TenantConflict,
     /// The exact external identity cannot be used as an active principal.
     PrincipalUnavailable,
     /// The authority exceeded a bounded provisioning rate.
@@ -479,7 +479,7 @@ pub enum ProvisioningFailureKind {
 
 /// Sanitized application failure with optional safe correlation identity.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
-#[error("workspace provisioning failed: {kind:?}")]
+#[error("tenant provisioning failed: {kind:?}")]
 pub struct ProvisioningFailure {
     kind: ProvisioningFailureKind,
     request_id: Option<ProvisioningRequestId>,
@@ -557,11 +557,11 @@ mod tests {
         )
     }
 
-    fn command() -> ProvisionWorkspaceCommand {
-        ProvisionWorkspaceCommand::new(
+    fn command() -> ProvisionTenantCommand {
+        ProvisionTenantCommand::new(
             OperationId::parse("55555555-5555-4555-8555-555555555555").unwrap(),
             ShardId::new("prod-us-east-1-001").unwrap(),
-            WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+            ManagedTenantId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
             DisplayName::new("Acme Engineering").unwrap(),
             DelegatedActorIssuer::new("https://cloud.automata.example").unwrap(),
             ExternalAccountSubject::parse("11111111-1111-4111-8111-111111111111").unwrap(),
@@ -571,13 +571,13 @@ mod tests {
 
     #[test]
     fn canonical_contract_values_authorize() {
-        let authorized = AuthorizedProvisionWorkspace::authorize(authority(), command()).unwrap();
+        let authorized = AuthorizedProvisionTenant::authorize(authority(), command()).unwrap();
         assert_eq!(
             authorized.authority().id().as_str(),
             "automata-cloud-production"
         );
         assert_eq!(
-            authorized.command().workspace_id().to_string(),
+            authorized.command().tenant_id().to_string(),
             "22222222-2222-4222-8222-222222222222"
         );
     }
@@ -587,7 +587,7 @@ mod tests {
         let mut wrong_shard = command();
         wrong_shard.shard_id = ShardId::new("prod-eu-west-1-001").unwrap();
         assert_eq!(
-            AuthorizedProvisionWorkspace::authorize(authority(), wrong_shard),
+            AuthorizedProvisionTenant::authorize(authority(), wrong_shard),
             Err(ProvisioningAuthorizationError::Forbidden)
         );
 
@@ -595,7 +595,7 @@ mod tests {
         wrong_issuer.initial_owner_issuer =
             DelegatedActorIssuer::new("https://other.automata.example").unwrap();
         assert_eq!(
-            AuthorizedProvisionWorkspace::authorize(authority(), wrong_issuer),
+            AuthorizedProvisionTenant::authorize(authority(), wrong_issuer),
             Err(ProvisioningAuthorizationError::Forbidden)
         );
     }

--- a/crates/automata-ci-provisioning/src/port.rs
+++ b/crates/automata-ci-provisioning/src/port.rs
@@ -4,14 +4,14 @@ use thiserror::Error;
 
 use crate::{
     ApplyGithubProviderConfigurationResult, ApplyGithubProviderRunnerPolicyResult,
-    ApplyWorkspaceEntitlementResult, ApplyWorkspaceGithubRepositoriesResult,
+    ApplyTenantEntitlementResult, ApplyTenantGithubRepositoriesResult,
     AuthorizedApplyGithubProviderConfiguration, AuthorizedApplyGithubProviderRunnerPolicy,
-    AuthorizedApplyWorkspaceEntitlement, AuthorizedApplyWorkspaceGithubRepositories,
-    AuthorizedListWorkspaceUsage, AuthorizedProvisionWorkspace, EntitlementFailure,
+    AuthorizedApplyTenantEntitlement, AuthorizedApplyTenantGithubRepositories,
+    AuthorizedListTenantUsage, AuthorizedProvisionTenant, EntitlementFailure,
     GithubProviderConfigurationFailure, GithubProviderDesiredState,
-    GithubProviderDesiredStateFailure, GithubProviderRunnerPolicyFailure, ProvisionWorkspaceResult,
-    ProvisioningAuthority, ProvisioningFailure, UsageExportFailure,
-    WorkspaceGithubRepositoriesFailure, WorkspaceUsagePage,
+    GithubProviderDesiredStateFailure, GithubProviderRunnerPolicyFailure, ProvisionTenantResult,
+    ProvisioningAuthority, ProvisioningFailure, TenantGithubRepositoriesFailure, TenantUsagePage,
+    UsageExportFailure,
 };
 
 const MAX_CERTIFICATE_COUNT: usize = 32;
@@ -105,10 +105,9 @@ pub enum ProvisioningAuthenticationError {
     Unavailable,
 }
 
-/// Boxed durable workspace provisioning operation.
-pub type WorkspaceProvisioningFuture<'a> = Pin<
-    Box<dyn Future<Output = Result<ProvisionWorkspaceResult, ProvisioningFailure>> + Send + 'a>,
->;
+/// Boxed durable tenant provisioning operation.
+pub type TenantProvisioningFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<ProvisionTenantResult, ProvisioningFailure>> + Send + 'a>>;
 
 /// Atomic, idempotent application port for one Core shard.
 ///
@@ -116,31 +115,24 @@ pub type WorkspaceProvisioningFuture<'a> = Pin<
 /// principal mapping, membership, built-in owner binding, audit event, and
 /// stable response in one durable transaction. Exact retries return the stored
 /// response without repeating effects.
-pub trait WorkspaceProvisioner: fmt::Debug + Send + Sync {
-    /// Applies one authorized workspace provisioning command.
-    fn provision(&self, request: AuthorizedProvisionWorkspace) -> WorkspaceProvisioningFuture<'_>;
+pub trait TenantProvisioner: fmt::Debug + Send + Sync {
+    /// Applies one authorized tenant provisioning command.
+    fn provision(&self, request: AuthorizedProvisionTenant) -> TenantProvisioningFuture<'_>;
 }
 
-/// Boxed durable workspace entitlement operation.
+/// Boxed durable tenant entitlement operation.
 pub type EntitlementApplicationFuture<'a> = Pin<
-    Box<
-        dyn Future<Output = Result<ApplyWorkspaceEntitlementResult, EntitlementFailure>>
-            + Send
-            + 'a,
-    >,
+    Box<dyn Future<Output = Result<ApplyTenantEntitlementResult, EntitlementFailure>> + Send + 'a>,
 >;
 
-/// Atomic, idempotent workspace entitlement application port.
+/// Atomic, idempotent tenant entitlement application port.
 ///
-/// Implementations must verify the workspace's durable external-management
+/// Implementations must verify the tenant's durable external-management
 /// binding, reject stale revisions, and commit the current snapshot and stable
 /// operation response in one transaction.
-pub trait WorkspaceEntitlementApplier: fmt::Debug + Send + Sync {
+pub trait TenantEntitlementApplier: fmt::Debug + Send + Sync {
     /// Applies one authorized complete entitlement snapshot.
-    fn apply(
-        &self,
-        request: AuthorizedApplyWorkspaceEntitlement,
-    ) -> EntitlementApplicationFuture<'_>;
+    fn apply(&self, request: AuthorizedApplyTenantEntitlement) -> EntitlementApplicationFuture<'_>;
 }
 
 /// Boxed shard-wide GitHub provider configuration application.
@@ -195,31 +187,31 @@ pub trait GithubProviderRunnerPolicyApplier: fmt::Debug + Send + Sync {
     ) -> GithubProviderRunnerPolicyApplicationFuture<'_>;
 }
 
-/// Boxed workspace GitHub repository desired-set application.
-pub type WorkspaceGithubRepositoriesApplicationFuture<'a> = Pin<
+/// Boxed tenant GitHub repository desired-set application.
+pub type TenantGithubRepositoriesApplicationFuture<'a> = Pin<
     Box<
         dyn Future<
                 Output = Result<
-                    ApplyWorkspaceGithubRepositoriesResult,
-                    WorkspaceGithubRepositoriesFailure,
+                    ApplyTenantGithubRepositoriesResult,
+                    TenantGithubRepositoriesFailure,
                 >,
             > + Send
             + 'a,
     >,
 >;
 
-/// Atomic, idempotent application port for one complete workspace repository set.
+/// Atomic, idempotent application port for one complete tenant repository set.
 ///
 /// Omission is authoritative: a successful revision replaces the complete
-/// desired set for that workspace. Implementations retain durable operation
+/// desired set for that tenant. Implementations retain durable operation
 /// receipts for replay while exposing only current desired state to the provider
 /// runtime.
-pub trait WorkspaceGithubRepositoriesApplier: fmt::Debug + Send + Sync {
-    /// Applies one authorized complete workspace repository selection.
+pub trait TenantGithubRepositoriesApplier: fmt::Debug + Send + Sync {
+    /// Applies one authorized complete tenant repository selection.
     fn apply(
         &self,
-        request: AuthorizedApplyWorkspaceGithubRepositories,
-    ) -> WorkspaceGithubRepositoriesApplicationFuture<'_>;
+        request: AuthorizedApplyTenantGithubRepositories,
+    ) -> TenantGithubRepositoriesApplicationFuture<'_>;
 }
 
 /// Boxed load of the current database-backed GitHub provider desired state.
@@ -237,15 +229,15 @@ pub type GithubProviderDesiredStateLoadFuture<'a> = Pin<
 
 /// Read port for one transactionally consistent provider desired-state snapshot.
 pub trait GithubProviderDesiredStateReader: fmt::Debug + Send + Sync {
-    /// Loads the current provider configuration and all current workspace sets.
+    /// Loads the current provider configuration and all current tenant sets.
     ///
     /// `None` means no shard-wide provider configuration has been installed.
     fn load(&self) -> GithubProviderDesiredStateLoadFuture<'_>;
 }
 
-/// Boxed durable workspace usage-export operation.
+/// Boxed durable tenant usage-export operation.
 pub type UsageExportFuture<'a> =
-    Pin<Box<dyn Future<Output = Result<WorkspaceUsagePage, UsageExportFailure>> + Send + 'a>>;
+    Pin<Box<dyn Future<Output = Result<TenantUsagePage, UsageExportFailure>> + Send + 'a>>;
 
 /// Stable cursor-pull port for immutable execution-accounting facts.
 ///
@@ -253,9 +245,9 @@ pub type UsageExportFuture<'a> =
 /// authority, return events in stable append order, and never reuse an event ID
 /// for different facts. A consumer can therefore commit event ingestion and
 /// its continuation cursor atomically for at-least-once delivery.
-pub trait WorkspaceUsageExporter: fmt::Debug + Send + Sync {
+pub trait TenantUsageExporter: fmt::Debug + Send + Sync {
     /// Lists one authority-scoped page after the request's exclusive cursor.
-    fn list(&self, request: AuthorizedListWorkspaceUsage) -> UsageExportFuture<'_>;
+    fn list(&self, request: AuthorizedListTenantUsage) -> UsageExportFuture<'_>;
 }
 
 #[cfg(test)]

--- a/crates/automata-ci-provisioning/src/usage.rs
+++ b/crates/automata-ci-provisioning/src/usage.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use automata_ci_core::WorkspaceId;
+use automata_ci_core::ManagedTenantId;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -199,10 +199,10 @@ impl ConsumedComputeMilliseconds {
 /// The event is provider-neutral actual usage, not a price, invoice line, or
 /// promise that a commercial provider will bill the interval.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct WorkspaceUsageEvent {
+pub struct TenantUsageEvent {
     event_id: UsageEventId,
     shard_id: ShardId,
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     attempt_id: UsageAttemptId,
     entitlement_revision: EntitlementRevision,
     interval_start: UsageTimestamp,
@@ -210,7 +210,7 @@ pub struct WorkspaceUsageEvent {
     consumed_compute: ConsumedComputeMilliseconds,
 }
 
-impl WorkspaceUsageEvent {
+impl TenantUsageEvent {
     /// Creates one positive accounted interval under an entitlement revision.
     ///
     /// # Errors
@@ -220,7 +220,7 @@ impl WorkspaceUsageEvent {
     pub fn new(
         event_id: UsageEventId,
         shard_id: ShardId,
-        workspace_id: WorkspaceId,
+        tenant_id: ManagedTenantId,
         attempt_id: UsageAttemptId,
         entitlement_revision: EntitlementRevision,
         interval_start: UsageTimestamp,
@@ -233,7 +233,7 @@ impl WorkspaceUsageEvent {
         Ok(Self {
             event_id,
             shard_id,
-            workspace_id,
+            tenant_id,
             attempt_id,
             entitlement_revision,
             interval_start,
@@ -254,10 +254,10 @@ impl WorkspaceUsageEvent {
         &self.shard_id
     }
 
-    /// Returns the workspace that consumed the compute.
+    /// Returns the tenant that consumed the compute.
     #[must_use]
-    pub const fn workspace_id(&self) -> WorkspaceId {
-        self.workspace_id
+    pub const fn tenant_id(&self) -> ManagedTenantId {
+        self.tenant_id
     }
 
     /// Returns the execution attempt that consumed the compute.
@@ -293,13 +293,13 @@ impl WorkspaceUsageEvent {
 
 /// Validated request for an authority-scoped page of immutable usage events.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ListWorkspaceUsageCommand {
+pub struct ListTenantUsageCommand {
     shard_id: ShardId,
     cursor: UsageExportCursor,
     page_size: UsageExportPageSize,
 }
 
-impl ListWorkspaceUsageCommand {
+impl ListTenantUsageCommand {
     /// Creates one cursor-pull request.
     #[must_use]
     pub const fn new(
@@ -335,23 +335,23 @@ impl ListWorkspaceUsageCommand {
 
 /// Usage request proven to target the authenticated authority's configured shard.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AuthorizedListWorkspaceUsage {
+pub struct AuthorizedListTenantUsage {
     authority: ProvisioningAuthority,
-    command: ListWorkspaceUsageCommand,
+    command: ListTenantUsageCommand,
 }
 
-impl AuthorizedListWorkspaceUsage {
+impl AuthorizedListTenantUsage {
     /// Authorizes a usage request against the server-derived shard binding.
     ///
     /// Durable export additionally filters events by this exact authority so
-    /// two authorities sharing a shard cannot observe each other's workspaces.
+    /// two authorities sharing a shard cannot observe each other's tenants.
     ///
     /// # Errors
     ///
     /// Rejects a command for another shard.
     pub fn authorize(
         authority: ProvisioningAuthority,
-        command: ListWorkspaceUsageCommand,
+        command: ListTenantUsageCommand,
     ) -> Result<Self, UsageAuthorizationError> {
         if authority.shard_id() != command.shard_id() {
             return Err(UsageAuthorizationError::Forbidden);
@@ -367,32 +367,32 @@ impl AuthorizedListWorkspaceUsage {
 
     /// Returns the validated semantic command.
     #[must_use]
-    pub const fn command(&self) -> &ListWorkspaceUsageCommand {
+    pub const fn command(&self) -> &ListTenantUsageCommand {
         &self.command
     }
 
     /// Consumes the request into its authority and command.
     #[must_use]
-    pub fn into_parts(self) -> (ProvisioningAuthority, ListWorkspaceUsageCommand) {
+    pub fn into_parts(self) -> (ProvisioningAuthority, ListTenantUsageCommand) {
         (self.authority, self.command)
     }
 }
 
 /// Stable page returned from the durable authority-scoped usage feed.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct WorkspaceUsagePage {
-    events: Vec<WorkspaceUsageEvent>,
+pub struct TenantUsagePage {
+    events: Vec<TenantUsageEvent>,
     next_cursor: UsageExportCursor,
 }
 
-impl WorkspaceUsagePage {
+impl TenantUsagePage {
     /// Creates one bounded page and its exclusive continuation cursor.
     ///
     /// # Errors
     ///
     /// Rejects more events than the version-one page bound.
     pub fn new(
-        events: Vec<WorkspaceUsageEvent>,
+        events: Vec<TenantUsageEvent>,
         next_cursor: UsageExportCursor,
     ) -> Result<Self, UsageValueError> {
         if events.len() > MAX_PAGE_SIZE as usize {
@@ -406,7 +406,7 @@ impl WorkspaceUsagePage {
 
     /// Returns the immutable events in stable feed order.
     #[must_use]
-    pub fn events(&self) -> &[WorkspaceUsageEvent] {
+    pub fn events(&self) -> &[TenantUsageEvent] {
         &self.events
     }
 
@@ -418,7 +418,7 @@ impl WorkspaceUsagePage {
 
     /// Consumes the page into its events and continuation cursor.
     #[must_use]
-    pub fn into_parts(self) -> (Vec<WorkspaceUsageEvent>, UsageExportCursor) {
+    pub fn into_parts(self) -> (Vec<TenantUsageEvent>, UsageExportCursor) {
         (self.events, self.next_cursor)
     }
 }
@@ -438,7 +438,7 @@ pub enum UsageExportFailureKind {
 
 /// Sanitized durable usage-export failure.
 #[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
-#[error("workspace usage export failed: {kind:?}")]
+#[error("tenant usage export failed: {kind:?}")]
 pub struct UsageExportFailure {
     kind: UsageExportFailureKind,
 }
@@ -507,11 +507,11 @@ mod tests {
         )
     }
 
-    fn event() -> WorkspaceUsageEvent {
-        WorkspaceUsageEvent::new(
+    fn event() -> TenantUsageEvent {
+        TenantUsageEvent::new(
             UsageEventId::parse("77777777-7777-4777-8777-777777777777").unwrap(),
             ShardId::new("prod-us-east-1-001").unwrap(),
-            WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+            ManagedTenantId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
             UsageAttemptId::parse("66666666-6666-4666-8666-666666666666").unwrap(),
             EntitlementRevision::new(3).unwrap(),
             UsageTimestamp::new(1_786_500_100, 0).unwrap(),
@@ -523,16 +523,16 @@ mod tests {
 
     #[test]
     fn cursor_pull_authorizes_for_exact_shard() {
-        let command = ListWorkspaceUsageCommand::new(
+        let command = ListTenantUsageCommand::new(
             ShardId::new("prod-us-east-1-001").unwrap(),
             UsageExportCursor::beginning(),
             UsageExportPageSize::new(250).unwrap(),
         );
-        let authorized = AuthorizedListWorkspaceUsage::authorize(authority(), command).unwrap();
+        let authorized = AuthorizedListTenantUsage::authorize(authority(), command).unwrap();
         assert_eq!(authorized.command().page_size().get(), 250);
         assert!(authorized.command().cursor().as_bytes().is_empty());
 
-        let page = WorkspaceUsagePage::new(
+        let page = TenantUsagePage::new(
             vec![event()],
             UsageExportCursor::new(vec![0, 0, 0, 1]).unwrap(),
         )
@@ -543,13 +543,13 @@ mod tests {
 
     #[test]
     fn another_shard_is_forbidden() {
-        let command = ListWorkspaceUsageCommand::new(
+        let command = ListTenantUsageCommand::new(
             ShardId::new("prod-eu-west-1-001").unwrap(),
             UsageExportCursor::beginning(),
             UsageExportPageSize::new(100).unwrap(),
         );
         assert_eq!(
-            AuthorizedListWorkspaceUsage::authorize(authority(), command),
+            AuthorizedListTenantUsage::authorize(authority(), command),
             Err(UsageAuthorizationError::Forbidden)
         );
     }
@@ -577,7 +577,7 @@ mod tests {
             Err(UsageValueError::InvalidPageSize)
         );
         assert_eq!(
-            WorkspaceUsagePage::new(
+            TenantUsagePage::new(
                 vec![event(); MAX_PAGE_SIZE as usize + 1],
                 UsageExportCursor::beginning(),
             ),
@@ -589,10 +589,10 @@ mod tests {
     fn usage_intervals_and_compute_are_positive() {
         let start = UsageTimestamp::new(1_786_500_100, 0).unwrap();
         assert_eq!(
-            WorkspaceUsageEvent::new(
+            TenantUsageEvent::new(
                 UsageEventId::parse("77777777-7777-4777-8777-777777777777").unwrap(),
                 ShardId::new("prod-us-east-1-001").unwrap(),
-                WorkspaceId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
+                ManagedTenantId::parse("22222222-2222-4222-8222-222222222222").unwrap(),
                 UsageAttemptId::parse("66666666-6666-4666-8666-666666666666").unwrap(),
                 EntitlementRevision::new(3).unwrap(),
                 start,

--- a/crates/automata-ci-scm/tests/support/mod.rs
+++ b/crates/automata-ci-scm/tests/support/mod.rs
@@ -1,4 +1,4 @@
-use automata_ci_core::{Sha256Digest, UnixMillis, WorkspaceId};
+use automata_ci_core::{ManagedTenantId, Sha256Digest, UnixMillis};
 use automata_ci_provider::{
     ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits,
     ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
@@ -17,7 +17,7 @@ pub(crate) fn connection_with_state(
     state: ProviderLifecycleState,
 ) -> ProviderConnectionManifest {
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
         ExternalRepositoryIdentity::new(
             "22222222-2222-4222-8222-222222222222"
                 .parse::<ProviderInstanceId>()

--- a/crates/automata-ci-store-postgres/migrations/0075_managed_tenant_terminology.sql
+++ b/crates/automata-ci-store-postgres/migrations/0075_managed_tenant_terminology.sql
@@ -1,0 +1,237 @@
+-- The externally managed isolation boundary is a Core tenant. Rename the
+-- provisional workspace vocabulary without rewriting frozen migration history.
+
+ALTER TABLE workspace_provisioning_operations
+    RENAME TO tenant_provisioning_operations;
+ALTER TABLE tenant_provisioning_operations
+    RENAME COLUMN workspace_id TO tenant_id;
+ALTER TABLE tenant_provisioning_operations
+    RENAME COLUMN workspace_display_name TO tenant_display_name;
+
+ALTER TABLE workspace_management_bindings
+    RENAME TO tenant_management_bindings;
+ALTER TABLE tenant_management_bindings
+    RENAME COLUMN workspace_id TO tenant_id;
+
+ALTER TABLE workspace_entitlement_operations
+    RENAME TO tenant_entitlement_operations;
+ALTER TABLE tenant_entitlement_operations
+    RENAME COLUMN workspace_id TO tenant_id;
+
+ALTER TABLE workspace_execution_entitlements
+    RENAME TO tenant_execution_entitlements;
+ALTER TABLE tenant_execution_entitlements
+    RENAME COLUMN workspace_id TO tenant_id;
+
+ALTER TABLE workspace_usage_events
+    RENAME TO tenant_usage_events;
+ALTER TABLE tenant_usage_events
+    RENAME COLUMN workspace_id TO tenant_id;
+ALTER SEQUENCE workspace_usage_events_sequence_seq
+    RENAME TO tenant_usage_events_sequence_seq;
+
+ALTER TABLE workspace_github_repository_operations
+    RENAME TO tenant_github_repository_operations;
+ALTER TABLE tenant_github_repository_operations
+    RENAME COLUMN workspace_id TO tenant_id;
+
+ALTER TABLE workspace_github_repository_current
+    RENAME TO tenant_github_repository_current;
+ALTER TABLE tenant_github_repository_current
+    RENAME COLUMN workspace_id TO tenant_id;
+
+ALTER TABLE workspace_github_repository_selections
+    RENAME TO tenant_github_repository_selections;
+ALTER TABLE tenant_github_repository_selections
+    RENAME COLUMN workspace_id TO tenant_id;
+
+ALTER TABLE workspace_github_repository_installation_bindings
+    RENAME TO tenant_github_repository_installation_bindings;
+ALTER TABLE tenant_github_repository_installation_bindings
+    RENAME COLUMN workspace_id TO tenant_id;
+
+ALTER TABLE provider_connection_revisions
+    RENAME COLUMN workspace_id TO tenant_id;
+
+-- PostgreSQL preserves constraint and index identifiers when their owning
+-- relation or column is renamed. Rename those catalog objects as well so new
+-- diagnostics and schema inspection contain only the accepted tenant term.
+DO $$
+DECLARE
+    relation_name TEXT;
+    constraint_row RECORD;
+    index_row RECORD;
+    replacement_name TEXT;
+BEGIN
+    FOREACH relation_name IN ARRAY ARRAY[
+        'tenant_provisioning_operations',
+        'tenant_management_bindings',
+        'tenant_entitlement_operations',
+        'tenant_execution_entitlements',
+        'tenant_usage_events',
+        'tenant_github_repository_operations',
+        'tenant_github_repository_current',
+        'tenant_github_repository_selections',
+        'tenant_github_repository_installation_bindings',
+        'provider_connection_revisions'
+    ]
+    LOOP
+        FOR constraint_row IN
+            SELECT constraint_catalog.oid, constraint_catalog.conname
+            FROM pg_catalog.pg_constraint AS constraint_catalog
+            WHERE constraint_catalog.conrelid = relation_name::REGCLASS
+              AND constraint_catalog.conname LIKE '%workspace%'
+            ORDER BY constraint_catalog.conname
+        LOOP
+            replacement_name := pg_catalog.replace(
+                constraint_row.conname,
+                'workspace',
+                'tenant'
+            );
+            EXECUTE pg_catalog.format(
+                'ALTER TABLE %I RENAME CONSTRAINT %I TO %I',
+                relation_name,
+                constraint_row.conname,
+                replacement_name
+            );
+        END LOOP;
+
+        FOR index_row IN
+            SELECT index_relation.relname
+            FROM pg_catalog.pg_index AS index_catalog
+            JOIN pg_catalog.pg_class AS index_relation
+              ON index_relation.oid = index_catalog.indexrelid
+            WHERE index_catalog.indrelid = relation_name::REGCLASS
+              AND index_relation.relname LIKE '%workspace%'
+            ORDER BY index_relation.relname
+        LOOP
+            replacement_name := pg_catalog.replace(
+                index_row.relname,
+                'workspace',
+                'tenant'
+            );
+            EXECUTE pg_catalog.format(
+                'ALTER INDEX %I RENAME TO %I',
+                index_row.relname,
+                replacement_name
+            );
+        END LOOP;
+    END LOOP;
+END;
+$$;
+
+LOCK TABLE rbac_roles IN SHARE MODE;
+
+UPDATE rbac_roles
+SET name = 'tenant-owner',
+    display_name = 'Tenant owner',
+    revision = revision + 1,
+    updated_at_ms = GREATEST(
+        updated_at_ms,
+        floor(extract(epoch FROM clock_timestamp()) * 1000)::BIGINT
+    )
+WHERE name = 'workspace-owner'
+  AND role_kind = 'built_in'
+  AND immutable;
+
+UPDATE rbac_permissions
+SET description = CASE name
+    WHEN 'billing:read'
+        THEN 'Read tenant billing, usage, invoice, and payment status.'
+    WHEN 'billing:manage'
+        THEN 'Manage tenant payment methods and subscription lifecycle.'
+    ELSE description
+END
+WHERE name IN ('billing:read', 'billing:manage');
+
+-- This trigger function was created before provider connections adopted the
+-- common tenant column. Replace the exact current body after the column rename.
+CREATE OR REPLACE FUNCTION automata_require_current_manifest_runtime_policy_pair()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+    pair_exists BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1
+        FROM workflow_runtime_policy_current AS current_policy
+        JOIN github_provider_manifest_current AS current_manifest
+          ON current_manifest.tenant_id = current_policy.tenant_id
+         AND current_manifest.repository_id = current_policy.repository_id
+        JOIN github_provider_manifest_revisions AS manifest
+          ON manifest.tenant_id = current_manifest.tenant_id
+         AND manifest.repository_id = current_manifest.repository_id
+         AND manifest.provider_connection_id = current_manifest.provider_connection_id
+         AND manifest.manifest_revision = current_manifest.manifest_revision
+         AND manifest.manifest_digest = current_manifest.manifest_digest
+        WHERE current_policy.tenant_id = NEW.tenant_id
+          AND current_policy.repository_id = NEW.repository_id
+          AND manifest.runtime_policy_revision = current_policy.policy_revision
+          AND manifest.runtime_policy_digest = current_policy.policy_digest
+    ) OR EXISTS (
+        SELECT 1
+        FROM workflow_runtime_policy_current AS current_policy
+        JOIN workflow_runtime_policy_revisions AS policy
+          ON policy.tenant_id = current_policy.tenant_id
+         AND policy.repository_id = current_policy.repository_id
+         AND policy.policy_revision = current_policy.policy_revision
+         AND policy.policy_digest = current_policy.policy_digest
+         AND policy.state = 'sealed'
+        JOIN repositories AS repository
+          ON repository.tenant_id = current_policy.tenant_id
+         AND repository.id = current_policy.repository_id
+        JOIN provider_connection_revisions AS connection
+          ON connection.tenant_id = repository.tenant_id
+         AND connection.external_repository_id = repository.provider_repository_id
+         AND connection.lifecycle_state = 'active'
+         AND connection.runner_policy_schema = policy.policy_schema
+         AND connection.runner_policy_digest = pg_catalog.sha256(policy.canonical_policy)
+        JOIN provider_instance_revisions AS provider
+          ON provider.instance_id = connection.provider_instance_id
+         AND provider.revision = connection.provider_revision
+         AND provider.provider_type = repository.scm_provider
+         AND provider.configuration_digest = connection.provider_configuration_digest
+         AND provider.capability_digest = connection.capability_digest
+         AND provider.lifecycle_state = 'active'
+        WHERE current_policy.tenant_id = NEW.tenant_id
+          AND current_policy.repository_id = NEW.repository_id
+    ) INTO pair_exists;
+    IF pair_exists IS NOT TRUE THEN
+        RAISE EXCEPTION 'current provider manifest and runtime policy are not an exact pair'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'provider_current_runtime_policy_pair';
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        WHERE namespace.nspname = 'public'
+          AND (
+              relation.relname LIKE 'workspace\_provisioning%' ESCAPE '\'
+              OR relation.relname LIKE 'workspace\_management%' ESCAPE '\'
+              OR relation.relname LIKE 'workspace\_entitlement%' ESCAPE '\'
+              OR relation.relname LIKE 'workspace\_execution%' ESCAPE '\'
+              OR relation.relname LIKE 'workspace\_usage%' ESCAPE '\'
+              OR relation.relname LIKE 'workspace\_github%' ESCAPE '\'
+              OR relation.relname = 'provider_connections_by_workspace'
+          )
+    ) THEN
+        RAISE EXCEPTION 'managed workspace relation survived tenant terminology migration';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns AS column_catalog
+        WHERE column_catalog.table_schema = 'public'
+          AND column_catalog.column_name IN ('workspace_id', 'workspace_display_name')
+    ) THEN
+        RAISE EXCEPTION 'managed workspace column survived tenant terminology migration';
+    END IF;
+END;
+$$;

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -1284,7 +1284,7 @@ async fn revalidate_provider_result_consumer(
          AND provider_instance.capability_digest = provider_connection.capability_digest
         JOIN repositories AS repository
           ON repository.id = $7
-         AND repository.tenant_id = provider_connection.workspace_id
+         AND repository.tenant_id = provider_connection.tenant_id
          AND repository.scm_provider = provider_instance.provider_type
          AND repository.provider_repository_id = provider_connection.external_repository_id
         WHERE outbox.subject_id = $1
@@ -1295,7 +1295,7 @@ async fn revalidate_provider_result_consumer(
           AND outbox.claim_started_at_ms <= $4
           AND outbox.claim_expires_at_ms > $4
           AND subject.connection_id = $6
-          AND provider_connection.workspace_id = $8
+          AND provider_connection.tenant_id = $8
           AND provider_instance.provider_type = 'github'
           AND provider_connection.external_repository_id = $9
         FOR SHARE OF outbox, subject, provider_connection, provider_instance, repository

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -1682,7 +1682,7 @@ async fn load_provider_selection_authority_row(
           AND invocation.created_at_ms = $8
           AND $9 >= invocation.claim_started_at_ms
           AND $9 < invocation.claim_expires_at_ms
-          AND connection.workspace_id = $10
+          AND connection.tenant_id = $10
           AND connection.lifecycle_state = 'active'
           AND provider.lifecycle_state = 'active'
           AND delivery.provider_type = $11

--- a/crates/automata-ci-store-postgres/src/migration_0061_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_0061_tests.rs
@@ -170,6 +170,63 @@ async fn seed_immutable_auxiliary_evidence(pool: &PgPool) -> TestResult {
     Ok(())
 }
 
+async fn seed_managed_workspace_owner(pool: &PgPool) -> TestResult {
+    let principal_id = Uuid::new_v4();
+    let role_id = Uuid::new_v4();
+    let mut transaction = pool.begin().await?;
+    sqlx::query(
+        r"
+        INSERT INTO human_principals (
+            id, status, display_name, revision, created_at_ms, updated_at_ms
+        ) VALUES ($1, 'active', 'Migration owner', 1, 1, 1)
+        ",
+    )
+    .bind(principal_id)
+    .execute(&mut *transaction)
+    .await?;
+    sqlx::query(
+        r"
+        INSERT INTO tenants (
+            id, display_name, created_at_ms, updated_at_ms
+        ) VALUES ('00000000-0000-4000-8000-000000000070', 'Migration tenant', 1, 1)
+        ",
+    )
+    .execute(&mut *transaction)
+    .await?;
+    sqlx::query(
+        r"
+        INSERT INTO tenant_human_memberships (
+            tenant_id, principal_id, status, authorization_revision,
+            revision, created_at_ms, updated_at_ms
+        ) VALUES (
+            '00000000-0000-4000-8000-000000000070', $1,
+            'active', 1, 1, 1, 1
+        )
+        ",
+    )
+    .bind(principal_id)
+    .execute(&mut *transaction)
+    .await?;
+    sqlx::query(
+        r"
+        INSERT INTO rbac_roles (
+            tenant_id, id, name, display_name, role_kind, immutable,
+            revision, created_by_principal_id, created_at_ms, updated_at_ms
+        ) VALUES (
+            '00000000-0000-4000-8000-000000000070', $2,
+            'workspace-owner', 'Workspace owner', 'built_in', TRUE,
+            1, $1, 1, 1
+        )
+        ",
+    )
+    .bind(principal_id)
+    .bind(role_id)
+    .execute(&mut *transaction)
+    .await?;
+    transaction.commit().await?;
+    Ok(())
+}
+
 async fn assert_migrated_contract(pool: &PgPool) -> TestResult {
     let aggregate_check_kind: String =
         sqlx::query_scalar("SELECT aggregate_check_kind FROM github_provider_delivery_evidence")
@@ -220,6 +277,89 @@ async fn assert_migrated_contract(pool: &PgPool) -> TestResult {
     Ok(())
 }
 
+async fn assert_managed_tenant_contract(pool: &PgPool) -> TestResult {
+    let managed_tenant_relations: i64 = sqlx::query_scalar(
+        r"
+        SELECT count(*)
+        FROM pg_catalog.pg_class AS relation
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        WHERE namespace.nspname = 'automata_test'
+          AND relation.relname IN (
+              'tenant_provisioning_operations',
+              'tenant_management_bindings',
+              'tenant_entitlement_operations',
+              'tenant_execution_entitlements',
+              'tenant_usage_events',
+              'tenant_github_repository_operations',
+              'tenant_github_repository_current',
+              'tenant_github_repository_selections',
+              'tenant_github_repository_installation_bindings'
+          )
+        ",
+    )
+    .fetch_one(pool)
+    .await?;
+    assert_eq!(managed_tenant_relations, 9);
+
+    let legacy_managed_workspace_objects: i64 = sqlx::query_scalar(
+        r"
+        SELECT (
+            SELECT count(*)
+            FROM pg_catalog.pg_class AS relation
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = relation.relnamespace
+            WHERE namespace.nspname = 'automata_test'
+              AND relation.relname LIKE 'workspace\_%' ESCAPE '\'
+        ) + (
+            SELECT count(*)
+            FROM information_schema.columns
+            WHERE table_schema = 'automata_test'
+              AND column_name = 'workspace_id'
+        ) + (
+            SELECT count(*)
+            FROM pg_catalog.pg_constraint AS constraint_catalog
+            JOIN pg_catalog.pg_class AS relation
+              ON relation.oid = constraint_catalog.conrelid
+            JOIN pg_catalog.pg_namespace AS namespace
+              ON namespace.oid = relation.relnamespace
+            WHERE namespace.nspname = 'automata_test'
+              AND constraint_catalog.conname LIKE '%workspace%'
+              AND relation.relname IN (
+                  'tenant_provisioning_operations',
+                  'tenant_management_bindings',
+                  'tenant_entitlement_operations',
+                  'tenant_execution_entitlements',
+                  'tenant_usage_events',
+                  'tenant_github_repository_operations',
+                  'tenant_github_repository_current',
+                  'tenant_github_repository_selections',
+                  'tenant_github_repository_installation_bindings',
+                  'provider_connection_revisions'
+              )
+        )
+        ",
+    )
+    .fetch_one(pool)
+    .await?;
+    assert_eq!(legacy_managed_workspace_objects, 0);
+
+    let owner_role: (String, String, i64) = sqlx::query_as(
+        r"
+        SELECT name, display_name, revision
+        FROM rbac_roles
+        WHERE role_kind = 'built_in'
+          AND immutable
+        ",
+    )
+    .fetch_one(pool)
+    .await?;
+    assert_eq!(owner_role.0, "tenant-owner");
+    assert_eq!(owner_role.1, "Tenant owner");
+    assert_eq!(owner_role.2, 2);
+    Ok(())
+}
+
 #[tokio::test]
 #[ignore = "requires PostgreSQL 18 via AUTOMATA_TEST_DATABASE_URL"]
 async fn production_migrations_upgrade_deployed_schema_and_immutable_evidence() -> TestResult {
@@ -237,15 +377,17 @@ async fn production_migrations_upgrade_deployed_schema_and_immutable_evidence() 
             .await?;
         assert_eq!(deployed_version, 60);
 
+        seed_managed_workspace_owner(&database.pool).await?;
         seed_immutable_auxiliary_evidence(&database.pool).await?;
 
         MIGRATOR.run(&database.pool).await?;
         let applied_version: i64 = sqlx::query_scalar("SELECT max(version) FROM _sqlx_migrations")
             .fetch_one(&database.pool)
             .await?;
-        assert_eq!(applied_version, 74);
+        assert_eq!(applied_version, 75);
 
         assert_migrated_contract(&database.pool).await?;
+        assert_managed_tenant_contract(&database.pool).await?;
         Ok(())
     })
     .await

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -301,6 +301,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0074_provider_handoff_consumer_guard.sql",
         "cc8e6393ec556f8e209a06b19f0333b97729a1dbd85509debc1b04a374eb6f3ff1c707709e3fb2c0a0326d81d637d4df",
     ),
+    (
+        "0075_managed_tenant_terminology.sql",
+        "24d361521f054b5de434c0ccfc06a1cac3ae3bbbad399277a529f323a09154a9d058876f43886fb99afdc49f7e1b7e28",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;
@@ -1117,6 +1121,34 @@ fn provider_delivery_runtime_authority_currentness_does_not_require_subject_evid
         assert!(
             source.contains(required),
             "currentness repair lost: {required}"
+        );
+    }
+}
+
+#[test]
+fn externally_managed_boundaries_use_tenant_terminology() {
+    let source = include_str!("../migrations/0075_managed_tenant_terminology.sql");
+
+    for required in [
+        "RENAME TO tenant_provisioning_operations",
+        "RENAME TO tenant_management_bindings",
+        "RENAME TO tenant_entitlement_operations",
+        "RENAME TO tenant_execution_entitlements",
+        "RENAME TO tenant_usage_events",
+        "RENAME TO tenant_github_repository_operations",
+        "RENAME COLUMN workspace_id TO tenant_id",
+        "SET name = 'tenant-owner'",
+        "LOCK TABLE rbac_roles IN SHARE MODE",
+    ] {
+        assert!(
+            source.contains(required),
+            "managed tenant terminology migration lost: {required}"
+        );
+    }
+    for forbidden in ["IF NOT EXISTS", " CASCADE"] {
+        assert!(
+            !source.contains(forbidden),
+            "managed tenant terminology retained transitional SQL: {forbidden}"
         );
     }
 }

--- a/crates/automata-ci-store-postgres/src/workflow_rerun.rs
+++ b/crates/automata-ci-store-postgres/src/workflow_rerun.rs
@@ -278,7 +278,7 @@ async fn resolve_github_check_targets(
               ON connection.connection_id = subject.connection_id
              AND connection.revision = subject.connection_revision
             JOIN workflow_runs AS run ON run.id = subject.run_id
-            WHERE connection.workspace_id = $1
+            WHERE connection.tenant_id = $1
               AND connection.connection_id = $2
               AND connection.external_repository_id = $3
               AND subject.object_algorithm = 'sha1'
@@ -326,7 +326,7 @@ async fn resolve_github_check_targets(
                   ON connection.connection_id = subject.connection_id
                  AND connection.revision = subject.connection_revision
                 JOIN workflow_runs AS run ON run.id = subject.run_id
-                WHERE connection.workspace_id = $1
+                WHERE connection.tenant_id = $1
                   AND connection.connection_id = $2
                   AND connection.external_repository_id = $3
                   AND subject.object_algorithm = 'sha1'

--- a/crates/automata-ci-workflow-service/src/provider_result.rs
+++ b/crates/automata-ci-workflow-service/src/provider_result.rs
@@ -441,7 +441,7 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
-    use automata_ci_core::{GitObjectId, RunId, Sha256Digest, UnixMillis, WorkspaceId};
+    use automata_ci_core::{GitObjectId, ManagedTenantId, RunId, Sha256Digest, UnixMillis};
     use automata_ci_provider::{
         ExternalRepositoryId, ExternalRepositoryIdentity, ProviderArchiveLimits,
         ProviderConfigurationRevision, ProviderConnectionConfiguration, ProviderConnectionId,
@@ -589,7 +589,7 @@ mod tests {
 
     fn connection() -> ProviderConnectionManifest {
         let configuration = ProviderConnectionConfiguration::new(
-            WorkspaceId::parse("11111111-1111-4111-8111-111111111111").unwrap(),
+            ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").unwrap(),
             ExternalRepositoryIdentity::new(
                 "22222222-2222-4222-8222-222222222222".parse().unwrap(),
                 ExternalRepositoryId::new("repository-42").unwrap(),

--- a/crates/automata-ci-workflow-service/src/provider_trigger.rs
+++ b/crates/automata-ci-workflow-service/src/provider_trigger.rs
@@ -575,11 +575,7 @@ fn admission_request(
     )
     .map_err(|_| ProviderWorkflowApplicationError::InvalidEvidence)?;
     let tenant = TenantScope::from_authenticated_tenant_id(
-        request
-            .connection
-            .configuration()
-            .workspace_id()
-            .to_string(),
+        request.connection.configuration().tenant_id().to_string(),
     )
     .map_err(|_| ProviderWorkflowApplicationError::InvalidEvidence)?;
     let idempotency = WorkflowAdmissionIdempotency::provider_delivery(

--- a/crates/automata-ci-workflow-service/tests/provider_application.rs
+++ b/crates/automata-ci-workflow-service/tests/provider_application.rs
@@ -5,7 +5,9 @@ use std::{
 
 use async_trait::async_trait;
 use automata_ci_blob::MemoryBlobStore;
-use automata_ci_core::{GitObjectId, Sha256Digest, TrustTokenRecursion, UnixMillis, WorkspaceId};
+use automata_ci_core::{
+    GitObjectId, ManagedTenantId, Sha256Digest, TrustTokenRecursion, UnixMillis,
+};
 use automata_ci_provider::{
     ClaimProviderResult, ClaimedProviderProcessing, ClaimedProviderResult, CompleteProviderResult,
     ExternalDeliveryId, ExternalDeliveryIdentity, ExternalRepositoryId, ExternalRepositoryIdentity,
@@ -564,7 +566,7 @@ fn connection_manifest(
     repository_identity: ExternalRepositoryIdentity,
 ) -> ProviderConnectionManifest {
     let configuration = ProviderConnectionConfiguration::new(
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace"),
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant"),
         repository_identity,
         provider_revision,
         Sha256Digest::from_bytes([8; 32]),

--- a/crates/automata-ci/README.md
+++ b/crates/automata-ci/README.md
@@ -20,7 +20,7 @@ This page is the configuration reference for the complete server.
 ## Deployment boundary
 
 The server can run as a standalone process, but the repository does not yet
-ship a standalone client that installs the GitHub App and per-workspace
+ship a standalone client that installs the GitHub App and per-tenant
 repository desired state. That state enters through the private,
 mutually-authenticated shard-management API described below. Do not seed or
 edit the provider tables directly: their revisions, authorization evidence,
@@ -55,29 +55,29 @@ and one or more SHA-256 pins for allowed leaf client certificates. mTLS first
 validates the client chain; the leaf pin then maps that verified connection to
 the configured provisioning authority. Supply both old and new pins during a
 bounded certificate-rotation overlap. This listener connects the public
-workspace-provisioning gRPC contract directly to the same PostgreSQL database
+tenant-provisioning gRPC contract directly to the same PostgreSQL database
 used by the other replicas in the shard, reusing this replica's existing pool.
 
 The management authority also enables a versioned delegated-actor HTTP surface
 on the human listener. A hosted control plane signs a short-lived ES256 actor
 assertion; Core verifies the configured issuer and audience, resolves current
-workspace membership and RBAC from PostgreSQL, and performs every read through
+tenant membership and RBAC from PostgreSQL, and performs every read through
 the same authorization-enforcing data boundary as self-hosted SSR. Version 2
 provides:
 
 | Method | Path | Result |
 | --- | --- | --- |
- | `GET` | `/internal/v2/workspaces/{workspace_id}/viewer` | Current Core principal and authorization revision |
- | `POST` | `/internal/v2/workspaces/{workspace_id}/authorization-checks` | Current allow/deny decisions for up to 16 tenant-scoped permissions |
- | `GET` | `/internal/v2/workspaces/{workspace_id}/repositories` | Authorized repository directory |
- | `GET` | `/internal/v2/workspaces/{workspace_id}/repositories/{owner}/{repository}/runs` | Filtered workflow and run page |
- | `GET` | `/internal/v2/workspaces/{workspace_id}/repositories/{owner}/{repository}/runs/{run_id}` | Run, job, and artifact snapshot |
- | `GET` | `/internal/v2/workspaces/{workspace_id}/repositories/{owner}/{repository}/runs/{run_id}/jobs/{job_id}` | Job metadata and structured-stream availability |
- | `POST` | `/internal/v2/workspaces/{workspace_id}/repositories/{owner}/{repository}/runs/{run_id}/jobs/{job_id}/live-ticket` | One-time, origin-bound direct log capability |
- | `POST` | `/internal/v2/workspaces/{workspace_id}/repositories/{repository_id}/workflows/{workflow_id}/dispatches` | Authorized, idempotent workflow dispatch with Core-owned source resolution |
+ | `GET` | `/internal/v2/tenants/{tenant_id}/viewer` | Current Core principal and authorization revision |
+ | `POST` | `/internal/v2/tenants/{tenant_id}/authorization-checks` | Current allow/deny decisions for up to 16 tenant-scoped permissions |
+ | `GET` | `/internal/v2/tenants/{tenant_id}/repositories` | Authorized repository directory |
+ | `GET` | `/internal/v2/tenants/{tenant_id}/repositories/{owner}/{repository}/runs` | Filtered workflow and run page |
+ | `GET` | `/internal/v2/tenants/{tenant_id}/repositories/{owner}/{repository}/runs/{run_id}` | Run, job, and artifact snapshot |
+ | `GET` | `/internal/v2/tenants/{tenant_id}/repositories/{owner}/{repository}/runs/{run_id}/jobs/{job_id}` | Job metadata and structured-stream availability |
+ | `POST` | `/internal/v2/tenants/{tenant_id}/repositories/{owner}/{repository}/runs/{run_id}/jobs/{job_id}/live-ticket` | One-time, origin-bound direct log capability |
+ | `POST` | `/internal/v2/tenants/{tenant_id}/repositories/{repository_id}/workflows/{workflow_id}/dispatches` | Authorized, idempotent workflow dispatch with Core-owned source resolution |
 
 Responses are `no-store` JSON and carry `protocol_version: 2` plus the exact
-workspace ID. Opaque pagination cursors must be returned unchanged. Run
+tenant ID. Opaque pagination cursors must be returned unchanged. Run
 numbers and artifact IDs and sizes are decimal strings
 so JavaScript clients cannot silently lose integer precision. Missing and
 unauthorized repository resources remain indistinguishable as `404`; a valid
@@ -416,8 +416,8 @@ independent, monotonically versioned resources:
 - one shard-wide GitHub App configuration containing the dashboard origin,
   App identity and credentials, webhook secret, Check name, runner policy, and
   scheduler policy;
-- one complete repository desired set per workspace. Omission from a newer set
-  is authoritative, including an empty set used to disconnect a workspace.
+- one complete repository desired set per tenant. Omission from a newer set
+  is authoritative, including an empty set used to disconnect a tenant.
 
 App private keys and webhook secrets are envelope-encrypted before their
 transaction commits, using the mandatory control-plane key provider. PostgreSQL

--- a/crates/automata-ci/src/app/delegated_actor_api.rs
+++ b/crates/automata-ci/src/app/delegated_actor_api.rs
@@ -54,25 +54,24 @@ use automata_ci_core::WorkflowId;
 use automata_ci_store::HumanLiveLogBrowserOrigin;
 
 /// Protected Core endpoint used by Cloud to resolve the current viewer.
-pub const DELEGATED_ACTOR_VIEWER_PATH: &str = "/internal/v2/workspaces/{workspace_id}/viewer";
+pub const DELEGATED_ACTOR_VIEWER_PATH: &str = "/internal/v2/tenants/{tenant_id}/viewer";
 /// Protected Core endpoint used by Cloud to check current tenant permissions.
 pub const DELEGATED_ACTOR_AUTHORIZATION_CHECK_PATH: &str =
-    "/internal/v2/workspaces/{workspace_id}/authorization-checks";
+    "/internal/v2/tenants/{tenant_id}/authorization-checks";
 /// Protected Core endpoint used by Cloud to list repositories visible to one actor.
-pub const DELEGATED_ACTOR_REPOSITORIES_PATH: &str =
-    "/internal/v2/workspaces/{workspace_id}/repositories";
+pub const DELEGATED_ACTOR_REPOSITORIES_PATH: &str = "/internal/v2/tenants/{tenant_id}/repositories";
 /// Protected Core endpoint used by Cloud to list repository workflow runs.
 pub const DELEGATED_ACTOR_RUNS_PATH: &str =
-    "/internal/v2/workspaces/{workspace_id}/repositories/{owner}/{repository}/runs";
+    "/internal/v2/tenants/{tenant_id}/repositories/{owner}/{repository}/runs";
 /// Protected Core endpoint used by Cloud to read one run and its current jobs.
 pub const DELEGATED_ACTOR_RUN_PATH: &str =
-    "/internal/v2/workspaces/{workspace_id}/repositories/{owner}/{repository}/runs/{run_id}";
+    "/internal/v2/tenants/{tenant_id}/repositories/{owner}/{repository}/runs/{run_id}";
 /// Protected Core endpoint used by Cloud to read job and structured-stream metadata.
-pub const DELEGATED_ACTOR_JOB_LOG_PATH: &str = "/internal/v2/workspaces/{workspace_id}/repositories/{owner}/{repository}/runs/{run_id}/jobs/{job_id}";
+pub const DELEGATED_ACTOR_JOB_LOG_PATH: &str = "/internal/v2/tenants/{tenant_id}/repositories/{owner}/{repository}/runs/{run_id}/jobs/{job_id}";
 /// Protected Core endpoint used by Cloud to authorize one browser log tail.
-pub const DELEGATED_ACTOR_LIVE_LOG_TICKET_PATH: &str = "/internal/v2/workspaces/{workspace_id}/repositories/{owner}/{repository}/runs/{run_id}/jobs/{job_id}/live-ticket";
+pub const DELEGATED_ACTOR_LIVE_LOG_TICKET_PATH: &str = "/internal/v2/tenants/{tenant_id}/repositories/{owner}/{repository}/runs/{run_id}/jobs/{job_id}/live-ticket";
 /// Protected Core endpoint used by Cloud to dispatch one exact durable workflow source.
-pub const DELEGATED_ACTOR_WORKFLOW_DISPATCH_PATH: &str = "/internal/v2/workspaces/{workspace_id}/repositories/{repository_id}/workflows/{workflow_id}/dispatches";
+pub const DELEGATED_ACTOR_WORKFLOW_DISPATCH_PATH: &str = "/internal/v2/tenants/{tenant_id}/repositories/{repository_id}/workflows/{workflow_id}/dispatches";
 
 const MAX_ASSERTION_BYTES: usize = 8 * 1024;
 const MAX_JWT_SEGMENT_BYTES: usize = 6 * 1024;
@@ -176,7 +175,7 @@ impl DelegatedActorVerifier {
             return Err(DelegatedActorVerificationError::Rejected);
         }
         let subject = canonical_uuid(&claims.sub)?;
-        let workspace_id = canonical_uuid(&claims.workspace_id)?;
+        let tenant_id = canonical_uuid(&claims.tenant_id)?;
         let session_id = canonical_uuid(&claims.session_id)?;
         let assertion_id = canonical_uuid(&claims.jti)?;
         let assertion = DelegatedActorAssertion::new(
@@ -191,7 +190,7 @@ impl DelegatedActorVerifier {
         .map_err(|_| DelegatedActorVerificationError::Rejected)?;
         Ok(VerifiedDelegatedActor {
             assertion,
-            workspace_id,
+            tenant_id,
         })
     }
 
@@ -248,7 +247,7 @@ impl DelegatedActorVerifier {
 #[derive(Debug)]
 struct VerifiedDelegatedActor {
     assertion: DelegatedActorAssertion,
-    workspace_id: Uuid,
+    tenant_id: Uuid,
 }
 
 #[derive(Debug)]
@@ -272,7 +271,7 @@ struct DelegatedActorClaims {
     iss: String,
     sub: String,
     aud: String,
-    workspace_id: String,
+    tenant_id: String,
     session_id: String,
     auth_time: u64,
     iat: u64,
@@ -415,9 +414,9 @@ impl std::fmt::Debug for DelegatedActorApiState {
 }
 
 #[derive(Serialize)]
-struct WorkspaceViewerResponse {
+struct TenantViewerResponse {
     protocol_version: u8,
-    workspace_id: String,
+    tenant_id: String,
     principal_id: String,
     display_name: String,
     authorization_revision: u64,
@@ -425,22 +424,22 @@ struct WorkspaceViewerResponse {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct WorkspaceAuthorizationCheckRequest {
+struct TenantAuthorizationCheckRequest {
     protocol_version: u8,
     permissions: Vec<String>,
 }
 
 #[derive(Serialize)]
-struct WorkspaceAuthorizationCheckResponse {
+struct TenantAuthorizationCheckResponse {
     protocol_version: u8,
-    workspace_id: String,
+    tenant_id: String,
     principal_id: String,
     authorization_revision: u64,
-    decisions: Vec<WorkspacePermissionDecisionResponse>,
+    decisions: Vec<TenantPermissionDecisionResponse>,
 }
 
 #[derive(Serialize)]
-struct WorkspacePermissionDecisionResponse {
+struct TenantPermissionDecisionResponse {
     permission: String,
     allowed: bool,
 }
@@ -470,7 +469,7 @@ struct RunDetailQuery {
 #[derive(Serialize)]
 struct RepositoryDirectoryResponse {
     protocol_version: u8,
-    workspace_id: String,
+    tenant_id: String,
     repositories: Vec<RepositoryDirectoryItemResponse>,
     next_cursor: Option<String>,
 }
@@ -494,7 +493,7 @@ struct RepositoryResponse {
 #[derive(Serialize)]
 struct RunListResponse {
     protocol_version: u8,
-    workspace_id: String,
+    tenant_id: String,
     repository: RepositoryResponse,
     workflows: Vec<WorkflowDefinitionResponse>,
     selected_workflow: Option<WorkflowDefinitionResponse>,
@@ -539,7 +538,7 @@ struct RunSummaryResponse {
 #[derive(Serialize)]
 struct RunDetailResponse {
     protocol_version: u8,
-    workspace_id: String,
+    tenant_id: String,
     repository: RepositoryResponse,
     run: RunSummaryResponse,
     jobs: VisibleCollectionResponse<JobSummaryResponse>,
@@ -579,7 +578,7 @@ struct ArtifactSummaryResponse {
 #[derive(Serialize)]
 struct JobLogResponse {
     protocol_version: u8,
-    workspace_id: String,
+    tenant_id: String,
     repository: RepositoryResponse,
     run: RunSummaryResponse,
     jobs: Vec<JobNavigationItemResponse>,
@@ -608,27 +607,24 @@ pub(crate) fn router(
     workflow_dispatch: Option<Arc<dyn WorkflowDispatchApiBackend>>,
 ) -> Router {
     let mut router = Router::new()
-        .route(DELEGATED_ACTOR_VIEWER_PATH, get(workspace_viewer))
+        .route(DELEGATED_ACTOR_VIEWER_PATH, get(tenant_viewer))
         .route(
             DELEGATED_ACTOR_AUTHORIZATION_CHECK_PATH,
-            post(workspace_authorization_check)
+            post(tenant_authorization_check)
                 .layer(DefaultBodyLimit::max(MAX_AUTHORIZATION_CHECK_BODY_BYTES)),
         )
-        .route(
-            DELEGATED_ACTOR_REPOSITORIES_PATH,
-            get(workspace_repositories),
-        )
-        .route(DELEGATED_ACTOR_RUNS_PATH, get(workspace_runs))
-        .route(DELEGATED_ACTOR_RUN_PATH, get(workspace_run))
-        .route(DELEGATED_ACTOR_JOB_LOG_PATH, get(workspace_job_log))
+        .route(DELEGATED_ACTOR_REPOSITORIES_PATH, get(tenant_repositories))
+        .route(DELEGATED_ACTOR_RUNS_PATH, get(tenant_runs))
+        .route(DELEGATED_ACTOR_RUN_PATH, get(tenant_run))
+        .route(DELEGATED_ACTOR_JOB_LOG_PATH, get(tenant_job_log))
         .route(
             DELEGATED_ACTOR_LIVE_LOG_TICKET_PATH,
-            post(workspace_live_log_ticket),
+            post(tenant_live_log_ticket),
         );
     if workflow_dispatch.is_some() {
         router = router.route(
             DELEGATED_ACTOR_WORKFLOW_DISPATCH_PATH,
-            post(workspace_workflow_dispatch),
+            post(tenant_workflow_dispatch),
         );
     }
     router.with_state(DelegatedActorApiState {
@@ -641,13 +637,13 @@ pub(crate) fn router(
     })
 }
 
-async fn workspace_authorization_check(
+async fn tenant_authorization_check(
     State(state): State<DelegatedActorApiState>,
-    Path(workspace_id): Path<String>,
+    Path(tenant_id): Path<String>,
     headers: HeaderMap,
-    payload: Result<Json<WorkspaceAuthorizationCheckRequest>, JsonRejection>,
+    payload: Result<Json<TenantAuthorizationCheckRequest>, JsonRejection>,
 ) -> Response {
-    let Ok(workspace_uuid) = canonical_uuid(&workspace_id) else {
+    let Ok(tenant_uuid) = canonical_uuid(&tenant_id) else {
         return status_response(StatusCode::NOT_FOUND);
     };
     let Ok(Json(request)) = payload else {
@@ -659,7 +655,7 @@ async fn workspace_authorization_check(
     let requested_permissions = permissions.iter().cloned().collect();
     let snapshot = match resolve_actor_with_tenant_permissions(
         &state,
-        workspace_uuid,
+        tenant_uuid,
         &headers,
         requested_permissions,
     )
@@ -675,14 +671,14 @@ async fn workspace_authorization_check(
     ) else {
         return status_response(StatusCode::INTERNAL_SERVER_ERROR);
     };
-    json_response(WorkspaceAuthorizationCheckResponse {
+    json_response(TenantAuthorizationCheckResponse {
         protocol_version: 2,
-        workspace_id,
+        tenant_id,
         principal_id: principal_id.as_str().to_owned(),
         authorization_revision,
         decisions: permissions
             .into_iter()
-            .map(|permission| WorkspacePermissionDecisionResponse {
+            .map(|permission| TenantPermissionDecisionResponse {
                 allowed: snapshot.allows_tenant_permission(&permission),
                 permission: permission.into(),
             })
@@ -691,7 +687,7 @@ async fn workspace_authorization_check(
 }
 
 fn authorization_check_permissions(
-    request: WorkspaceAuthorizationCheckRequest,
+    request: TenantAuthorizationCheckRequest,
 ) -> Option<Vec<Permission>> {
     if request.protocol_version != 2
         || request.permissions.is_empty()
@@ -711,15 +707,15 @@ fn authorization_check_permissions(
     Some(permissions)
 }
 
-async fn workspace_workflow_dispatch(
+async fn tenant_workflow_dispatch(
     State(state): State<DelegatedActorApiState>,
-    Path((workspace_id, repository_id, workflow_id)): Path<(String, String, String)>,
+    Path((tenant_id, repository_id, workflow_id)): Path<(String, String, String)>,
     request: axum::extract::Request,
 ) -> Response {
-    let Ok(workspace_uuid) = canonical_uuid(&workspace_id) else {
+    let Ok(tenant_uuid) = canonical_uuid(&tenant_id) else {
         return status_response(StatusCode::NOT_FOUND);
     };
-    let snapshot = match resolve_actor(&state, workspace_uuid, request.headers()).await {
+    let snapshot = match resolve_actor(&state, tenant_uuid, request.headers()).await {
         Ok(snapshot) => snapshot,
         Err(response) => return response,
     };
@@ -733,7 +729,7 @@ async fn workspace_workflow_dispatch(
     dispatch_delegated_workflow(
         backend,
         actor,
-        workspace_uuid,
+        tenant_uuid,
         repository_id,
         workflow_id,
         request,
@@ -741,15 +737,15 @@ async fn workspace_workflow_dispatch(
     .await
 }
 
-async fn workspace_viewer(
+async fn tenant_viewer(
     State(state): State<DelegatedActorApiState>,
-    Path(workspace_id): Path<String>,
+    Path(tenant_id): Path<String>,
     headers: HeaderMap,
 ) -> Response {
-    let Ok(workspace_uuid) = canonical_uuid(&workspace_id) else {
+    let Ok(tenant_uuid) = canonical_uuid(&tenant_id) else {
         return status_response(StatusCode::NOT_FOUND);
     };
-    let snapshot = match resolve_actor(&state, workspace_uuid, &headers).await {
+    let snapshot = match resolve_actor(&state, tenant_uuid, &headers).await {
         Ok(snapshot) => snapshot,
         Err(response) => return response,
     };
@@ -765,9 +761,9 @@ async fn workspace_viewer(
             (header::CACHE_CONTROL, "no-store"),
             (header::CONTENT_TYPE, "application/json"),
         ],
-        Json(WorkspaceViewerResponse {
+        Json(TenantViewerResponse {
             protocol_version: 2,
-            workspace_id,
+            tenant_id,
             principal_id: principal_id.as_str().to_owned(),
             display_name: snapshot.viewer().display_name().to_owned(),
             authorization_revision,
@@ -776,16 +772,16 @@ async fn workspace_viewer(
         .into_response()
 }
 
-async fn workspace_repositories(
+async fn tenant_repositories(
     State(state): State<DelegatedActorApiState>,
-    Path(workspace_id): Path<String>,
+    Path(tenant_id): Path<String>,
     Query(query): Query<RepositoryDirectoryQuery>,
     headers: HeaderMap,
 ) -> Response {
     if !valid_cursor(query.cursor.as_deref()) {
         return status_response(StatusCode::BAD_REQUEST);
     }
-    let context = match resolve_context(&state, &workspace_id, &headers).await {
+    let context = match resolve_context(&state, &tenant_id, &headers).await {
         Ok(context) => context,
         Err(response) => return response,
     };
@@ -794,14 +790,14 @@ async fn workspace_repositories(
         limit: REPOSITORY_PAGE_SIZE,
     };
     match state.web_data.repository_page(&context, &request).await {
-        Ok(page) => json_response(repository_directory_response(workspace_id, page)),
+        Ok(page) => json_response(repository_directory_response(tenant_id, page)),
         Err(error) => web_data_error_response(error),
     }
 }
 
-async fn workspace_runs(
+async fn tenant_runs(
     State(state): State<DelegatedActorApiState>,
-    Path((workspace_id, owner, repository)): Path<(String, String, String)>,
+    Path((tenant_id, owner, repository)): Path<(String, String, String)>,
     Query(query): Query<RunListQuery>,
     headers: HeaderMap,
 ) -> Response {
@@ -828,7 +824,7 @@ async fn workspace_runs(
         "completed" => StatusFilter::Completed,
         _ => return status_response(StatusCode::BAD_REQUEST),
     };
-    let context = match resolve_context(&state, &workspace_id, &headers).await {
+    let context = match resolve_context(&state, &tenant_id, &headers).await {
         Ok(context) => context,
         Err(response) => return response,
     };
@@ -845,15 +841,15 @@ async fn workspace_runs(
         .list_runs(&context, &repository, &request)
         .await
     {
-        Ok(Some(page)) => json_response(run_list_response(workspace_id, page)),
+        Ok(Some(page)) => json_response(run_list_response(tenant_id, page)),
         Ok(None) => status_response(StatusCode::NOT_FOUND),
         Err(error) => web_data_error_response(error),
     }
 }
 
-async fn workspace_run(
+async fn tenant_run(
     State(state): State<DelegatedActorApiState>,
-    Path((workspace_id, owner, repository, run_id)): Path<(String, String, String, String)>,
+    Path((tenant_id, owner, repository, run_id)): Path<(String, String, String, String)>,
     Query(query): Query<RunDetailQuery>,
     headers: HeaderMap,
 ) -> Response {
@@ -866,7 +862,7 @@ async fn workspace_run(
     if !valid_cursor(query.job_cursor.as_deref()) {
         return status_response(StatusCode::BAD_REQUEST);
     }
-    let context = match resolve_context(&state, &workspace_id, &headers).await {
+    let context = match resolve_context(&state, &tenant_id, &headers).await {
         Ok(context) => context,
         Err(response) => return response,
     };
@@ -879,15 +875,15 @@ async fn workspace_run(
         .run_detail(&context, &repository, run_id, &request)
         .await
     {
-        Ok(Some(page)) => json_response(run_detail_response(workspace_id, page)),
+        Ok(Some(page)) => json_response(run_detail_response(tenant_id, page)),
         Ok(None) => status_response(StatusCode::NOT_FOUND),
         Err(error) => web_data_error_response(error),
     }
 }
 
-async fn workspace_job_log(
+async fn tenant_job_log(
     State(state): State<DelegatedActorApiState>,
-    Path((workspace_id, owner, repository, run_id, job_id)): Path<(
+    Path((tenant_id, owner, repository, run_id, job_id)): Path<(
         String,
         String,
         String,
@@ -906,7 +902,7 @@ async fn workspace_job_log(
     let (Some(run_id), Some(job_id)) = (parse_run_id(&run_id), parse_job_id(&job_id)) else {
         return status_response(StatusCode::NOT_FOUND);
     };
-    let context = match resolve_context(&state, &workspace_id, &headers).await {
+    let context = match resolve_context(&state, &tenant_id, &headers).await {
         Ok(context) => context,
         Err(response) => return response,
     };
@@ -915,15 +911,15 @@ async fn workspace_job_log(
         .job_log(&context, &repository, run_id, job_id)
         .await
     {
-        Ok(Some(page)) => json_response(job_log_response(workspace_id, page)),
+        Ok(Some(page)) => json_response(job_log_response(tenant_id, page)),
         Ok(None) => status_response(StatusCode::NOT_FOUND),
         Err(error) => web_data_error_response(error),
     }
 }
 
-async fn workspace_live_log_ticket(
+async fn tenant_live_log_ticket(
     State(state): State<DelegatedActorApiState>,
-    Path((workspace_id, owner, repository, run_id, job_id)): Path<(
+    Path((tenant_id, owner, repository, run_id, job_id)): Path<(
         String,
         String,
         String,
@@ -932,10 +928,10 @@ async fn workspace_live_log_ticket(
     )>,
     headers: HeaderMap,
 ) -> Response {
-    let Ok(workspace_uuid) = canonical_uuid(&workspace_id) else {
+    let Ok(tenant_uuid) = canonical_uuid(&tenant_id) else {
         return status_response(StatusCode::NOT_FOUND);
     };
-    let snapshot = match resolve_actor(&state, workspace_uuid, &headers).await {
+    let snapshot = match resolve_actor(&state, tenant_uuid, &headers).await {
         Ok(snapshot) => snapshot,
         Err(response) => return response,
     };
@@ -945,7 +941,7 @@ async fn workspace_live_log_ticket(
     let (Some(run_id), Some(job_id)) = (parse_run_id(&run_id), parse_job_id(&job_id)) else {
         return status_response(StatusCode::NOT_FOUND);
     };
-    let Ok(tenant_id) = TenantId::new(workspace_id) else {
+    let Ok(tenant_id) = TenantId::new(tenant_id) else {
         return status_response(StatusCode::NOT_FOUND);
     };
     let Ok(context) = RequestContext::new(
@@ -977,14 +973,14 @@ async fn workspace_live_log_ticket(
 
 async fn resolve_context(
     state: &DelegatedActorApiState,
-    workspace_id: &str,
+    tenant_id: &str,
     headers: &HeaderMap,
 ) -> Result<RequestContext, Response> {
-    let workspace_uuid =
-        canonical_uuid(workspace_id).map_err(|_| status_response(StatusCode::NOT_FOUND))?;
-    let snapshot = resolve_actor(state, workspace_uuid, headers).await?;
-    let tenant_id = TenantId::new(workspace_id.to_owned())
-        .map_err(|_| status_response(StatusCode::NOT_FOUND))?;
+    let tenant_uuid =
+        canonical_uuid(tenant_id).map_err(|_| status_response(StatusCode::NOT_FOUND))?;
+    let snapshot = resolve_actor(state, tenant_uuid, headers).await?;
+    let tenant_id =
+        TenantId::new(tenant_id.to_owned()).map_err(|_| status_response(StatusCode::NOT_FOUND))?;
     RequestContext::new(
         tenant_id,
         snapshot.authorization().clone(),
@@ -997,12 +993,12 @@ async fn resolve_context(
 }
 
 fn repository_directory_response(
-    workspace_id: String,
+    tenant_id: String,
     page: RepositoryDirectoryPage,
 ) -> RepositoryDirectoryResponse {
     RepositoryDirectoryResponse {
         protocol_version: 2,
-        workspace_id,
+        tenant_id,
         repositories: page
             .repositories
             .into_iter()
@@ -1037,10 +1033,10 @@ fn repository_response(repository: Repository) -> RepositoryResponse {
     }
 }
 
-fn run_list_response(workspace_id: String, page: RunListPage) -> RunListResponse {
+fn run_list_response(tenant_id: String, page: RunListPage) -> RunListResponse {
     RunListResponse {
         protocol_version: 2,
-        workspace_id,
+        tenant_id,
         repository: repository_response(page.repository),
         workflows: page
             .workflows
@@ -1090,10 +1086,10 @@ fn run_summary_response(run: RunSummary) -> RunSummaryResponse {
     }
 }
 
-fn run_detail_response(workspace_id: String, page: RunDetailPage) -> RunDetailResponse {
+fn run_detail_response(tenant_id: String, page: RunDetailPage) -> RunDetailResponse {
     RunDetailResponse {
         protocol_version: 2,
-        workspace_id,
+        tenant_id,
         repository: repository_response(page.repository),
         run: run_summary_response(page.run),
         jobs: VisibleCollectionResponse {
@@ -1143,10 +1139,10 @@ fn artifact_summary_response(artifact: ArtifactSummary) -> ArtifactSummaryRespon
     }
 }
 
-fn job_log_response(workspace_id: String, page: JobLogPage) -> JobLogResponse {
+fn job_log_response(tenant_id: String, page: JobLogPage) -> JobLogResponse {
     JobLogResponse {
         protocol_version: 2,
-        workspace_id,
+        tenant_id,
         repository: repository_response(page.repository),
         run: run_summary_response(page.run),
         jobs: page
@@ -1225,15 +1221,15 @@ fn web_data_error_response(error: WebDataError) -> Response {
 
 async fn resolve_actor(
     state: &DelegatedActorApiState,
-    workspace_uuid: Uuid,
+    tenant_uuid: Uuid,
     headers: &HeaderMap,
 ) -> Result<Box<DelegatedActorRequestSnapshot>, Response> {
-    resolve_actor_with_tenant_permissions(state, workspace_uuid, headers, BTreeSet::new()).await
+    resolve_actor_with_tenant_permissions(state, tenant_uuid, headers, BTreeSet::new()).await
 }
 
 async fn resolve_actor_with_tenant_permissions(
     state: &DelegatedActorApiState,
-    workspace_uuid: Uuid,
+    tenant_uuid: Uuid,
     headers: &HeaderMap,
     requested_tenant_permissions: BTreeSet<Permission>,
 ) -> Result<Box<DelegatedActorRequestSnapshot>, Response> {
@@ -1242,13 +1238,13 @@ async fn resolve_actor_with_tenant_permissions(
     };
     let now = unix_time();
     let verified = match state.verifier.verify(token, now).await {
-        Ok(value) if value.workspace_id == workspace_uuid => value,
+        Ok(value) if value.tenant_id == tenant_uuid => value,
         Ok(_) | Err(DelegatedActorVerificationError::Rejected) => return Err(unauthorized()),
         Err(DelegatedActorVerificationError::Unavailable) => {
             return Err(status_response(StatusCode::SERVICE_UNAVAILABLE));
         }
     };
-    let Ok(tenant_id) = TenantId::new(workspace_uuid.hyphenated().to_string()) else {
+    let Ok(tenant_id) = TenantId::new(tenant_uuid.hyphenated().to_string()) else {
         return Err(status_response(StatusCode::NOT_FOUND));
     };
     let request = ResolveDelegatedActorRequest::new(verified.assertion, tenant_id)
@@ -1504,7 +1500,7 @@ mod tests {
 
     #[test]
     fn authorization_check_accepts_one_exact_bounded_permission_set() {
-        let parsed = authorization_check_permissions(WorkspaceAuthorizationCheckRequest {
+        let parsed = authorization_check_permissions(TenantAuthorizationCheckRequest {
             protocol_version: 2,
             permissions: vec!["billing:read".to_owned(), "billing:manage".to_owned()],
         })
@@ -1515,23 +1511,23 @@ mod tests {
         );
 
         for rejected in [
-            WorkspaceAuthorizationCheckRequest {
+            TenantAuthorizationCheckRequest {
                 protocol_version: 1,
                 permissions: vec!["billing:read".to_owned()],
             },
-            WorkspaceAuthorizationCheckRequest {
+            TenantAuthorizationCheckRequest {
                 protocol_version: 2,
                 permissions: Vec::new(),
             },
-            WorkspaceAuthorizationCheckRequest {
+            TenantAuthorizationCheckRequest {
                 protocol_version: 2,
                 permissions: vec!["billing:read".to_owned(), "billing:read".to_owned()],
             },
-            WorkspaceAuthorizationCheckRequest {
+            TenantAuthorizationCheckRequest {
                 protocol_version: 2,
                 permissions: vec!["billing/read".to_owned()],
             },
-            WorkspaceAuthorizationCheckRequest {
+            TenantAuthorizationCheckRequest {
                 protocol_version: 2,
                 permissions: (0..=MAX_DELEGATED_TENANT_PERMISSION_CHECKS)
                     .map(|index| format!("billing:test-{index}"))
@@ -1588,12 +1584,12 @@ mod tests {
             None,
         );
 
-        let workspace_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
-        let token = sign_current_test_token(&key, &random, workspace_id);
+        let tenant_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+        let token = sign_current_test_token(&key, &random, tenant_id);
         let request = Request::builder()
             .method("POST")
             .uri(format!(
-                "/internal/v2/workspaces/{workspace_id}/authorization-checks"
+                "/internal/v2/tenants/{tenant_id}/authorization-checks"
             ))
             .header(header::AUTHORIZATION, format!("Bearer {token}"))
             .header(header::CONTENT_TYPE, "application/json")
@@ -1623,7 +1619,7 @@ mod tests {
             body,
             serde_json::json!({
                 "protocol_version": 2,
-                "workspace_id": workspace_id,
+                "tenant_id": tenant_id,
                 "principal_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
                 "authorization_revision": 17,
                 "decisions": [
@@ -1635,7 +1631,7 @@ mod tests {
         assert_eq!(
             *resolver.observed.lock().expect("resolver observation lock"),
             vec![(
-                TenantId::new(workspace_id).expect("tenant ID"),
+                TenantId::new(tenant_id).expect("tenant ID"),
                 BTreeSet::from([billing_manage, billing_read])
             )]
         );
@@ -1668,7 +1664,7 @@ mod tests {
             "iss": "https://cloud.automata.example",
             "sub": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
             "aud": "prod-us-east-1",
-            "workspace_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "tenant_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
             "session_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
             "auth_time": 900,
             "iat": 1_000,
@@ -1681,8 +1677,8 @@ mod tests {
             .await
             .expect("valid assertion");
         assert_eq!(
-            verified_actor.workspace_id,
-            Uuid::parse_str("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb").expect("workspace")
+            verified_actor.tenant_id,
+            Uuid::parse_str("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb").expect("tenant")
         );
 
         let mut wrong_audience = claims.clone();
@@ -1726,7 +1722,7 @@ mod tests {
     fn sign_current_test_token(
         key: &EcdsaKeyPair,
         random: &SystemRandom,
-        workspace_id: &str,
+        tenant_id: &str,
     ) -> String {
         let now = unix_time().as_seconds();
         let header = serde_json::json!({"alg": "ES256", "kid": "key_1", "typ": "at+jwt"});
@@ -1735,7 +1731,7 @@ mod tests {
             "iss": "https://cloud.automata.example",
             "sub": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
             "aud": "prod-us-east-1",
-            "workspace_id": workspace_id,
+            "tenant_id": tenant_id,
             "session_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
             "auth_time": now.saturating_sub(10),
             "iat": now,

--- a/crates/automata-ci/src/app/workflow_dispatch_api.rs
+++ b/crates/automata-ci/src/app/workflow_dispatch_api.rs
@@ -270,7 +270,7 @@ async fn prepare_request(
 pub(crate) async fn dispatch_delegated_workflow(
     backend: &Arc<dyn WorkflowDispatchApiBackend>,
     actor: RepositoryMutationActor,
-    workspace_id: Uuid,
+    tenant_id: Uuid,
     repository_id: String,
     workflow_id: String,
     request: Request,
@@ -292,7 +292,7 @@ pub(crate) async fn dispatch_delegated_workflow(
         Err(error) => return error.into_response(),
     };
     match backend.dispatch(dispatch).await {
-        Ok(outcome) => delegated_success_response(workspace_id, outcome),
+        Ok(outcome) => delegated_success_response(tenant_id, outcome),
         Err(error) => ApiError::from(error).into_response(),
     }
 }
@@ -425,7 +425,7 @@ fn success_response(outcome: WorkflowDispatchApiOutcome) -> Response {
     )
 }
 
-fn delegated_success_response(workspace_id: Uuid, outcome: WorkflowDispatchApiOutcome) -> Response {
+fn delegated_success_response(tenant_id: Uuid, outcome: WorkflowDispatchApiOutcome) -> Response {
     json_response(
         if outcome.is_replay() {
             StatusCode::OK
@@ -434,7 +434,7 @@ fn delegated_success_response(workspace_id: Uuid, outcome: WorkflowDispatchApiOu
         },
         &DelegatedDispatchResponseDocument {
             protocol_version: 1,
-            workspace_id,
+            tenant_id,
             run_id: outcome.run_id().as_uuid(),
             run_number: outcome.run_number().to_string(),
             replay: outcome.is_replay(),
@@ -514,7 +514,7 @@ struct DispatchResponseDocument {
 #[derive(Debug, Serialize)]
 struct DelegatedDispatchResponseDocument {
     protocol_version: u8,
-    workspace_id: Uuid,
+    tenant_id: Uuid,
     run_id: Uuid,
     run_number: String,
     replay: bool,
@@ -561,7 +561,7 @@ mod tests {
     const WORKFLOW_ID: &str = "22222222-2222-4222-8222-222222222222";
     const OPERATION_ID: &str = "33333333-3333-4333-8333-333333333333";
     const RUN_ID: &str = "44444444-4444-4444-8444-444444444444";
-    const WORKSPACE_ID: &str = "55555555-5555-4555-8555-555555555555";
+    const TENANT_ID: &str = "55555555-5555-4555-8555-555555555555";
     const SHA: &str = "0123456789abcdef0123456789abcdef01234567";
     const PATH: &str = "/api/v1/repositories/aaaaaaaa-1111-4111-8111-111111111111/workflows/22222222-2222-4222-8222-222222222222/dispatches";
 
@@ -742,13 +742,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delegated_route_retains_external_authority_and_workspace_envelope() {
+    async fn delegated_route_retains_external_authority_and_tenant_envelope() {
         let backend = RecordingBackend::success(false);
         let dispatch_backend: Arc<dyn WorkflowDispatchApiBackend> = backend.clone();
         let response = dispatch_delegated_workflow(
             &dispatch_backend,
             delegated_mutation_actor(),
-            Uuid::parse_str(WORKSPACE_ID).expect("workspace ID"),
+            Uuid::parse_str(TENANT_ID).expect("tenant ID"),
             REPOSITORY_ID.to_owned(),
             WORKFLOW_ID.to_owned(),
             request(PATH, None, "application/json", valid_body()),
@@ -760,7 +760,7 @@ mod tests {
             response_json(response).await,
             json!({
                 "protocol_version": 1,
-                "workspace_id": WORKSPACE_ID,
+                "tenant_id": TENANT_ID,
                 "run_id": RUN_ID,
                 "run_number": "17",
                 "replay": false

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -72,16 +72,16 @@ use automata_ci_provider_github::{
 use automata_ci_provider_postgres::PostgresProviderManifestRepository;
 use automata_ci_provisioning::{
     GithubProviderConfigurationApplier, GithubProviderDesiredStateReader,
-    GithubProviderRunnerPolicyApplier, ProvisioningWorkloadAuthenticator,
-    WorkspaceEntitlementApplier, WorkspaceGithubRepositoriesApplier, WorkspaceProvisioner,
+    GithubProviderRunnerPolicyApplier, ProvisioningWorkloadAuthenticator, TenantEntitlementApplier,
+    TenantGithubRepositoriesApplier, TenantProvisioner,
 };
 use automata_ci_provisioning_grpc::{
     ManagementApplicationPorts, ManagementGrpcServer, ManagementServerTlsConfig,
 };
 use automata_ci_provisioning_postgres::{
     PostgresGithubProviderConfigurationApplier, PostgresGithubProviderDesiredStateReader,
-    PostgresGithubProviderRunnerPolicyApplier, PostgresWorkspaceEntitlementApplier,
-    PostgresWorkspaceGithubRepositoriesApplier, PostgresWorkspaceProvisioner,
+    PostgresGithubProviderRunnerPolicyApplier, PostgresTenantEntitlementApplier,
+    PostgresTenantGithubRepositoriesApplier, PostgresTenantProvisioner,
 };
 use automata_ci_runner_auth_postgres::PostgresRunnerMachineDirectory;
 use automata_ci_runner_results::{
@@ -868,11 +868,11 @@ fn build_management_server(
             config.authority().clone(),
             config.client_certificate_sha256().to_vec(),
         ));
-    let provisioner: Arc<dyn WorkspaceProvisioner> = Arc::new(PostgresWorkspaceProvisioner::new(
+    let provisioner: Arc<dyn TenantProvisioner> = Arc::new(PostgresTenantProvisioner::new(
         store.postgres_pool().clone(),
     ));
-    let entitlement_applier: Arc<dyn WorkspaceEntitlementApplier> = Arc::new(
-        PostgresWorkspaceEntitlementApplier::new(store.postgres_pool().clone()),
+    let entitlement_applier: Arc<dyn TenantEntitlementApplier> = Arc::new(
+        PostgresTenantEntitlementApplier::new(store.postgres_pool().clone()),
     );
     let provider_configuration_applier: Arc<dyn GithubProviderConfigurationApplier> =
         Arc::new(PostgresGithubProviderConfigurationApplier::new(
@@ -882,8 +882,8 @@ fn build_management_server(
     let runner_policy_applier: Arc<dyn GithubProviderRunnerPolicyApplier> = Arc::new(
         PostgresGithubProviderRunnerPolicyApplier::new(store.postgres_pool().clone()),
     );
-    let workspace_repositories_applier: Arc<dyn WorkspaceGithubRepositoriesApplier> = Arc::new(
-        PostgresWorkspaceGithubRepositoriesApplier::new(store.postgres_pool().clone()),
+    let tenant_repositories_applier: Arc<dyn TenantGithubRepositoriesApplier> = Arc::new(
+        PostgresTenantGithubRepositoriesApplier::new(store.postgres_pool().clone()),
     );
     Ok(Some(ManagementGrpcServer::new(
         listener,
@@ -894,7 +894,7 @@ fn build_management_server(
             entitlement_applier,
             provider_configuration_applier,
             runner_policy_applier,
-            workspace_repositories_applier,
+            tenant_repositories_applier,
         ),
     )))
 }

--- a/crates/automata-ci/src/server/github_provider_config.rs
+++ b/crates/automata-ci/src/server/github_provider_config.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeSet, fmt, sync::Arc};
 use std::str::FromStr as _;
 
 use automata_ci_core::JobAuthorityProfile;
-use automata_ci_core::{UnixMillis, WorkspaceId};
+use automata_ci_core::{ManagedTenantId, UnixMillis};
 use automata_ci_github_delivery::GithubScheduleServiceConfig;
 use automata_ci_provider::{
     ProviderConfigurationRevision, ProviderInstanceId, ProviderWebhookEndpointId,
@@ -288,7 +288,7 @@ impl GithubProviderConfig {
             webhook_verifier_revision,
             runner_policy_revision,
             configuration,
-            workspaces,
+            tenants,
         ) = desired.into_parts();
         let instance_id = configured_instance_id(shard_id.as_str())?;
         let endpoint_id = configured_endpoint_id(shard_id.as_str())?;
@@ -323,26 +323,26 @@ impl GithubProviderConfig {
         .map(GithubProviderScheduleConfig)
         .map_err(|_| GithubProviderConfigError)?;
         let mut repositories = Vec::new();
-        for workspace in workspaces {
-            let workspace_id = workspace.workspace_id();
-            let workspace_revision = workspace.revision();
-            let workspace_applied_at = unix_millis(workspace.applied_at())?;
+        for tenant in tenants {
+            let tenant_id = tenant.tenant_id();
+            let tenant_revision = tenant.revision();
+            let tenant_applied_at = unix_millis(tenant.applied_at())?;
             // One reviewed shard generation must describe both the provider
             // authority and every repository projection loaded by a replica.
             // Mixed generations are never partially activated.
-            if workspace_revision.get() != configuration_revision.get() {
+            if tenant_revision.get() != configuration_revision.get() {
                 return Err(GithubProviderConfigError);
             }
             let projected_revision = configuration_revision.get();
-            for selected in workspace.repositories() {
+            for selected in tenant.repositories() {
                 repositories.push(database_repository_config(
-                    workspace_id,
+                    tenant_id,
                     projected_revision,
                     runner_policy_revision,
                     selected,
                     &runner_policy,
                     &check_name,
-                    workspace_applied_at,
+                    tenant_applied_at,
                 )?);
             }
         }
@@ -500,7 +500,7 @@ impl fmt::Debug for DatabaseGithubProviderConfig {
 }
 
 fn database_repository_config(
-    workspace_id: WorkspaceId,
+    tenant_id: ManagedTenantId,
     projected_revision: u64,
     runner_policy_revision: u64,
     selected: &GithubProviderRepositorySelection,
@@ -508,23 +508,23 @@ fn database_repository_config(
     check_name: &GithubCheckName,
     applied_at: UnixMillis,
 ) -> Result<GithubProviderRepositoryConfig, GithubProviderConfigError> {
-    let tenant = TenantScope::from_authenticated_tenant_id(workspace_id.to_string())
+    let tenant = TenantScope::from_authenticated_tenant_id(tenant_id.to_string())
         .map_err(|_| GithubProviderConfigError)?;
     let repository_id = selected.repository_id();
-    let workspace_bytes = workspace_id.as_uuid();
+    let tenant_bytes = tenant_id.as_uuid();
     let repository_bytes = repository_id.get().to_be_bytes();
     let revision_bytes = projected_revision.to_be_bytes();
     let policy_revision = GithubServerServiceRevision::new(projected_revision)
         .map_err(|_| GithubProviderConfigError)?;
     let connection_id = GithubProviderConnectionId(ConfiguredUuid::derive(
         DATABASE_CONNECTION_ID_DOMAIN,
-        &[workspace_bytes.as_bytes(), &repository_bytes],
+        &[tenant_bytes.as_bytes(), &repository_bytes],
     ));
     let authority = |scope: &'static [u8]| GithubProviderAuthorityConfig {
         authority_id: GithubProviderAuthorityId(ConfiguredUuid::derive(
             DATABASE_AUTHORITY_ID_DOMAIN,
             &[
-                workspace_bytes.as_bytes(),
+                tenant_bytes.as_bytes(),
                 &repository_bytes,
                 &revision_bytes,
                 scope,

--- a/crates/automata-ci/src/server/github_provider_credentials.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials.rs
@@ -1284,11 +1284,7 @@ impl GithubProviderCredentialAdapters {
         GithubProviderCredentialHandoffError,
     > {
         let tenant = TenantScope::from_authenticated_tenant_id(
-            context
-                .connection()
-                .configuration()
-                .workspace_id()
-                .to_string(),
+            context.connection().configuration().tenant_id().to_string(),
         )
         .map_err(|_| GithubProviderCredentialHandoffError::Inconsistent)?;
         let github_repository_id = external_repository_id

--- a/crates/automata-ci/src/server/github_provider_reconciliation.rs
+++ b/crates/automata-ci/src/server/github_provider_reconciliation.rs
@@ -110,7 +110,7 @@ fn common_connections(
             repository.connection_id().as_bytes(),
         ))
         .map_err(|_| GithubProviderConfigError)?;
-        let workspace_id = automata_ci_core::WorkspaceId::parse(repository.tenant().as_str())
+        let tenant_id = automata_ci_core::ManagedTenantId::parse(repository.tenant().as_str())
             .map_err(|_| GithubProviderConfigError)?;
         let external_repository_id =
             ExternalRepositoryId::new(repository.repository_id().get().to_string())
@@ -134,7 +134,7 @@ fn common_connections(
         connections.push(
             ProviderConnectionDesiredState::new(
                 connection_id,
-                workspace_id,
+                tenant_id,
                 external_repository_id,
                 visibility,
                 ProviderDefaultBranch::new(default_branch)

--- a/crates/automata-ci/src/server/github_provider_tests.rs
+++ b/crates/automata-ci/src/server/github_provider_tests.rs
@@ -560,15 +560,15 @@ async fn duplicate_config_and_durable_manifest_selector_drift_fail_closed() {
 
 fn database_desired_state(
     configuration_revision: u64,
-    workspace_revision: u64,
+    tenant_revision: u64,
     runner_policy_revision: u64,
 ) -> automata_ci_provisioning::GithubProviderDesiredState {
     use automata_ci_core::JobAuthorityProfile;
-    use automata_ci_core::WorkspaceId;
+    use automata_ci_core::ManagedTenantId;
     use automata_ci_provisioning::{
         GithubProviderConfiguration, GithubProviderConfigurationRevision,
         GithubProviderRepositorySelection, GithubProviderSchedulePolicy, GithubProviderSecret,
-        ShardId, WorkspaceGithubRepositoriesDesiredState, WorkspaceGithubRepositoriesRevision,
+        ShardId, TenantGithubRepositoriesDesiredState, TenantGithubRepositoriesRevision,
     };
     use automata_ci_store::{
         GithubCheckName, GithubRepositoryName, GithubServerServiceAppClientId,
@@ -591,8 +591,8 @@ fn database_desired_state(
         GithubProviderSchedulePolicy::default(),
     )
     .expect("provider configuration");
-    let workspace_id =
-        WorkspaceId::parse("11111111-1111-4111-8111-111111111111").expect("workspace ID");
+    let tenant_id =
+        ManagedTenantId::parse("11111111-1111-4111-8111-111111111111").expect("tenant ID");
     let repository = GithubProviderRepositorySelection::new(
         ProviderInstallationId::new(101).expect("installation ID"),
         ProviderRepositoryId::new(301).expect("repository ID"),
@@ -617,15 +617,14 @@ fn database_desired_state(
         .expect("desired-state version"),
         configuration,
         vec![
-            WorkspaceGithubRepositoriesDesiredState::new(
-                workspace_id,
-                WorkspaceGithubRepositoriesRevision::new(workspace_revision)
-                    .expect("workspace revision"),
+            TenantGithubRepositoriesDesiredState::new(
+                tenant_id,
+                TenantGithubRepositoriesRevision::new(tenant_revision).expect("tenant revision"),
                 automata_ci_provisioning::GithubProviderTimestamp::new(2_000, 0)
-                    .expect("workspace applied time"),
+                    .expect("tenant applied time"),
                 vec![repository],
             )
-            .expect("workspace desired state"),
+            .expect("tenant desired state"),
         ],
     )
     .expect("provider desired state")

--- a/docs/architecture-decisions/0001-protocol-boundaries.md
+++ b/docs/architecture-decisions/0001-protocol-boundaries.md
@@ -43,7 +43,7 @@ authentication. Management RPCs do not declare an HTTP projection.
 Core owns a separate HTTP/JSON API for browsers, CLIs, and third-party
 integrations. The self-hosted UI calls Core directly. Automata Cloud exposes its
 own thin HTTP/JSON edge, authenticates SaaS users, and delegates ordinary
-workspace operations to the same Core API on the selected shard. Cloud-only
+tenant operations to the same Core API on the selected shard. Cloud-only
 billing and account routes are implemented with Fastify. HTTP schemas and
 generated OpenAPI descriptions live with the route implementations rather than
 in a centralized contracts directory.

--- a/docs/architecture-decisions/0002-tenant-entitlement-enforcement.md
+++ b/docs/architecture-decisions/0002-tenant-entitlement-enforcement.md
@@ -1,15 +1,15 @@
-# ADR 0002: Enforce aggregate workspace entitlements with periodic accounting
+# ADR 0002: Enforce aggregate tenant entitlements with periodic accounting
 
 - Status: Accepted
 - Date: 2026-08-14
 
 ## Context
 
-An externally managed Automata workspace can receive a finite compute allowance,
+An externally managed Automata tenant can receive a finite compute allowance,
 an uncapped metered policy, or a paused policy. A finite allowance must work
 across concurrent jobs whose durations cannot be predicted. Core must continue
 to operate when its external control plane is temporarily unavailable, and
-self-hosted workspaces must remain fully functional without a SaaS entitlement
+self-hosted tenants must remain fully functional without a SaaS entitlement
 provider.
 
 Automata already assigns each attempt through a short-lived, fenced runner
@@ -24,7 +24,7 @@ can tolerate a small bounded enforcement overshoot.
 
 ## Decision
 
-Core receives a complete, monotonically revisioned workspace entitlement from
+Core receives a complete, monotonically revisioned tenant entitlement from
 an authorized external control plane. The public management contract is
 provider-neutral and supports:
 
@@ -32,11 +32,11 @@ provider-neutral and supports:
 - uncapped metered execution; and
 - paused execution.
 
-The capped policy is a workspace aggregate. It does not distribute time to jobs
+The capped policy is a tenant aggregate. It does not distribute time to jobs
 in advance and does not introduce rolling per-job budget leases. Core accounts
 actual execution periodically against the active entitlement revision. When a
 compute allowance or validity period is exhausted, Core durably marks the
-workspace exhausted, rejects new execution, and issues ordinary durable
+tenant exhausted, rejects new execution, and issues ordinary durable
 cancellation commands for active attempts.
 
 Jobs do not pause when an entitlement is exhausted. Runners follow the existing
@@ -50,9 +50,9 @@ must not retroactively bill trial overshoot; a future product marketed as a
 hard monetary cap must either absorb the termination overshoot or clearly
 define a different customer-visible guarantee.
 
-Externally provisioned workspaces carry an immutable durable binding to their
+Externally provisioned tenants carry an immutable durable binding to their
 management authority. Only that authority can apply entitlement snapshots.
-Managed workspaces fail closed until they have a usable snapshot. Workspaces
+Managed tenants fail closed until they have a usable snapshot. Tenants
 without an external-management binding are self-hosted and remain unrestricted
 by this mechanism.
 

--- a/docs/architecture-decisions/0003-pull-tenant-usage.md
+++ b/docs/architecture-decisions/0003-pull-tenant-usage.md
@@ -1,4 +1,4 @@
-# ADR 0003: Pull immutable workspace usage by cursor
+# ADR 0003: Pull immutable tenant usage by cursor
 
 - Status: Accepted
 - Date: 2026-08-14
@@ -25,7 +25,7 @@ exclusive cursor. An empty cursor means the beginning of the retained feed.
 The cursor is meaningful only for the exact authenticated authority and shard
 that issued it.
 
-Each immutable event has a globally stable event ID, workspace and attempt
+Each immutable event has a globally stable event ID, tenant and attempt
 identity, entitlement revision, positive accounting interval, and actual
 consumed compute in milliseconds. Events are raw provider-neutral accounting
 facts. They contain no plan, price, currency, invoice, Stripe identifier, or
@@ -39,7 +39,7 @@ created by the consumer transaction rather than promised by the network.
 
 Core derives the authority from verified workload identity on every request.
 The durable feed filters by that exact authority even if multiple authorities
-can manage workspaces on one shard. Cursors and page sizes are bounded. A stale
+can manage tenants on one shard. Cursors and page sizes are bounded. A stale
 or unknown cursor fails explicitly; a consumer must alert and reconcile rather
 than skip silently.
 

--- a/docs/architecture-decisions/0004-resumable-live-log-delivery.md
+++ b/docs/architecture-decisions/0004-resumable-live-log-delivery.md
@@ -17,11 +17,11 @@ rebuilding page snapshots adds avoidable latency and work and cannot provide the
 intended live-log experience at scale.
 
 Automata Cloud must not proxy log bytes through its private API. A browser may
-connect to any healthy Core replica in the workspace's shard, and no workspace
+connect to any healthy Core replica in the tenant's shard, and no tenant
 or runner connection is permanently assigned to one HTTP replica. A live
 connection can nevertheless terminate on one replica for its lifetime, so
 replica loss, deployment draining, network changes, and suspended browser tabs
-must not lose output or require sticky workspace routing.
+must not lose output or require sticky tenant routing.
 
 WebTransport is newly available across current major browsers and offers
 reliable multiplexed streams, stream backpressure, and QUIC connection
@@ -106,7 +106,7 @@ checks and measured demand justifies enabling it.
 ## Consequences
 
 - Core replicas remain interchangeable across reconnects; a live connection
-  does not create workspace affinity.
+  does not create tenant affinity.
 - Ordering, replay, completion, authorization, and limits can be tested once
   below both streaming transports.
 - PostgreSQL and object storage remain the recovery source of truth while the

--- a/docs/maintainers/roadmaps/provider-platform-and-forgejo.md
+++ b/docs/maintainers/roadmaps/provider-platform-and-forgejo.md
@@ -264,7 +264,7 @@ combination. Unknown fields and schema versions fail closed. Adapter documents
 are canonical serialized values, not unvalidated `serde_json::Value` passed
 through application services.
 
-Repository connections contain common policy such as workspace, provider
+Repository connections contain common policy such as tenant, provider
 instance, external repository ID, visibility, default branch, workflow source
 selection, runner policy, and archive limits. A bounded adapter-owned policy
 document holds only behavior that cannot be expressed commonly. GitHub App
@@ -280,7 +280,7 @@ POST /api/v1/provider-webhooks/{opaque_endpoint_id}
 
 The endpoint record resolves the provider instance, connection, active secret
 generation, body limit, and adapter type before parsing the payload. The public
-path does not contain a provider name, repository name, or workspace ID.
+path does not contain a provider name, repository name, or tenant ID.
 
 `DeliveryAdapter` receives an exact raw method, selected headers, bounded body,
 endpoint binding, and candidate secret generations. It returns either a
@@ -479,7 +479,7 @@ ProviderConnectionDesiredState
 
 Provider factories validate desired state before the transaction commits.
 Provisioning returns typed capability and configuration errors without secret
-values. A workspace may select connections from multiple instances and types.
+values. A tenant may select connections from multiple instances and types.
 
 This is a destructive schema and protobuf replacement. The cutover procedure
 is: stop all services, delete the unreleased database and durable test state,

--- a/ui/src/components/ProviderConnectionPanel.tsx
+++ b/ui/src/components/ProviderConnectionPanel.tsx
@@ -72,7 +72,7 @@ function lifecycleDescription(
     case "pending":
       return `Waiting for ${providerLabel} to confirm this installation.`;
     case "active":
-      return `Choose which ${providerLabel} repositories this workspace can use.`;
+      return `Choose which ${providerLabel} repositories this tenant can use.`;
     case "suspended":
       return `This ${providerLabel} installation is suspended. Existing selections are read-only.`;
     case "removed":

--- a/ui/tests/integration/provider-connection-components.test.tsx
+++ b/ui/tests/integration/provider-connection-components.test.tsx
@@ -33,6 +33,8 @@ describe("provider connection package components", () => {
 
     expect(html).toContain('data-provider-connection-state="active"');
     expect(html).toContain("Connected");
+    expect(html).toContain("repositories this tenant can use");
+    expect(html).not.toContain("workspace");
     expect(html).toContain("Host action");
     expect(html).toContain('name="repository_ids"');
     expect(html).toContain('value="123"');


### PR DESCRIPTION
## Summary

- replace the unreleased managed-workspace domain and gRPC contracts with provider-neutral tenant terminology
- move delegated HTTP routes and claims to `/internal/v2/tenants/{tenant_id}/...`
- rename current PostgreSQL management, entitlement, usage, and GitHub desired-state objects in migration 0070
- rename the built-in owner role and audit vocabulary while preserving real runner/job filesystem workspaces
- update protocol and architecture documentation

Cloud will expose GitHub-backed organizations whose UUID is the corresponding Core tenant ID. `ManagedTenantId` remains the strict UUID type for this externally managed boundary; normal Core auth/storage still owns generic tenant semantics. This is a direct greenfield contract replacement with no compatibility aliases or generated code checked in.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- changed-package test suite: passed
- migration layout suite: 24 passed
- PostgreSQL 18 deployed-schema upgrade test through migration 0070: passed
- full workspace tests: Core main suite passed 518 tests; run later stopped on 29 unrelated `automata-ci-local` secure-directory tests caused by this host environment
- workspace Clippy reached this change cleanly, then stopped on the pre-existing `automata-ci-postgres/tests/store/execution/runner_control.rs` 104-line `too_many_lines` lint in an untouched file