### PR TITLE
fix: restore provider-neutral GitHub CI handoffs

### DIFF
--- a/.ci/workflows/release.yml
+++ b/.ci/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
             > "$comparison"
           gh api --method GET \
             "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_COMMIT}/check-runs" \
-            -f 'check_name=Automata CI / required' \
+            -f 'check_name=Automata CI / .ci/workflows/ci.yml' \
             -f filter=latest \
             -f per_page=100 \
             > "$checks"

--- a/crates/automata-ci-credential-github/src/adapter.rs
+++ b/crates/automata-ci-credential-github/src/adapter.rs
@@ -14,7 +14,7 @@ use reqwest::{
     header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT},
     redirect::Policy,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use url::Url;
@@ -50,6 +50,8 @@ const MAX_REQUEST_BODY_BYTES: usize = 16 * 1_024;
 const MAX_TOKEN_LIFETIME_SECONDS: u64 = 3_600;
 const MAX_PROVIDER_CLOCK_SKEW_SECONDS: u64 = 60;
 const MAX_REPOSITORY_COMPONENT_BYTES: usize = 100;
+const MAX_WEBHOOK_URL_BYTES: usize = 2_048;
+const MAX_WEBHOOK_SECRET_BYTES: usize = 16 * 1_024;
 const BROKER_POLICY_FINGERPRINT_DOMAIN: &[u8] = b"automata-ci/github-app-broker-policy/v1\0";
 
 struct ValidatedResponseMetadata {
@@ -69,6 +71,21 @@ struct PreparedMintRequest {
     endpoint: Url,
     authorization: HeaderValue,
     body: Vec<u8>,
+}
+
+#[derive(Serialize)]
+struct AppWebhookUpdateRequest<'a> {
+    url: &'a str,
+    content_type: &'static str,
+    insecure_ssl: &'static str,
+    secret: &'a str,
+}
+
+#[derive(Deserialize)]
+struct AppWebhookUpdateResponse {
+    url: String,
+    content_type: String,
+    insecure_ssl: serde_json::Value,
 }
 
 /// GitHub App installation-token client with a fixed network and identity scope.
@@ -260,6 +277,104 @@ impl GithubAppCredentialBroker {
             return Err(GithubAppInstallationObservationError::InvalidResponse);
         }
         Ok(endpoint)
+    }
+
+    fn app_webhook_configuration_url(&self) -> Result<Url, GithubAppWebhookUpdateError> {
+        let mut endpoint = self.config.api_base.clone();
+        let mut segments = endpoint
+            .path_segments_mut()
+            .map_err(|()| GithubAppWebhookUpdateError::InvalidConfiguration)?;
+        segments.pop_if_empty();
+        segments.push("app");
+        segments.push("hook");
+        segments.push("config");
+        drop(segments);
+        if !self.config.trusts_api_url(&endpoint) {
+            return Err(GithubAppWebhookUpdateError::InvalidConfiguration);
+        }
+        Ok(endpoint)
+    }
+
+    /// Converges the GitHub App's delivery URL, JSON encoding, TLS verification,
+    /// and HMAC secret through the App-authenticated configuration endpoint.
+    ///
+    /// This operation intentionally reapplies the secret because GitHub never
+    /// returns it for comparison. The private key, App assertion, webhook
+    /// secret, provider response body, and remote URL are omitted from errors.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an invalid public HTTPS URL or secret and returns a sanitized
+    /// failure when authentication, transport, provider status, or response
+    /// validation fails.
+    pub async fn update_app_webhook_configuration(
+        &self,
+        webhook_url: &Url,
+        webhook_secret: &[u8],
+    ) -> Result<(), GithubAppWebhookUpdateError> {
+        if webhook_url.as_str().len() > MAX_WEBHOOK_URL_BYTES
+            || webhook_url.scheme() != "https"
+            || webhook_url.host_str().is_none()
+            || !webhook_url.username().is_empty()
+            || webhook_url.password().is_some()
+            || webhook_url.query().is_some()
+            || webhook_url.fragment().is_some()
+            || webhook_secret.is_empty()
+            || webhook_secret.len() > MAX_WEBHOOK_SECRET_BYTES
+        {
+            return Err(GithubAppWebhookUpdateError::InvalidConfiguration);
+        }
+        let secret = std::str::from_utf8(webhook_secret)
+            .map_err(|_| GithubAppWebhookUpdateError::InvalidConfiguration)?;
+        let body = serde_json::to_vec(&AppWebhookUpdateRequest {
+            url: webhook_url.as_str(),
+            content_type: "json",
+            insecure_ssl: "0",
+            secret,
+        })
+        .map_err(|_| GithubAppWebhookUpdateError::InvalidConfiguration)?;
+        if body.len() > MAX_REQUEST_BODY_BYTES {
+            return Err(GithubAppWebhookUpdateError::InvalidConfiguration);
+        }
+        let assertion = self
+            .signer
+            .sign(self.clock.now())
+            .map_err(|_| GithubAppWebhookUpdateError::Authentication)?;
+        let authorization = bearer_header(assertion.expose_secret())
+            .map_err(|_| GithubAppWebhookUpdateError::Authentication)?;
+        let response = self
+            .client
+            .patch(self.app_webhook_configuration_url()?)
+            .header(ACCEPT, ACCEPT_API_JSON)
+            .header(AUTHORIZATION, authorization)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await
+            .map_err(|_| GithubAppWebhookUpdateError::Transport)?;
+        if response.status() != StatusCode::OK {
+            return Err(GithubAppWebhookUpdateError::Rejected);
+        }
+        let response =
+            crate::response::read_created_response(response, self.config.limits.max_response_bytes)
+                .await;
+        if response.completion != CreatedBodyCompletion::Complete || !response.metadata_valid {
+            return Err(GithubAppWebhookUpdateError::InvalidResponse);
+        }
+        let response: AppWebhookUpdateResponse = serde_json::from_slice(&response.body)
+            .map_err(|_| GithubAppWebhookUpdateError::InvalidResponse)?;
+        let tls_verification_enabled = match response.insecure_ssl {
+            serde_json::Value::String(value) => value == "0",
+            serde_json::Value::Number(value) => value.as_u64() == Some(0),
+            _ => false,
+        };
+        if response.url != webhook_url.as_str()
+            || response.content_type != "json"
+            || !tls_verification_enabled
+        {
+            return Err(GithubAppWebhookUpdateError::InvalidResponse);
+        }
+        Ok(())
     }
 
     /// Observes the effective GitHub App installation capabilities.
@@ -593,6 +708,26 @@ impl GithubAppCredentialBroker {
         }
         Ok(endpoint)
     }
+}
+
+/// Sanitized failure while converging a GitHub App webhook configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum GithubAppWebhookUpdateError {
+    /// The public webhook URL, HMAC secret, or derived API endpoint is invalid.
+    #[error("GitHub App webhook configuration is invalid")]
+    InvalidConfiguration,
+    /// The App assertion could not be produced or encoded.
+    #[error("GitHub App webhook configuration could not be authenticated")]
+    Authentication,
+    /// The fixed-origin GitHub API request did not complete.
+    #[error("GitHub App webhook configuration transport failed")]
+    Transport,
+    /// GitHub rejected the authenticated update.
+    #[error("GitHub App webhook configuration was rejected")]
+    Rejected,
+    /// GitHub returned an invalid or mismatched bounded response.
+    #[error("GitHub App webhook configuration response was invalid")]
+    InvalidResponse,
 }
 
 fn permissions_match_github_response(requested: &PermissionSet, returned: &PermissionSet) -> bool {

--- a/crates/automata-ci-credential-github/src/authority_coordinator.rs
+++ b/crates/automata-ci-credential-github/src/authority_coordinator.rs
@@ -19,12 +19,12 @@ use automata_ci_store::{
     GithubRuntimeAuthorityEnvelopeMetadata, GithubRuntimeAuthorityInspection,
     GithubRuntimeAuthorityMintFailure, GithubRuntimeAuthorityReceipt,
     GithubRuntimeAuthorityRepository, GithubRuntimeAuthorityState,
-    GithubRuntimeAuthorityTerminalReason, GithubRuntimeAuthorityWorkerId,
-    GithubServerServiceAppClientId, GithubServerServiceAppId, GithubServerServiceJwtIssuer,
-    InspectGithubRuntimeAuthority, MAX_GITHUB_AUTHORITY_MINT_CLAIM_MILLIS,
-    MAX_GITHUB_AUTHORITY_MINT_RETRY_BACKOFF_MILLIS, MarkGithubRuntimeAuthorityIndeterminate,
-    ProtectedGithubRuntimeAuthority, RejectGithubRuntimeAuthorityMint,
-    RetryGithubRuntimeAuthorityMint, Sha256Digest,
+    GithubRuntimeAuthorityStoreError, GithubRuntimeAuthorityTerminalReason,
+    GithubRuntimeAuthorityWorkerId, GithubServerServiceAppClientId, GithubServerServiceAppId,
+    GithubServerServiceJwtIssuer, InspectGithubRuntimeAuthority,
+    MAX_GITHUB_AUTHORITY_MINT_CLAIM_MILLIS, MAX_GITHUB_AUTHORITY_MINT_RETRY_BACKOFF_MILLIS,
+    MarkGithubRuntimeAuthorityIndeterminate, ProtectedGithubRuntimeAuthority,
+    RejectGithubRuntimeAuthorityMint, RetryGithubRuntimeAuthorityMint, Sha256Digest,
 };
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
@@ -785,7 +785,10 @@ impl GithubRuntimeAuthorityMintCoordinator {
             .repository
             .claim_github_runtime_authority_mint(claim)
             .await
-            .map_err(|_| GithubRuntimeAuthorityCoordinatorError::Repository)?
+            .map_err(|error| {
+                observe_repository_failure("claim", &error);
+                GithubRuntimeAuthorityCoordinatorError::Repository
+            })?
         else {
             return self.claim_unavailable(identity).await;
         };
@@ -826,8 +829,10 @@ impl GithubRuntimeAuthorityMintCoordinator {
             .repository
             .begin_github_runtime_authority_mint(begin)
             .await
-            .map_err(|_| GithubRuntimeAuthorityCoordinatorError::Repository)?
-        {
+            .map_err(|error| {
+                observe_repository_failure("begin", &error);
+                GithubRuntimeAuthorityCoordinatorError::Repository
+            })? {
             BeginGithubRuntimeAuthorityMintOutcome::AlreadyStarted(receipt) => {
                 return Ok(GithubRuntimeAuthorityCoordinationOutcome::AlreadyStarted(
                     receipt,
@@ -859,7 +864,10 @@ impl GithubRuntimeAuthorityMintCoordinator {
         self.repository
             .inspect_github_runtime_authority(request)
             .await
-            .map_err(|_| GithubRuntimeAuthorityCoordinatorError::Repository)
+            .map_err(|error| {
+                observe_repository_failure("inspect", &error);
+                GithubRuntimeAuthorityCoordinatorError::Repository
+            })
     }
 
     async fn claim_unavailable(
@@ -932,7 +940,10 @@ impl GithubRuntimeAuthorityMintCoordinator {
                     .repository
                     .mark_github_runtime_authority_indeterminate(request)
                     .await
-                    .map_err(|_| GithubRuntimeAuthorityCoordinatorError::Repository)?;
+                    .map_err(|error| {
+                        observe_repository_failure("indeterminate", &error);
+                        GithubRuntimeAuthorityCoordinatorError::Repository
+                    })?;
                 Ok(GithubRuntimeAuthorityCoordinationOutcome::Transitioned(
                     receipt,
                 ))
@@ -965,14 +976,20 @@ impl GithubRuntimeAuthorityMintCoordinator {
             self.repository
                 .retry_github_runtime_authority_mint(request)
                 .await
-                .map_err(|_| GithubRuntimeAuthorityCoordinatorError::Repository)?
+                .map_err(|error| {
+                    observe_repository_failure("retry", &error);
+                    GithubRuntimeAuthorityCoordinatorError::Repository
+                })?
         } else {
             let request = RejectGithubRuntimeAuthorityMint::new(claim, failure, observed_at)
                 .map_err(|_| GithubRuntimeAuthorityCoordinatorError::InvalidTime)?;
             self.repository
                 .reject_github_runtime_authority_mint(request)
                 .await
-                .map_err(|_| GithubRuntimeAuthorityCoordinatorError::Repository)?
+                .map_err(|error| {
+                    observe_repository_failure("reject", &error);
+                    GithubRuntimeAuthorityCoordinatorError::Repository
+                })?
         };
         Ok(GithubRuntimeAuthorityCoordinationOutcome::Transitioned(
             receipt,
@@ -1013,6 +1030,24 @@ impl GithubRuntimeAuthorityMintCoordinator {
     fn observation_at_least(&self, lower_bound: UnixMillis) -> UnixMillis {
         self.clock.now().max(lower_bound)
     }
+}
+
+fn observe_repository_failure(operation: &'static str, error: &GithubRuntimeAuthorityStoreError) {
+    let kind = match error {
+        GithubRuntimeAuthorityStoreError::Operation(_) => "operation",
+        GithubRuntimeAuthorityStoreError::CorruptData => "corrupt_data",
+        GithubRuntimeAuthorityStoreError::IdentityConflict => "identity_conflict",
+        GithubRuntimeAuthorityStoreError::MintClaimRejected => "mint_claim_rejected",
+        GithubRuntimeAuthorityStoreError::RevocationClaimRejected => "revocation_claim_rejected",
+        GithubRuntimeAuthorityStoreError::QuarantineRejected => "quarantine_rejected",
+        GithubRuntimeAuthorityStoreError::FenceExhausted => "fence_exhausted",
+        GithubRuntimeAuthorityStoreError::RetryLimitReached => "retry_limit_reached",
+    };
+    tracing::warn!(
+        operation,
+        kind,
+        "GitHub runtime-authority repository failure"
+    );
 }
 
 impl fmt::Debug for GithubRuntimeAuthorityMintCoordinator {

--- a/crates/automata-ci-credential-github/src/lib.rs
+++ b/crates/automata-ci-credential-github/src/lib.rs
@@ -35,7 +35,9 @@ mod server_service_authority;
 mod signer;
 mod supervised_custody;
 
-pub use adapter::{GithubAppBrokerConstructionError, GithubAppCredentialBroker};
+pub use adapter::{
+    GithubAppBrokerConstructionError, GithubAppCredentialBroker, GithubAppWebhookUpdateError,
+};
 pub use authority_coordinator::{
     GithubJobRuntimeAuthorityRequestValueError, GithubRuntimeAuthorityCommitSupervisor,
     GithubRuntimeAuthorityCommitSupervisorError, GithubRuntimeAuthorityCoordinationOutcome,

--- a/crates/automata-ci-credential-github/src/server_service_authority.rs
+++ b/crates/automata-ci-credential-github/src/server_service_authority.rs
@@ -1236,7 +1236,7 @@ impl GithubServerServiceCredentialIssuer {
                     required_through = requested_through.get(),
                     "GitHub server-service credential handoff repository rejected request"
                 );
-                map_store_handoff_error(error)
+                map_store_handoff_error(&error)
             })?;
         if GithubServerServiceAuthoritySelector::from_identity(handoff.identity())
             != requested_selector
@@ -1415,7 +1415,7 @@ impl GithubServerServiceCredentialIssuer {
 }
 
 fn map_store_handoff_error(
-    error: GithubServerServiceStoreError,
+    error: &GithubServerServiceStoreError,
 ) -> GithubServerServiceHandoffError {
     match error {
         GithubServerServiceStoreError::Operation(_) => GithubServerServiceHandoffError::Repository,

--- a/crates/automata-ci-credential-github/src/server_service_authority.rs
+++ b/crates/automata-ci-credential-github/src/server_service_authority.rs
@@ -1084,6 +1084,9 @@ pub enum GithubServerServiceHandoffError {
     /// Key management is temporarily unavailable; custody was not quarantined.
     #[error("GitHub server-service handoff key management is unavailable")]
     Unavailable,
+    /// The exact durable handoff request no longer matches current claim state.
+    #[error("GitHub server-service credential handoff was rejected")]
+    Rejected,
     /// Returned handoff evidence did not match the exact request.
     #[error("GitHub server-service handoff binding is inconsistent")]
     Inconsistent,
@@ -1214,7 +1217,7 @@ impl GithubServerServiceCredentialIssuer {
             .repository
             .acquire_github_server_service_handoff(request)
             .await
-            .map_err(|_| GithubServerServiceHandoffError::Repository)?;
+            .map_err(map_store_handoff_error)?;
         if GithubServerServiceAuthoritySelector::from_identity(handoff.identity())
             != requested_selector
             || handoff.consumer() != requested_consumer
@@ -1388,6 +1391,23 @@ impl GithubServerServiceCredentialIssuer {
         )
         .map_err(|_| GithubServerServiceHandoffError::Inconsistent)?;
         Ok(PendingGithubServerServiceHandoffRelease { request })
+    }
+}
+
+fn map_store_handoff_error(
+    error: GithubServerServiceStoreError,
+) -> GithubServerServiceHandoffError {
+    match error {
+        GithubServerServiceStoreError::Operation(_) => GithubServerServiceHandoffError::Repository,
+        GithubServerServiceStoreError::HandoffRejected
+        | GithubServerServiceStoreError::NotFound
+        | GithubServerServiceStoreError::ClaimRejected => GithubServerServiceHandoffError::Rejected,
+        GithubServerServiceStoreError::CorruptData
+        | GithubServerServiceStoreError::IdentityConflict
+        | GithubServerServiceStoreError::FenceExhausted
+        | GithubServerServiceStoreError::HandoffStillLive => {
+            GithubServerServiceHandoffError::Inconsistent
+        }
     }
 }
 

--- a/crates/automata-ci-credential-github/src/server_service_authority.rs
+++ b/crates/automata-ci-credential-github/src/server_service_authority.rs
@@ -1217,7 +1217,21 @@ impl GithubServerServiceCredentialIssuer {
             .repository
             .acquire_github_server_service_handoff(request)
             .await
-            .map_err(map_store_handoff_error)?;
+            .map_err(|error| {
+                tracing::warn!(
+                    error = ?error,
+                    action = requested_consumer.action().as_str(),
+                    tenant = requested_selector.tenant().as_str(),
+                    authority_id = ?requested_selector.authority_id(),
+                    identity_digest = %requested_selector.identity_digest(),
+                    app_configuration_revision = requested_selector
+                        .app_configuration_revision()
+                        .get(),
+                    policy_revision = requested_selector.policy_revision().get(),
+                    "GitHub server-service credential handoff repository rejected request"
+                );
+                map_store_handoff_error(error)
+            })?;
         if GithubServerServiceAuthoritySelector::from_identity(handoff.identity())
             != requested_selector
             || handoff.consumer() != requested_consumer

--- a/crates/automata-ci-credential-github/src/server_service_authority.rs
+++ b/crates/automata-ci-credential-github/src/server_service_authority.rs
@@ -1228,6 +1228,12 @@ impl GithubServerServiceCredentialIssuer {
                         .app_configuration_revision()
                         .get(),
                     policy_revision = requested_selector.policy_revision().get(),
+                    consumer_id = ?requested_consumer.consumer_id(),
+                    consumer_owner = ?requested_consumer.owner(),
+                    consumer_fence = requested_consumer.fence().get(),
+                    consumer_revision = requested_consumer.revision().get(),
+                    requested_at = requested_at.get(),
+                    required_through = requested_through.get(),
                     "GitHub server-service credential handoff repository rejected request"
                 );
                 map_store_handoff_error(error)

--- a/crates/automata-ci-credential-github/src/server_service_authority_tests.rs
+++ b/crates/automata-ci-credential-github/src/server_service_authority_tests.rs
@@ -1407,3 +1407,15 @@ fn handoff_id(value: u128) -> GithubServerServiceHandoffId {
 fn worker(value: u128) -> GithubServerServiceWorkerId {
     GithubServerServiceWorkerId::from_uuid(Uuid::from_u128(value)).expect("worker")
 }
+
+#[test]
+fn rejected_store_handoff_is_not_reported_as_repository_unavailable() {
+    assert_eq!(
+        map_store_handoff_error(GithubServerServiceStoreError::HandoffRejected),
+        GithubServerServiceHandoffError::Rejected
+    );
+    assert_eq!(
+        map_store_handoff_error(GithubServerServiceStoreError::NotFound),
+        GithubServerServiceHandoffError::Rejected
+    );
+}

--- a/crates/automata-ci-credential-github/tests/app_webhook_configuration.rs
+++ b/crates/automata-ci-credential-github/tests/app_webhook_configuration.rs
@@ -1,0 +1,65 @@
+mod support;
+
+use automata_ci_credential_github::GithubAppWebhookUpdateError;
+use axum::http::StatusCode;
+use serde_json::Value;
+use support::{FixtureServer, ResponseSpec};
+
+#[tokio::test]
+async fn app_webhook_update_is_app_authenticated_and_exact() {
+    let server = FixtureServer::spawn().await;
+    let webhook_url = url::Url::parse(
+        "https://hooks.automata-ci.com/webhooks/providers/13c64af9-66a7-5c2b-ab8b-f45728967c05",
+    )
+    .unwrap();
+    server.enqueue(ResponseSpec::json(
+        StatusCode::OK,
+        format!(
+            r#"{{"url":"{webhook_url}","content_type":"json","insecure_ssl":"0","secret":"********"}}"#
+        ),
+    ));
+
+    server
+        .broker()
+        .update_app_webhook_configuration(&webhook_url, b"fixture-webhook-secret")
+        .await
+        .expect("exact webhook configuration must converge");
+
+    let requests = server.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "PATCH");
+    assert_eq!(requests[0].uri, "/api/v3/app/hook/config");
+    assert_eq!(requests[0].headers["accept"], "application/vnd.github+json");
+    assert!(
+        requests[0].headers["authorization"]
+            .to_str()
+            .unwrap()
+            .starts_with("Bearer eyJ")
+    );
+    let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(body["url"], webhook_url.as_str());
+    assert_eq!(body["content_type"], "json");
+    assert_eq!(body["insecure_ssl"], "0");
+    assert_eq!(body["secret"], "fixture-webhook-secret");
+}
+
+#[tokio::test]
+async fn app_webhook_update_rejects_mismatched_provider_response() {
+    let server = FixtureServer::spawn().await;
+    let webhook_url = url::Url::parse(
+        "https://hooks.automata-ci.com/webhooks/providers/13c64af9-66a7-5c2b-ab8b-f45728967c05",
+    )
+    .unwrap();
+    server.enqueue(ResponseSpec::json(
+        StatusCode::OK,
+        r#"{"url":"https://elsewhere.example/hook","content_type":"json","insecure_ssl":"0"}"#,
+    ));
+
+    let error = server
+        .broker()
+        .update_app_webhook_configuration(&webhook_url, b"fixture-webhook-secret")
+        .await
+        .expect_err("mismatched endpoint must fail closed");
+
+    assert_eq!(error, GithubAppWebhookUpdateError::InvalidResponse);
+}

--- a/crates/automata-ci-github-delivery/src/result_adapter.rs
+++ b/crates/automata-ci-github-delivery/src/result_adapter.rs
@@ -34,7 +34,6 @@ const CURSOR_SCHEMA: u16 = 1;
 const RESULT_STATE_DOMAIN: &[u8] = b"automata.github.common-result-state.v1\0";
 const DEFAULT_VISIBILITY_MARGIN_MILLIS: i64 = 2_000;
 const MAX_GITHUB_ANNOTATIONS_PER_REQUEST: usize = 50;
-const GITHUB_RESULT_PROVIDER_TAIL_MILLIS: i64 = 10 * 60 * 1_000;
 
 /// One exact GitHub Checks action requested from credential authority.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -55,6 +54,29 @@ pub enum GithubResultOperation {
     ReadAnnotations,
     /// Append one exact bounded annotation batch.
     AppendAnnotations,
+}
+
+impl GithubResultOperation {
+    /// Returns the bounded provider-I/O tail required by this operation.
+    ///
+    /// Suite creation, check-run creation, and creation reconciliation each
+    /// issue one bounded request. Reading or mutating an existing check run
+    /// may perform a read followed by a write, so it uses the two-request
+    /// publication horizon admitted by the durable server-service action.
+    const fn provider_tail_millis(self) -> i64 {
+        match self {
+            Self::EnsureSuite | Self::CreateRun | Self::ReconcileRun => {
+                automata_ci_store::MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS
+            }
+            Self::ReadRun
+            | Self::StartRun
+            | Self::CompleteRun
+            | Self::ReadAnnotations
+            | Self::AppendAnnotations => {
+                2 * automata_ci_store::MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS
+            }
+        }
+    }
 }
 
 /// Borrowed exact authority request for one common result claim.
@@ -346,7 +368,7 @@ impl GithubResultProviderAdapter {
         let Some(required_through) = claim
             .expires_at()
             .get()
-            .checked_add(GITHUB_RESULT_PROVIDER_TAIL_MILLIS)
+            .checked_add(operation.provider_tail_millis())
             .map(UnixMillis::new)
         else {
             return failed(ResultPublisherError::Conflict);
@@ -1829,6 +1851,31 @@ mod tests {
                 Err(ResultPublisherError::Conflict)
             );
         }
+    }
+
+    #[test]
+    fn result_operation_horizon_matches_durable_action_shape() {
+        let one_request = automata_ci_store::MAX_GITHUB_SERVICE_CONSUMER_REQUEST_MILLIS;
+        assert_eq!(
+            GithubResultOperation::EnsureSuite.provider_tail_millis(),
+            one_request
+        );
+        assert_eq!(
+            GithubResultOperation::CreateRun.provider_tail_millis(),
+            one_request
+        );
+        assert_eq!(
+            GithubResultOperation::ReconcileRun.provider_tail_millis(),
+            one_request
+        );
+        assert_eq!(
+            GithubResultOperation::ReadRun.provider_tail_millis(),
+            2 * one_request
+        );
+        assert_eq!(
+            GithubResultOperation::CompleteRun.provider_tail_millis(),
+            2 * one_request
+        );
     }
 
     #[test]

--- a/crates/automata-ci-github-delivery/src/schedule.rs
+++ b/crates/automata-ci-github-delivery/src/schedule.rs
@@ -284,7 +284,10 @@ impl<'a> GithubScheduleSourceCredentialRequest<'a> {
             GithubServerServiceClaimFence::new(self.claim.fence().get())
                 .map_err(|_| GithubScheduleSourceCredentialValueError)?,
             GithubServerServiceAction::DiscoverRepositorySchedules,
-            GithubServerServiceRevision::new(self.manifest.revision().get())
+            // Schedule discovery has a stable consumer contract revision. The
+            // manifest revision tracks provider configuration evolution and is
+            // intentionally independent from this handoff claim revision.
+            GithubServerServiceRevision::new(1)
                 .map_err(|_| GithubScheduleSourceCredentialValueError)?,
         ))
     }

--- a/crates/automata-ci-github-delivery/src/trigger_handler.rs
+++ b/crates/automata-ci-github-delivery/src/trigger_handler.rs
@@ -341,7 +341,14 @@ impl GithubWorkflowTriggerHandler {
             .await
         {
             Ok(source) => source,
-            Err(outcome) => return outcome,
+            Err(outcome) => {
+                tracing::warn!(
+                    trigger_kind = normalized_trigger_kind(normalized),
+                    outcome = ?outcome,
+                    "GitHub trigger source resolution failed"
+                );
+                return outcome;
+            }
         };
         let recursion = match normalized {
             NormalizedTrigger::RepositoryDispatch(_) => TrustTokenRecursion::Unknown,
@@ -425,14 +432,28 @@ impl GithubWorkflowTriggerHandler {
         );
         let first = match first {
             Ok(request) => self.application.apply(request).await,
-            Err(_) => return fail_invalid(),
+            Err(error) => {
+                tracing::warn!(
+                    trigger_kind = normalized_trigger_kind(normalized),
+                    ?error,
+                    "GitHub trigger application request rejected"
+                );
+                return fail_invalid();
+            }
         };
         match first {
             Ok(ProviderWorkflowApplicationOutcome::Applied(_)) => {
                 return ProviderTriggerOutcome::Complete;
             }
             Ok(ProviderWorkflowApplicationOutcome::RequiresChangedFiles) => {}
-            Err(error) => return application_outcome(&error),
+            Err(error) => {
+                tracing::warn!(
+                    trigger_kind = normalized_trigger_kind(normalized),
+                    ?error,
+                    "GitHub trigger workflow application failed"
+                );
+                return application_outcome(&error);
+            }
         }
         let metadata = match self
             .changed_files_metadata(context, trigger, invocation, lease, repository)
@@ -457,9 +478,23 @@ impl GithubWorkflowTriggerHandler {
                     ProviderTriggerOutcome::Complete
                 }
                 Ok(ProviderWorkflowApplicationOutcome::RequiresChangedFiles) => fail_invalid(),
-                Err(error) => application_outcome(&error),
+                Err(error) => {
+                    tracing::warn!(
+                        trigger_kind = normalized_trigger_kind(normalized),
+                        ?error,
+                        "GitHub trigger workflow application failed after changed-file replay"
+                    );
+                    application_outcome(&error)
+                }
             },
-            Err(_) => fail_invalid(),
+            Err(error) => {
+                tracing::warn!(
+                    trigger_kind = normalized_trigger_kind(normalized),
+                    ?error,
+                    "GitHub trigger changed-file application request rejected"
+                );
+                fail_invalid()
+            }
         }
     }
 
@@ -829,4 +864,13 @@ const fn retry_unavailable() -> ProviderTriggerOutcome {
 
 const fn fail_invalid() -> ProviderTriggerOutcome {
     ProviderTriggerOutcome::Fail(ProviderProcessingFailure::InvalidEvidence)
+}
+
+fn normalized_trigger_kind(trigger: &NormalizedTrigger) -> &'static str {
+    match trigger {
+        NormalizedTrigger::Push(_) => "push",
+        NormalizedTrigger::PullRequest(_) => "pull_request",
+        NormalizedTrigger::MergeQueue(_) => "merge_queue",
+        NormalizedTrigger::RepositoryDispatch(_) => "repository_dispatch",
+    }
 }

--- a/crates/automata-ci-github-delivery/src/trigger_handler.rs
+++ b/crates/automata-ci-github-delivery/src/trigger_handler.rs
@@ -8,7 +8,7 @@ use automata_ci_core::{GitObjectId, TrustSnapshot, TrustTokenRecursion, UnixMill
 use automata_ci_provider::{
     ClaimedProviderProcessing, ExternalRepositoryId, NormalizedTrigger, ProviderConnectionRevision,
     ProviderGitRef, ProviderGitRefKind, ProviderProcessingClaimFence, ProviderProcessingFailure,
-    VerifiedProviderTriggerDelivery,
+    RepositoryVisibility, VerifiedProviderTriggerDelivery,
 };
 use automata_ci_provider_delivery::{
     ProviderDeliveryClock, ProviderProcessingLease, ProviderRuntimeContext, ProviderTriggerOutcome,
@@ -472,6 +472,22 @@ impl GithubWorkflowTriggerHandler {
         lease: &ProviderProcessingLease,
         repository: &GithubTriggerRepository,
     ) -> Result<ResolvedGithubSource, ProviderTriggerOutcome> {
+        let archive_limits = ArchiveLimits::new(
+            context
+                .connection()
+                .configuration()
+                .archive_limits()
+                .compressed_bytes(),
+        )
+        .map_err(|_| fail_invalid())?;
+        let normalized = trigger.trigger().trigger();
+        if context.connection().configuration().visibility() == RepositoryVisibility::Public
+            && let Some(revision) = normalized.workflow_source_revision()
+        {
+            return fetch_exact_source(repository, normalized, revision, None, archive_limits)
+                .await
+                .map_err(scm_error);
+        }
         let request = credential_request(
             context,
             trigger,
@@ -491,21 +507,12 @@ impl GithubWorkflowTriggerHandler {
             credential.release().await;
             return Err(fail_invalid());
         }
-        let archive_limits = ArchiveLimits::new(
-            context
-                .connection()
-                .configuration()
-                .archive_limits()
-                .compressed_bytes(),
-        )
-        .map_err(|_| fail_invalid())?;
-        let normalized = trigger.trigger().trigger();
         let result = if let Some(revision) = normalized.workflow_source_revision() {
             fetch_exact_source(
                 repository,
                 normalized,
                 revision,
-                credential.token(),
+                Some(credential.token()),
                 archive_limits,
             )
             .await
@@ -646,19 +653,25 @@ async fn fetch_exact_source(
     repository: &GithubTriggerRepository,
     trigger: &NormalizedTrigger,
     revision: GitObjectId,
-    token: &SecretString,
+    token: Option<&SecretString>,
     limits: ArchiveLimits,
 ) -> Result<ResolvedGithubSource, ScmError> {
-    let archive = repository
-        .endpoint
-        .fetch_repository_source(RepositorySourceRequest::authenticated(
+    let request = match token {
+        Some(token) => RepositorySourceRequest::authenticated(
             &repository.source_connection,
             &revision,
             token,
             limits,
             RepositorySourceRedirectPolicy::ConfiguredArchiveOrigin,
-        ))
-        .await?;
+        ),
+        None => RepositorySourceRequest::public(
+            &repository.source_connection,
+            &revision,
+            limits,
+            RepositorySourceRedirectPolicy::ConfiguredArchiveOrigin,
+        ),
+    };
+    let archive = repository.endpoint.fetch_repository_source(request).await?;
     let execution_ref = trigger
         .workflow_execution_ref()
         .cloned()

--- a/crates/automata-ci-github-delivery/tests/trigger_handler.rs
+++ b/crates/automata-ci-github-delivery/tests/trigger_handler.rs
@@ -140,12 +140,70 @@ async fn common_worker_drives_exact_github_source_diff_admission_and_result_cont
     assert!(requests.iter().all(|request| request.body.is_empty()));
 }
 
+#[tokio::test]
+async fn public_exact_source_uses_the_direct_archive_without_a_credential() {
+    let server = HttpServer::spawn().await;
+    enqueue_public_filtered_source(&server);
+    let contract = contract_with_visibility(&server.origin(), RepositoryVisibility::Public);
+
+    assert_eq!(
+        contract.worker.run_once().await.expect("processing pass"),
+        ProviderProcessingWorkerOutcome::Completed
+    );
+    assert_eq!(
+        contract
+            .credentials
+            .operations
+            .lock()
+            .expect("credential lock")
+            .as_slice(),
+        &[GithubTriggerCredentialOperation::ReadPushChangedFiles]
+    );
+    assert_eq!(contract.releases.load(Ordering::SeqCst), 1);
+
+    let requests = server.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(
+        requests[0].uri,
+        format!("/owner/repository/legacy.tar.gz/{AFTER}")
+    );
+    assert!(!requests[0].headers.contains_key("authorization"));
+    assert_eq!(
+        requests[1].uri,
+        format!("/api/v3/repos/owner/repository/compare/{BEFORE}...{AFTER}?per_page=100&page=1")
+    );
+    assert_eq!(requests[1].headers["authorization"], "Bearer trigger-token");
+}
+
 fn enqueue_filtered_source(server: &HttpServer) {
     let source = archive(BTreeMap::from([(WORKFLOW_PATH, FILTERED_WORKFLOW)]));
     server.enqueue(
         HttpResponse::status(StatusCode::FOUND)
             .header("location", server.url("archive/source.tar.gz").as_str()),
     );
+    server.enqueue(HttpResponse::binary(
+        StatusCode::OK,
+        "application/gzip",
+        source.to_vec(),
+    ));
+    server.enqueue(HttpResponse::json(
+        StatusCode::OK,
+        serde_json::to_vec(&json!({
+            "status": "ahead",
+            "ahead_by": 1,
+            "behind_by": 0,
+            "total_commits": 1,
+            "base_commit": {"sha": BEFORE},
+            "merge_base_commit": {"sha": BEFORE},
+            "commits": [{"sha": AFTER}],
+            "files": [{"filename": "src/lib.rs", "status": "modified"}]
+        }))
+        .expect("compare response"),
+    ));
+}
+
+fn enqueue_public_filtered_source(server: &HttpServer) {
+    let source = archive(BTreeMap::from([(WORKFLOW_PATH, FILTERED_WORKFLOW)]));
     server.enqueue(HttpResponse::binary(
         StatusCode::OK,
         "application/gzip",
@@ -177,9 +235,13 @@ struct Contract {
 }
 
 fn contract(origin: &Url) -> Contract {
-    let (provider, connection) = manifests(origin);
+    contract_with_visibility(origin, RepositoryVisibility::Private)
+}
+
+fn contract_with_visibility(origin: &Url, visibility: RepositoryVisibility) -> Contract {
+    let (provider, connection) = manifests(origin, visibility);
     let worker_id = ProviderProcessingWorkerId::from_uuid(Uuid::from_u128(5)).expect("worker");
-    let invocation = invocation(&provider, &connection, worker_id);
+    let invocation = invocation(&provider, &connection, worker_id, visibility);
     let processing = Arc::new(ProcessingRepository::new(invocation));
     let manifests = Arc::new(Manifests {
         provider,
@@ -591,7 +653,10 @@ impl ProviderResultRepository for Results {
     }
 }
 
-fn manifests(origin: &Url) -> (ProviderInstanceManifest, ProviderConnectionManifest) {
+fn manifests(
+    origin: &Url,
+    visibility: RepositoryVisibility,
+) -> (ProviderInstanceManifest, ProviderConnectionManifest) {
     let instance_id = ProviderInstanceId::from_uuid(Uuid::from_u128(1)).expect("instance");
     let provider_revision = ProviderConfigurationRevision::new(1).expect("provider revision");
     let api = origin.join("api/v3/").expect("API origin");
@@ -628,7 +693,7 @@ fn manifests(origin: &Url) -> (ProviderInstanceManifest, ProviderConnectionManif
         provider_revision,
         provider.configuration().digest(),
         provider.capability_digest(),
-        RepositoryVisibility::Private,
+        visibility,
         ProviderDefaultBranch::new("main").expect("default branch"),
         ProviderWorkflowSource::Directory(
             ProviderRepositoryPath::new(".ci/workflows").expect("workflow root"),
@@ -671,12 +736,13 @@ fn invocation(
     provider: &ProviderInstanceManifest,
     connection: &ProviderConnectionManifest,
     worker_id: ProviderProcessingWorkerId,
+    visibility: RepositoryVisibility,
 ) -> ClaimedProviderProcessing {
     let repository = ProviderRepository::new(
         connection.configuration().repository().clone(),
         ExternalSubjectId::new("7").expect("owner ID"),
         ProviderRepositoryPath::new("owner/repository").expect("repository path"),
-        RepositoryVisibility::Private,
+        visibility,
     );
     let push = PushTrigger::new(
         repository,

--- a/crates/automata-ci-postgres/README.md
+++ b/crates/automata-ci-postgres/README.md
@@ -8,6 +8,8 @@ its cleanup utility, and the explicitly enabled `test-support` fixture API.
 Schema migrations belong to `automata-ci-store-postgres`. All PostgreSQL
 integration suites compile into the explicit `postgres` target; run the
 database-backed lane through `./scripts/ci/run-postgres-tests.sh`.
+The harness applies migrations in production's `public` schema and reserves
+`automata_test` for deterministic test helpers such as its clock override.
 
 - [Architecture documentation](https://github.com/automata-ci/automata/blob/main/docs/architecture.md)
 - API documentation: run `cargo doc -p automata-ci-postgres --open` from a source checkout.

--- a/crates/automata-ci-postgres/src/test_support/clock.rs
+++ b/crates/automata-ci-postgres/src/test_support/clock.rs
@@ -4,7 +4,8 @@ use super::{TestResult, message_error};
 
 /// A schema-local replacement for `PostgreSQL`'s wall clock.
 ///
-/// Pools created by this crate search `automata_test` before `pg_catalog`, so
+/// Application pools created by this crate search `automata_test` before the
+/// production `public` schema and `pg_catalog`, so
 /// unqualified calls to `clock_timestamp()` resolve this fixture on every
 /// current and replacement connection while the clock is frozen.
 #[derive(Debug)]

--- a/crates/automata-ci-postgres/src/test_support/database.rs
+++ b/crates/automata-ci-postgres/src/test_support/database.rs
@@ -27,6 +27,8 @@ const MAX_NAMESPACE_LENGTH: usize = 27;
 // Eight connections preserve those in-test races while the PostgreSQL lane's
 // two libtest workers bound aggregate demand to sixteen primary connections.
 const DEFAULT_POOL_CONNECTIONS: u32 = 8;
+const MIGRATION_SEARCH_PATH: &str = "public, pg_catalog";
+const APPLICATION_SEARCH_PATH: &str = "automata_test, public, pg_catalog";
 const MINIMUM_POSTGRES_VERSION: i32 = 180_000;
 const TEMPLATE_MARKER_VERSION: &str = "automata-ci-postgres-test-support:v1";
 const TEMPLATE_LOCK_SALT: i64 = 6_482_851_405_936_141_723;
@@ -308,8 +310,11 @@ impl PostgresTestHarness {
     /// Creates or reuses the fully initialized, disconnected job template.
     ///
     /// The initializer executes at most once for a namespace across cooperating
-    /// processes. Its pool searches `automata_test, pg_catalog`. Callers must
-    /// supply a namespace unique to the complete CI run. Set
+    /// processes. Its migration pool uses production's `public` schema. Cloned
+    /// application pools search `automata_test, public, pg_catalog` so the test
+    /// clock may shadow `pg_catalog.clock_timestamp()` without relocating the
+    /// production schema. Callers must supply a namespace unique to the complete
+    /// CI run. Set
     /// `INITIALIZER_FINGERPRINT_ENVIRONMENT`
     /// or call [`Self::with_initializer_fingerprint`] so incompatible
     /// initializers fail closed. Without a fingerprint, callers must change the
@@ -367,8 +372,8 @@ impl PostgresTestHarness {
 
     /// Creates an application-empty test database from `PostgreSQL` `template0`.
     ///
-    /// Only the `automata_test` schema is bootstrapped, so migration tests start
-    /// without any current application objects or migration ledger.
+    /// Only the `automata_test` helper schema is bootstrapped, so migration tests
+    /// start with an empty production `public` schema and no migration ledger.
     ///
     /// # Errors
     ///
@@ -406,6 +411,7 @@ impl PostgresTestHarness {
             &self.admin_options,
             &database_name,
             DEFAULT_POOL_CONNECTIONS,
+            MIGRATION_SEARCH_PATH,
         )
         .await
         {
@@ -531,6 +537,7 @@ impl PostgresTestHarness {
             &self.admin_options,
             template_name,
             DEFAULT_POOL_CONNECTIONS,
+            MIGRATION_SEARCH_PATH,
         )
         .await
         {
@@ -711,6 +718,7 @@ impl PreparedTemplate {
             &self.harness.admin_options,
             &database_name,
             DEFAULT_POOL_CONNECTIONS,
+            APPLICATION_SEARCH_PATH,
         )
         .await
         {
@@ -784,14 +792,31 @@ impl TestDatabase {
         self.database_name.as_str()
     }
 
-    /// Creates a replacement pool with the canonical fixed search path.
+    /// Creates a replacement application pool with the canonical fixed search path.
     ///
     /// # Errors
     ///
     /// Returns an error if `max_connections` is zero or `PostgreSQL` cannot open
     /// the pool.
     pub(super) async fn connect_pool(&self, max_connections: u32) -> TestResult<PgPool> {
-        connect_database_pool(&self.admin_options, &self.database_name, max_connections).await
+        connect_database_pool(
+            &self.admin_options,
+            &self.database_name,
+            max_connections,
+            APPLICATION_SEARCH_PATH,
+        )
+        .await
+    }
+
+    /// Creates a replacement pool with production's migration search path.
+    pub(super) async fn connect_migration_pool(&self, max_connections: u32) -> TestResult<PgPool> {
+        connect_database_pool(
+            &self.admin_options,
+            &self.database_name,
+            max_connections,
+            MIGRATION_SEARCH_PATH,
+        )
+        .await
     }
 
     /// Closes the primary pool and drops exactly this database with `FORCE`.
@@ -945,6 +970,7 @@ async fn connect_database_pool(
     admin_options: &PgConnectOptions,
     database_name: &DatabaseIdentifier,
     max_connections: u32,
+    search_path: &'static str,
 ) -> TestResult<PgPool> {
     if max_connections == 0 {
         return Err(message_error(
@@ -954,10 +980,10 @@ async fn connect_database_pool(
     let options = admin_options.clone().database(database_name.as_str());
     Ok(PgPoolOptions::new()
         .max_connections(max_connections)
-        .after_connect(|connection, _metadata| {
+        .after_connect(move |connection, _metadata| {
             Box::pin(async move {
                 sqlx::query("SELECT pg_catalog.set_config('search_path', $1, false)")
-                    .bind("automata_test, pg_catalog")
+                    .bind(search_path)
                     .execute(connection)
                     .await?;
                 Ok(())

--- a/crates/automata-ci-postgres/src/test_support/mod.rs
+++ b/crates/automata-ci-postgres/src/test_support/mod.rs
@@ -92,6 +92,16 @@ impl PostgresTestDatabase {
     pub async fn connect_pool(&self, max_connections: u32) -> TestResult<PgPool> {
         self.database.connect_pool(max_connections).await
     }
+
+    /// Opens another pool with production's migration search path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `max_connections` is zero or `PostgreSQL` cannot
+    /// establish the pool.
+    pub async fn connect_migration_pool(&self, max_connections: u32) -> TestResult<PgPool> {
+        self.database.connect_migration_pool(max_connections).await
+    }
 }
 
 /// Runs a test with an isolated, migrated database and default Store adapter.
@@ -141,8 +151,8 @@ where
 
 /// Runs a test with an application-empty database and configured Store adapter.
 ///
-/// The database contains the `automata_test` schema but no current application
-/// objects or migration ledger.
+/// The database contains the `automata_test` helper schema but no current
+/// application objects or migration ledger in production's `public` schema.
 ///
 /// # Errors
 ///

--- a/crates/automata-ci-postgres/src/test_support/tests.rs
+++ b/crates/automata-ci-postgres/src/test_support/tests.rs
@@ -208,7 +208,7 @@ async fn template0_database_is_application_empty() -> TestResult {
                 .fetch_one(database.pool())
                 .await?;
                 let migration_ledger_exists: bool = sqlx::query_scalar(
-                    "SELECT pg_catalog.to_regclass('automata_test._sqlx_migrations') IS NOT NULL",
+                    "SELECT pg_catalog.to_regclass('public._sqlx_migrations') IS NOT NULL",
                 )
                 .fetch_one(database.pool())
                 .await?;

--- a/crates/automata-ci-postgres/tests/auth/delegated_actor.rs
+++ b/crates/automata-ci-postgres/tests/auth/delegated_actor.rs
@@ -26,7 +26,7 @@ use crate::support::{TestResult, run_with_database};
 static MIGRATOR: sqlx::migrate::Migrator =
     sqlx::migrate!("../automata-ci-store-postgres/migrations");
 
-const PRE_BILLING_MIGRATION_VERSION: i64 = 60;
+const PRE_BILLING_MIGRATION_VERSION: i64 = 62;
 const PROVISIONING_PAUSE_LOCK: i64 = 1_504_061_001;
 
 fn authority() -> ProvisioningAuthority {
@@ -152,7 +152,7 @@ async fn billing_migration_serializes_concurrent_owner_provisioning() -> TestRes
             )
             .await?;
 
-            let migration_pool = database.connect_pool(1).await?;
+            let migration_pool = database.connect_migration_pool(1).await?;
             let migration = tokio::spawn(async move { MIGRATOR.run(&migration_pool).await });
             wait_for_pending_lock(
                 database.pool(),

--- a/crates/automata-ci-runner/src/podman_probe/lifecycle.rs
+++ b/crates/automata-ci-runner/src/podman_probe/lifecycle.rs
@@ -655,6 +655,36 @@ impl<'a> ProbeResources<'a> {
         exists.arg(kind.description()).arg("exists").arg(identifier);
         let output = self.commands.execute(&exists, self.cancellation);
         match output.termination() {
+            CommandTermination::Exited(Some(1)) if kind == ResourceKind::Container => {
+                // Podman reports false from `container exists` while a
+                // container is asynchronously transitioning through Removing.
+                // That state still owns the user namespace, so treating it as
+                // absent would report cleanup complete and make the next
+                // admission probe fail with "not enough unused IDs". Recheck
+                // the all-containers listing before declaring it absent.
+                let mut listing = cleanup_podman_request(deadline);
+                listing
+                    .arg("ps")
+                    .arg("--all")
+                    .arg("--no-trunc")
+                    .arg("--format")
+                    .arg("{{.ID}}\n{{.Names}}");
+                if identifier.starts_with("automata-probe-ctr-") {
+                    listing.arg("--filter").arg(format!("name=^{identifier}$"));
+                } else {
+                    listing.arg("--filter").arg(format!("id={identifier}"));
+                }
+                let listing_output = self.commands.execute(&listing, self.cancellation);
+                if !listing_output.succeeded() {
+                    return Err(listing_output.failure_detail());
+                }
+                let present = listing_output
+                    .stdout()
+                    .lines()
+                    .map(str::trim)
+                    .any(|line| !line.is_empty());
+                Ok(present)
+            }
             CommandTermination::Exited(Some(1)) => Ok(false),
             _ if output.succeeded() => Ok(true),
             _ => Err(output.failure_detail()),
@@ -1397,5 +1427,107 @@ fn checked_command(
         CommandTermination::ExecutionIntegrityFailed | CommandTermination::Exited(_) => Err(
             ProbeFailure::degraded(ProbeReasonCode::ActiveProbeCommandFailed, detail),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        ffi::OsString,
+        path::PathBuf,
+        sync::Mutex,
+        time::{Duration, Instant},
+    };
+
+    use automata_ci_execution::NetworkPolicy;
+
+    use super::*;
+
+    struct ScriptedExecutor {
+        outputs: Mutex<VecDeque<CommandOutput>>,
+        requests: Mutex<Vec<Vec<OsString>>>,
+    }
+
+    impl ScriptedExecutor {
+        fn new(outputs: impl IntoIterator<Item = CommandOutput>) -> Self {
+            Self {
+                outputs: Mutex::new(outputs.into_iter().collect()),
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl CommandExecutor for ScriptedExecutor {
+        fn execute(
+            &self,
+            request: &CommandRequest,
+            _cancellation: &ProbeCancellation,
+        ) -> CommandOutput {
+            self.requests
+                .lock()
+                .expect("request record must be available")
+                .push(request.arguments().to_vec());
+            self.outputs
+                .lock()
+                .expect("scripted output must be available")
+                .pop_front()
+                .expect("every request must have a scripted output")
+        }
+    }
+
+    #[test]
+    fn removing_container_remains_present_until_all_container_listing_is_empty() {
+        let identifier = "0123456789abcdef0123456789abcdef";
+        let plan = ActiveProbePlan::new_in(
+            PathBuf::from("/proc/self/exe"),
+            identifier,
+            "/var/lib/automata-runner-test",
+            NetworkPolicy::PrivateEgress,
+        )
+        .expect("test plan must be valid");
+        let container_name = plan.container_name().to_owned();
+        let executor = ScriptedExecutor::new([
+            CommandOutput::failure(1, "container does not exist"),
+            CommandOutput::success(format!("{container_name}\n")),
+        ]);
+        let cancellation = ProbeCancellation::default();
+        let mut resources = ProbeResources::new(
+            &plan,
+            b"unused",
+            &executor,
+            &cancellation,
+            Duration::from_secs(1),
+        );
+
+        let exists = resources
+            .resource_exists(
+                ResourceKind::Container,
+                &container_name,
+                Instant::now() + Duration::from_secs(1),
+            )
+            .expect("removing-state fallback lookup must succeed");
+        resources.cleanup_finished = true;
+
+        assert!(exists, "a removing container still owns host resources");
+        let requests = executor
+            .requests
+            .lock()
+            .expect("request record must be available");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[1],
+            [
+                "--remote=false",
+                "ps",
+                "--all",
+                "--no-trunc",
+                "--format",
+                "{{.ID}}\n{{.Names}}",
+                "--filter",
+                &format!("name=^{container_name}$"),
+            ]
+            .map(OsString::from)
+        );
     }
 }

--- a/crates/automata-ci-store-postgres/migrations/0070_provider_admission_idempotency_key.sql
+++ b/crates/automata-ci-store-postgres/migrations/0070_provider_admission_idempotency_key.sql
@@ -1,0 +1,252 @@
+-- Bind the workflow-namespaced provider idempotency key into immutable
+-- admission evidence. Provider deliveries can select multiple workflow files,
+-- so the receipt key intentionally differs from the bare delivery UUID.
+ALTER TABLE provider_workflow_admission_evidence
+    ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+
+DROP TRIGGER IF EXISTS provider_workflow_admission_evidence_no_update_delete
+    ON provider_workflow_admission_evidence;
+
+UPDATE provider_workflow_admission_evidence AS evidence
+SET idempotency_key = receipt.idempotency_key
+FROM workflow_admission_receipts AS receipt
+WHERE receipt.run_id = evidence.run_id
+  AND receipt.idempotency_kind = 'provider_delivery'
+  AND receipt.request_digest = evidence.request_digest;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM provider_workflow_admission_evidence
+        WHERE idempotency_key IS NULL
+    ) THEN
+        RAISE EXCEPTION 'provider admission evidence lacks its workflow idempotency key';
+    END IF;
+END;
+$$;
+
+ALTER TABLE provider_workflow_admission_evidence
+    ALTER COLUMN idempotency_key SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_constraint
+        WHERE conrelid = 'provider_workflow_admission_evidence'::REGCLASS
+          AND conname = 'provider_workflow_admission_evidence_idempotency_key_shape'
+    ) THEN
+        ALTER TABLE provider_workflow_admission_evidence
+            ADD CONSTRAINT provider_workflow_admission_evidence_idempotency_key_shape
+            CHECK (
+                octet_length(idempotency_key) BETWEEN 1 AND 1024
+                AND idempotency_key !~ '[[:cntrl:]]'
+            );
+    END IF;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS provider_workflow_admission_evidence_no_update_delete
+    ON provider_workflow_admission_evidence;
+CREATE TRIGGER provider_workflow_admission_evidence_no_update_delete
+    BEFORE UPDATE OR DELETE ON provider_workflow_admission_evidence
+    FOR EACH ROW EXECUTE FUNCTION automata_provider_workflow_admission_evidence_immutable();
+
+-- The common admission path is the source of truth for provider-delivery
+-- executions.  Build the GitHub execution-origin projection from that
+-- immutable evidence and the exact current adapter credentials; activation,
+-- runner authority, and workload custody all consume this one projection.
+-- Scheduled and rerun origins remain in the existing second branch below.
+CREATE OR REPLACE VIEW github_workflow_run_base_manifest_origins AS
+SELECT
+    evidence.tenant_id,
+    evidence.repository_id,
+    evidence.workflow_id,
+    run.snapshot_id,
+    evidence.run_id,
+    marker.root_invocation_id,
+    'provider_delivery'::TEXT AS origin_kind,
+    evidence.delivery_id AS origin_id,
+    'provider_delivery'::TEXT AS admission_idempotency_kind,
+    receipt.idempotency_key COLLATE pg_catalog."C" AS admission_idempotency_key,
+    evidence.run_id AS github_check_subject_id,
+    evidence.source_revision AS github_check_head_sha,
+    evidence.workflow_path COLLATE pg_catalog."C",
+    snapshot.source_digest,
+    evidence.event_name COLLATE pg_catalog."C",
+    run.event_digest,
+    evidence.git_ref COLLATE pg_catalog."C",
+    run.plan_schema::SMALLINT AS workflow_plan_schema,
+    run.plan_digest,
+    evidence.request_digest AS logical_admission_digest,
+    evidence.admitted_at_ms,
+    evidence.request_digest AS subject_evidence_sha256,
+    evidence.connection_id AS provider_connection_id,
+    manifest.provider_installation_id,
+    manifest.github_repository_id,
+    manifest.github_repository_owner_id,
+    manifest.github_repository_name,
+    manifest.repository_visibility,
+    manifest.manifest_revision AS provider_manifest_revision,
+    manifest.manifest_digest AS provider_manifest_digest,
+    manifest.webhook_verifier_fingerprint_sha256
+        AS authenticated_webhook_verifier_fingerprint_sha256,
+    manifest.webhook_verifier_revision
+        AS authenticated_webhook_verifier_revision,
+    checks.id AS checks_authority_id,
+    checks.identity_digest AS checks_authority_identity_digest,
+    checks.app_configuration_revision
+        AS checks_authority_app_configuration_revision,
+    checks.policy_revision AS checks_authority_policy_revision,
+    contents.id AS repository_contents_authority_id,
+    contents.identity_digest AS repository_contents_authority_identity_digest,
+    contents.app_configuration_revision
+        AS repository_contents_authority_app_configuration_revision,
+    contents.policy_revision AS repository_contents_authority_policy_revision
+FROM provider_workflow_admission_evidence AS evidence
+JOIN workflow_admission_receipts AS receipt
+  ON receipt.run_id = evidence.run_id
+ AND receipt.tenant_id = evidence.tenant_id
+ AND receipt.repository_id = evidence.repository_id
+ AND receipt.idempotency_kind = 'provider_delivery'
+ AND receipt.request_digest = evidence.request_digest
+ AND receipt.committed_at_ms = evidence.admitted_at_ms
+JOIN workflow_runs AS run ON run.id = evidence.run_id
+JOIN logical_workflow_runs AS marker ON marker.run_id = evidence.run_id
+JOIN workflow_snapshots AS snapshot
+  ON snapshot.id = run.snapshot_id
+ AND snapshot.workflow_id = run.workflow_id
+JOIN github_provider_manifest_current AS current_manifest
+  ON current_manifest.tenant_id = evidence.tenant_id
+ AND current_manifest.provider_connection_id = evidence.connection_id
+JOIN github_provider_manifest_revisions AS manifest
+  ON manifest.tenant_id = current_manifest.tenant_id
+ AND manifest.repository_id = evidence.repository_id
+ AND manifest.provider_connection_id = current_manifest.provider_connection_id
+ AND manifest.manifest_revision = current_manifest.manifest_revision
+ AND manifest.manifest_digest = current_manifest.manifest_digest
+ AND manifest.runner_policy_digest = evidence.runner_policy_digest
+ AND manifest.runtime_policy_revision = (
+     SELECT pin.policy_revision
+     FROM logical_workflow_runtime_policy_pins AS pin
+     WHERE pin.run_id = evidence.run_id
+ )
+JOIN github_server_service_authorities AS checks
+  ON checks.tenant_id = evidence.tenant_id
+ AND checks.repository_id = evidence.repository_id
+ AND checks.provider_connection_id = evidence.connection_id
+ AND checks.provider_installation_id = manifest.provider_installation_id
+ AND checks.github_repository_id = manifest.github_repository_id
+ AND checks.github_repository_name = manifest.github_repository_name
+ AND checks.service_scope = 'checks_write'
+ AND checks.app_configuration_revision = manifest.app_configuration_revision
+ AND checks.policy_revision = manifest.policy_revision
+ AND checks.state = 'active'
+JOIN github_server_service_authorities AS contents
+  ON contents.tenant_id = evidence.tenant_id
+ AND contents.repository_id = evidence.repository_id
+ AND contents.provider_connection_id = evidence.connection_id
+ AND contents.provider_installation_id = manifest.provider_installation_id
+ AND contents.github_repository_id = manifest.github_repository_id
+ AND contents.github_repository_name = manifest.github_repository_name
+ AND contents.service_scope = 'repository_contents_read'
+ AND contents.app_configuration_revision = manifest.app_configuration_revision
+ AND contents.policy_revision = manifest.policy_revision
+ AND contents.state = 'active'
+WHERE evidence.provider_type = 'github';
+
+CREATE OR REPLACE FUNCTION automata_require_open_workflow_admission_graph()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM 1
+    FROM logical_workflow_runs AS marker
+    JOIN workflow_admission_receipts AS receipt ON receipt.run_id = marker.run_id
+    JOIN provider_workflow_admission_evidence AS evidence
+      ON evidence.run_id = marker.run_id
+     AND evidence.request_digest = marker.admission_digest
+    JOIN logical_workflow_runtime_policy_pins AS pin ON pin.run_id = marker.run_id
+    WHERE marker.run_id = NEW.run_id
+      AND marker.root_invocation_id = NEW.invocation_id
+      AND marker.admission_graph_sealed_at_ms IS NULL
+      AND receipt.committed_at_ms IS NOT NULL
+      AND receipt.idempotency_kind = 'provider_delivery'
+      AND receipt.idempotency_key = evidence.idempotency_key
+      AND receipt.request_digest = marker.admission_digest
+      AND evidence.admitted_at_ms = receipt.committed_at_ms
+      AND pin.pinned_at_ms = evidence.admitted_at_ms
+    FOR KEY SHARE OF marker, receipt, evidence, pin;
+    IF FOUND THEN
+        RETURN NEW;
+    END IF;
+
+    PERFORM 1
+    FROM logical_workflow_runs AS marker
+    JOIN workflow_admission_receipts AS receipt ON receipt.run_id = marker.run_id
+    JOIN github_workflow_run_manifest_origins AS origin
+      ON origin.run_id = marker.run_id
+     AND origin.root_invocation_id = marker.root_invocation_id
+    JOIN logical_workflow_runtime_policy_pins AS pin ON pin.run_id = marker.run_id
+    WHERE marker.run_id = NEW.run_id
+      AND marker.root_invocation_id = NEW.invocation_id
+      AND marker.admission_graph_sealed_at_ms IS NULL
+      AND receipt.committed_at_ms IS NOT NULL
+      AND receipt.idempotency_kind = origin.admission_idempotency_kind
+      AND receipt.idempotency_key = origin.admission_idempotency_key
+      AND receipt.request_digest = marker.admission_digest
+      AND origin.logical_admission_digest = marker.admission_digest
+      AND origin.admitted_at_ms = receipt.committed_at_ms
+      AND pin.pinned_at_ms = origin.admitted_at_ms
+    FOR KEY SHARE OF marker, receipt, pin;
+    IF FOUND THEN
+        RETURN NEW;
+    END IF;
+
+    PERFORM 1
+    FROM logical_workflow_runs AS marker
+    JOIN workflow_admission_receipts AS receipt ON receipt.run_id = marker.run_id
+    JOIN logical_workflow_runtime_policy_pins AS pin ON pin.run_id = marker.run_id
+    JOIN security_audit_events AS audit
+      ON audit.tenant_id = pin.tenant_id
+     AND audit.action = 'workflow.dispatch'
+     AND audit.outcome = 'succeeded'
+     AND audit.resource_kind = 'workflow_run'
+     AND audit.resource_id = marker.run_id::TEXT
+     AND audit.occurred_at_ms = pin.pinned_at_ms
+     AND audit.actor_kind = 'human'
+     AND audit.actor_principal_id IS NOT NULL
+     AND audit.actor_session_id IS NOT NULL
+     AND audit.authorization_revision IS NOT NULL
+    WHERE marker.run_id = NEW.run_id
+      AND marker.root_invocation_id = NEW.invocation_id
+      AND marker.admission_graph_sealed_at_ms IS NULL
+      AND receipt.committed_at_ms IS NOT NULL
+      AND receipt.github_subject_evidence_required = FALSE
+      AND receipt.request_digest = marker.admission_digest
+      AND pin.pinned_at_ms = receipt.committed_at_ms
+    FOR KEY SHARE OF marker, receipt, pin, audit;
+    IF FOUND THEN
+        RETURN NEW;
+    END IF;
+
+    PERFORM 1
+    FROM logical_workflow_reusable_call_publications AS publication
+    JOIN logical_workflow_runs AS marker ON marker.run_id = publication.run_id
+    WHERE publication.run_id = NEW.run_id
+      AND publication.child_invocation_id = NEW.invocation_id
+      AND publication.child_graph_sealed_at_ms IS NULL
+      AND marker.admission_graph_sealed_at_ms IS NOT NULL
+      AND marker.state IN ('pending', 'active')
+      AND NOT EXISTS (
+          SELECT 1 FROM logical_workflow_run_result_claims AS claim
+          WHERE claim.run_id = marker.run_id
+      )
+    FOR KEY SHARE OF publication, marker;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'workflow graph insertion is outside an authenticated publication window'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'workflow_admission_graph_construction_window';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/crates/automata-ci-store-postgres/migrations/0071_provider_delivery_preparation_provenance.sql
+++ b/crates/automata-ci-store-postgres/migrations/0071_provider_delivery_preparation_provenance.sql
@@ -1,0 +1,71 @@
+-- Provider-delivery admissions carry authenticated provider/manifest
+-- provenance rather than GitHub subject-evidence rows.  The preparation
+-- trigger already joins the exact manifest origin and sealed runtime policy;
+-- requiring the separate subject-evidence flag here incorrectly rejects
+-- provider-delivery workflow jobs at the first preparation claim.
+CREATE OR REPLACE FUNCTION automata_require_preparation_runner_policy_provenance() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        IF NEW.runner_policy_digest IS DISTINCT FROM OLD.runner_policy_digest
+            OR NEW.runner_policy_object_key IS DISTINCT FROM OLD.runner_policy_object_key
+            OR NEW.runner_policy_size_bytes IS DISTINCT FROM OLD.runner_policy_size_bytes
+            OR NEW.runner_policy_media_type IS DISTINCT FROM OLD.runner_policy_media_type
+        THEN
+            RAISE EXCEPTION 'logical preparation runner policy is immutable'
+                USING ERRCODE = 'check_violation',
+                      CONSTRAINT = 'workflow_preparation_runner_policy_immutable';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    PERFORM 1
+    FROM logical_workflow_jobs AS job
+    JOIN logical_workflow_runtime_policy_pins AS pin ON pin.run_id = job.run_id
+    JOIN github_workflow_run_manifest_origins AS origin
+      ON origin.run_id = job.run_id
+     AND origin.tenant_id = pin.tenant_id
+     AND origin.repository_id = pin.repository_id
+    JOIN workflow_admission_receipts AS receipt
+      ON receipt.tenant_id = origin.tenant_id
+     AND receipt.idempotency_kind = origin.admission_idempotency_kind
+     AND receipt.idempotency_key = origin.admission_idempotency_key
+     AND receipt.repository_id = origin.repository_id
+     AND receipt.run_id = origin.run_id
+     AND receipt.request_digest = origin.logical_admission_digest
+     AND receipt.committed_at_ms = origin.admitted_at_ms
+    JOIN github_provider_manifest_revisions AS manifest
+      ON manifest.tenant_id = origin.tenant_id
+     AND manifest.repository_id = origin.repository_id
+     AND manifest.provider_connection_id = origin.provider_connection_id
+     AND manifest.manifest_revision = origin.provider_manifest_revision
+     AND manifest.manifest_digest = origin.provider_manifest_digest
+    JOIN workflow_runtime_policy_revisions AS policy
+      ON policy.tenant_id = pin.tenant_id
+     AND policy.repository_id = pin.repository_id
+     AND policy.policy_revision = pin.policy_revision
+     AND policy.policy_digest = pin.policy_digest
+     AND policy.state = 'sealed'
+    WHERE job.run_id = NEW.run_id
+      AND job.invocation_id = NEW.invocation_id
+      AND job.id = NEW.logical_job_id
+      AND NEW.runtime_policy_revision = pin.policy_revision
+      AND NEW.runtime_policy_digest = pin.policy_digest
+      AND manifest.runtime_policy_revision = pin.policy_revision
+      AND manifest.runtime_policy_digest = pin.policy_digest
+      AND NEW.runner_policy_digest = manifest.runner_policy_digest
+      AND NEW.runner_policy_object_key = manifest.runner_policy_object_key
+      AND NEW.runner_policy_size_bytes = manifest.runner_policy_size_bytes
+      AND NEW.runner_policy_media_type = manifest.runner_policy_media_type
+      AND NEW.runner_policy_digest = pg_catalog.sha256(policy.canonical_policy)
+      AND NEW.runner_policy_size_bytes = pg_catalog.octet_length(policy.canonical_policy)
+    FOR KEY SHARE OF job, pin, receipt, manifest, policy;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'logical preparation runner policy lacks authenticated manifest provenance'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'workflow_preparation_runner_policy_provenance';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/crates/automata-ci-store-postgres/migrations/0072_provider_delivery_runtime_provenance.sql
+++ b/crates/automata-ci-store-postgres/migrations/0072_provider_delivery_runtime_provenance.sql
@@ -1,0 +1,700 @@
+-- Authenticated provider deliveries bind the exact manifest, admission receipt,
+-- runtime policy, repository, and execution lineage without creating separate
+-- GitHub subject-evidence rows. Keep that provider provenance authoritative for
+-- runtime credentials while scheduled and rerun admissions retain their own
+-- subject-evidence guards at admission.
+
+CREATE OR REPLACE FUNCTION automata_github_runtime_authority_has_provenance(authority github_runtime_authority_issuances) RETURNS boolean
+    LANGUAGE sql STABLE
+    AS $$
+    SELECT automata_github_runtime_authority_has_selection_tails(authority)
+       AND EXISTS (
+        SELECT 1
+        FROM github_workflow_run_manifest_origins AS origin
+        JOIN github_provider_manifest_revisions AS manifest
+          ON manifest.tenant_id = origin.tenant_id
+         AND manifest.repository_id = origin.repository_id
+         AND manifest.provider_connection_id = origin.provider_connection_id
+         AND manifest.manifest_revision = origin.provider_manifest_revision
+         AND manifest.manifest_digest = origin.provider_manifest_digest
+        JOIN github_server_service_authorities AS checks
+          ON checks.tenant_id = origin.tenant_id
+         AND checks.id = origin.checks_authority_id
+         AND checks.repository_id = origin.repository_id
+         AND checks.provider_connection_id = origin.provider_connection_id
+         AND checks.provider_installation_id = origin.provider_installation_id
+         AND checks.github_repository_id = origin.github_repository_id
+         AND checks.github_repository_name = origin.github_repository_name
+         AND checks.service_scope = 'checks_write'
+         AND checks.identity_digest = origin.checks_authority_identity_digest
+         AND checks.app_configuration_revision =
+             origin.checks_authority_app_configuration_revision
+         AND checks.policy_revision = origin.checks_authority_policy_revision
+        JOIN github_server_service_authorities AS contents_authority
+          ON contents_authority.tenant_id = origin.tenant_id
+         AND contents_authority.id = origin.repository_contents_authority_id
+         AND contents_authority.repository_id = origin.repository_id
+         AND contents_authority.provider_connection_id =
+             origin.provider_connection_id
+         AND contents_authority.provider_installation_id =
+             origin.provider_installation_id
+         AND contents_authority.github_repository_id = origin.github_repository_id
+         AND contents_authority.github_repository_name =
+             origin.github_repository_name
+         AND contents_authority.service_scope = 'repository_contents_read'
+         AND contents_authority.identity_digest =
+             origin.repository_contents_authority_identity_digest
+         AND contents_authority.app_configuration_revision =
+             origin.repository_contents_authority_app_configuration_revision
+         AND contents_authority.policy_revision =
+             origin.repository_contents_authority_policy_revision
+        JOIN workflow_admission_receipts AS admission
+          ON admission.tenant_id = origin.tenant_id
+         AND admission.idempotency_kind = origin.admission_idempotency_kind
+         AND admission.idempotency_key = origin.admission_idempotency_key
+         AND admission.request_digest = origin.logical_admission_digest
+         AND admission.repository_id = origin.repository_id
+         AND admission.run_id = origin.run_id
+         AND admission.committed_at_ms = origin.admitted_at_ms
+        JOIN logical_workflow_runtime_policy_pins AS pin
+          ON pin.run_id = origin.run_id
+         AND pin.tenant_id = origin.tenant_id
+         AND pin.repository_id = origin.repository_id
+        JOIN workflow_runtime_policy_revisions AS policy
+          ON policy.tenant_id = pin.tenant_id
+         AND policy.repository_id = pin.repository_id
+         AND policy.policy_revision = pin.policy_revision
+         AND policy.policy_digest = pin.policy_digest
+         AND policy.state = 'sealed'
+        JOIN logical_workflow_concrete_jobs AS concrete
+          ON concrete.job_id = authority.job_id
+         AND concrete.run_id = authority.run_id
+        JOIN logical_workflow_materialization_claims AS materialization
+          ON materialization.instance_id = concrete.instance_id
+         AND materialization.run_id = concrete.run_id
+         AND materialization.invocation_id = concrete.invocation_id
+         AND materialization.logical_job_id = concrete.logical_job_id
+         AND materialization.descriptor_digest = concrete.descriptor_digest
+         AND materialization.expected_job_id = concrete.job_id
+         AND materialization.expected_attempt_id = concrete.initial_attempt_id
+         AND materialization.owner_id = concrete.claim_owner_id
+         AND materialization.generation = concrete.claim_generation
+         AND materialization.claimed_at_ms = concrete.claim_started_at_ms
+         AND materialization.expires_at_ms = concrete.claim_expires_at_ms
+         AND materialization.updated_at_ms = concrete.committed_at_ms
+        JOIN logical_workflow_instances AS instance
+          ON instance.id = concrete.instance_id
+         AND instance.run_id = concrete.run_id
+         AND instance.invocation_id = concrete.invocation_id
+         AND instance.logical_job_id = concrete.logical_job_id
+        JOIN logical_workflow_activation_publications AS activation_publication
+          ON activation_publication.run_id = instance.run_id
+         AND activation_publication.invocation_id = instance.invocation_id
+         AND activation_publication.logical_job_id = instance.logical_job_id
+        JOIN logical_workflow_activation_preparations AS preparation
+          ON preparation.run_id = activation_publication.run_id
+         AND preparation.invocation_id = activation_publication.invocation_id
+         AND preparation.logical_job_id = activation_publication.logical_job_id
+         AND preparation.activation_input_digest =
+             activation_publication.activation_input_digest
+        JOIN logical_workflow_activation_preparation_claims AS preparation_claim
+          ON preparation_claim.run_id = preparation.run_id
+         AND preparation_claim.invocation_id = preparation.invocation_id
+         AND preparation_claim.logical_job_id = preparation.logical_job_id
+         AND preparation_claim.descriptor_digest = preparation.descriptor_digest
+        JOIN logical_workflow_jobs AS logical_job
+          ON logical_job.run_id = concrete.run_id
+         AND logical_job.invocation_id = concrete.invocation_id
+         AND logical_job.id = concrete.logical_job_id
+        JOIN logical_workflow_invocations AS invocation
+          ON invocation.run_id = concrete.run_id
+         AND invocation.id = concrete.invocation_id
+        JOIN logical_workflow_runs AS marker
+          ON marker.run_id = concrete.run_id
+        WHERE origin.tenant_id = authority.tenant_id
+          AND origin.repository_id = authority.repository_id
+          AND origin.run_id = authority.run_id
+          AND origin.origin_kind IN (
+              'provider_delivery', 'scheduled_fire', 'workflow_rerun'
+          )
+          AND contents_authority.github_app_id = manifest.github_app_id
+          AND contents_authority.github_app_client_id =
+              manifest.github_app_client_id
+          AND contents_authority.github_app_jwt_issuer_kind =
+              manifest.github_app_jwt_issuer_kind
+          AND contents_authority.app_key_spki_sha256 =
+              manifest.app_key_spki_sha256
+          AND contents_authority.app_configuration_revision =
+              manifest.app_configuration_revision
+          AND contents_authority.policy_revision = manifest.policy_revision
+          AND origin.provider_connection_id = authority.provider_connection_id
+          AND origin.provider_installation_id =
+              authority.provider_installation_id
+          AND origin.github_repository_id = authority.github_repository_id
+          AND origin.github_repository_name = authority.github_repository_name
+          AND manifest.github_app_id = authority.github_app_id
+          AND manifest.github_app_client_id = authority.github_app_client_id
+          AND manifest.github_app_jwt_issuer_kind =
+              authority.github_app_jwt_issuer_kind
+          AND authority.github_app_jwt_issuer_value =
+              CASE manifest.github_app_jwt_issuer_kind
+                  WHEN 'app_client_id' THEN manifest.github_app_client_id
+                  WHEN 'app_id' THEN manifest.github_app_id::TEXT
+              END
+          AND manifest.app_key_spki_sha256 = authority.issuer_fingerprint
+          AND manifest.github_app_id = checks.github_app_id
+          AND manifest.github_app_client_id = checks.github_app_client_id
+          AND manifest.github_app_jwt_issuer_kind =
+              checks.github_app_jwt_issuer_kind
+          AND manifest.app_key_spki_sha256 = checks.app_key_spki_sha256
+          AND manifest.app_configuration_revision =
+              checks.app_configuration_revision
+          AND manifest.policy_revision = checks.policy_revision
+          AND checks.configuration_fingerprint =
+              authority.configuration_fingerprint
+          AND marker.root_invocation_id = origin.root_invocation_id
+          AND marker.admission_digest = origin.logical_admission_digest
+          AND marker.admitted_at_ms = origin.admitted_at_ms
+          AND automata_logical_workflow_invocation_published(
+              concrete.run_id, concrete.invocation_id
+          )
+          AND invocation.plan_schema = 1
+          AND manifest.runtime_policy_revision = pin.policy_revision
+          AND manifest.runtime_policy_digest = pin.policy_digest
+          AND manifest.runner_policy_digest =
+              pg_catalog.sha256(policy.canonical_policy)
+          AND manifest.runner_policy_object_key = 'github/runner-policy/v1/'
+              || pg_catalog.encode(manifest.runner_policy_digest, 'hex') || '.json'
+          AND manifest.runner_policy_size_bytes =
+              pg_catalog.octet_length(policy.canonical_policy)
+          AND manifest.runner_policy_media_type =
+              'application/vnd.automata.github-runner-policy+json'
+          AND logical_job.runtime_policy_revision = pin.policy_revision
+          AND logical_job.runtime_policy_digest = pin.policy_digest
+          AND preparation_claim.runtime_policy_revision = pin.policy_revision
+          AND preparation_claim.runtime_policy_digest = pin.policy_digest
+          AND preparation_claim.runner_policy_digest =
+              manifest.runner_policy_digest
+          AND preparation_claim.runner_policy_object_key =
+              manifest.runner_policy_object_key
+          AND preparation_claim.runner_policy_size_bytes =
+              manifest.runner_policy_size_bytes
+          AND preparation_claim.runner_policy_media_type =
+              manifest.runner_policy_media_type
+          AND preparation.runtime_policy_revision = pin.policy_revision
+          AND preparation.runtime_policy_digest = pin.policy_digest
+          AND activation_publication.runtime_policy_revision = pin.policy_revision
+          AND activation_publication.runtime_policy_digest = pin.policy_digest
+          AND instance.runtime_policy_revision = pin.policy_revision
+          AND instance.runtime_policy_digest = pin.policy_digest
+          AND materialization.runtime_policy_revision = pin.policy_revision
+          AND materialization.runtime_policy_digest = pin.policy_digest
+          AND concrete.runtime_policy_revision = pin.policy_revision
+          AND concrete.runtime_policy_digest = pin.policy_digest
+          AND logical_job.authority_profile = 'standard'
+          AND preparation_claim.authority_profile = 'standard'
+          AND preparation.authority_profile = 'standard'
+          AND activation_publication.authority_profile = 'standard'
+          AND materialization.authority_profile = 'standard'
+          AND concrete.authority_profile = 'standard'
+    )
+$$;
+
+CREATE OR REPLACE FUNCTION automata_workload_oidc_authority_is_current(authority workload_oidc_authorities, observed_at_ms bigint, required_current_before_ms bigint) RETURNS boolean
+    LANGUAGE sql STABLE
+    AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM job_attempts AS attempt
+        JOIN jobs AS job
+          ON job.id = attempt.job_id
+         AND job.id = authority.job_id
+         AND job.run_id = authority.run_id
+        JOIN workflow_runs AS run
+          ON run.id = job.run_id
+         AND run.id = authority.run_id
+         AND run.repository_id = authority.repository_id
+         AND run.workflow_id = authority.workflow_id
+        JOIN repositories AS repository
+          ON repository.id = run.repository_id
+         AND repository.id = authority.repository_id
+         AND repository.tenant_id = authority.tenant_id
+        JOIN workflow_definitions AS workflow
+          ON workflow.id = run.workflow_id
+         AND workflow.repository_id = run.repository_id
+        JOIN workflow_snapshots AS snapshot
+          ON snapshot.id = run.snapshot_id
+         AND snapshot.workflow_id = run.workflow_id
+        JOIN logical_workflow_runs AS marker
+          ON marker.run_id = run.id
+        JOIN logical_workflow_invocations AS invocation
+          ON invocation.run_id = run.id
+         AND invocation.id = authority.invocation_id
+        JOIN logical_workflow_jobs AS logical_job
+          ON logical_job.run_id = run.id
+         AND logical_job.invocation_id = invocation.id
+         AND logical_job.id = authority.logical_job_id
+        JOIN logical_workflow_activation_preparation_claims AS preparation_claim
+          ON preparation_claim.run_id = logical_job.run_id
+         AND preparation_claim.invocation_id = logical_job.invocation_id
+         AND preparation_claim.logical_job_id = logical_job.id
+        JOIN logical_workflow_activation_preparations AS preparation
+          ON preparation.run_id = preparation_claim.run_id
+         AND preparation.invocation_id = preparation_claim.invocation_id
+         AND preparation.logical_job_id = preparation_claim.logical_job_id
+         AND preparation.descriptor_digest = preparation_claim.descriptor_digest
+        JOIN logical_workflow_activation_publications AS activation_publication
+          ON activation_publication.run_id = logical_job.run_id
+         AND activation_publication.invocation_id = logical_job.invocation_id
+         AND activation_publication.logical_job_id = logical_job.id
+         AND activation_publication.activation_input_digest =
+             preparation.activation_input_digest
+        JOIN logical_workflow_instances AS instance
+          ON instance.run_id = run.id
+         AND instance.invocation_id = invocation.id
+         AND instance.logical_job_id = logical_job.id
+         AND instance.id = authority.instance_id
+        JOIN logical_workflow_concrete_jobs AS concrete
+          ON concrete.instance_id = instance.id
+         AND concrete.run_id = run.id
+         AND concrete.invocation_id = invocation.id
+         AND concrete.logical_job_id = logical_job.id
+         AND concrete.job_id = job.id
+        JOIN logical_workflow_materialization_claims AS materialization
+          ON materialization.instance_id = concrete.instance_id
+         AND materialization.run_id = concrete.run_id
+         AND materialization.invocation_id = concrete.invocation_id
+         AND materialization.logical_job_id = concrete.logical_job_id
+         AND materialization.descriptor_digest = concrete.descriptor_digest
+         AND materialization.expected_job_id = concrete.job_id
+         AND materialization.expected_attempt_id = concrete.initial_attempt_id
+         AND materialization.owner_id = concrete.claim_owner_id
+         AND materialization.generation = concrete.claim_generation
+         AND materialization.claimed_at_ms = concrete.claim_started_at_ms
+         AND materialization.expires_at_ms = concrete.claim_expires_at_ms
+         AND materialization.updated_at_ms = concrete.committed_at_ms
+        JOIN runners AS runner
+          ON runner.id = attempt.runner_id
+         AND runner.id = authority.runner_id
+         AND runner.tenant_id = authority.tenant_id
+         AND runner.generation = authority.runner_generation
+         AND runner.session_epoch = authority.runner_session_epoch
+        JOIN runner_sessions AS session
+          ON session.id = attempt.runner_session_id
+         AND session.id = authority.runner_session_id
+         AND session.runner_id = authority.runner_id
+         AND session.session_epoch = authority.runner_session_epoch
+         AND session.runner_generation = authority.runner_generation
+        JOIN github_workflow_run_manifest_origins AS origin
+          ON origin.tenant_id = authority.tenant_id
+         AND origin.repository_id = authority.repository_id
+         AND origin.workflow_id = authority.workflow_id
+         AND origin.run_id = authority.run_id
+         AND origin.root_invocation_id = marker.root_invocation_id
+         AND origin.subject_evidence_sha256 =
+             authority.github_run_subject_evidence_sha256
+        JOIN workflow_admission_receipts AS admission_receipt
+          ON admission_receipt.tenant_id = origin.tenant_id
+         AND admission_receipt.idempotency_kind =
+             origin.admission_idempotency_kind
+         AND admission_receipt.idempotency_key =
+             origin.admission_idempotency_key
+         AND admission_receipt.request_digest = origin.logical_admission_digest
+         AND admission_receipt.repository_id = origin.repository_id
+         AND admission_receipt.run_id = origin.run_id
+         AND admission_receipt.committed_at_ms = origin.admitted_at_ms
+        JOIN github_provider_manifest_revisions AS manifest
+          ON manifest.tenant_id = origin.tenant_id
+         AND manifest.repository_id = origin.repository_id
+         AND manifest.provider_connection_id = origin.provider_connection_id
+         AND manifest.manifest_revision = origin.provider_manifest_revision
+         AND manifest.manifest_digest = origin.provider_manifest_digest
+        JOIN github_server_service_authorities AS checks_authority
+          ON checks_authority.tenant_id = origin.tenant_id
+         AND checks_authority.id = origin.checks_authority_id
+         AND checks_authority.repository_id = origin.repository_id
+         AND checks_authority.provider_connection_id =
+             origin.provider_connection_id
+         AND checks_authority.provider_installation_id =
+             origin.provider_installation_id
+         AND checks_authority.github_repository_id =
+             origin.github_repository_id
+         AND checks_authority.github_repository_name =
+             origin.github_repository_name
+         AND checks_authority.service_scope = 'checks_write'
+         AND checks_authority.identity_digest =
+             origin.checks_authority_identity_digest
+         AND checks_authority.app_configuration_revision =
+             origin.checks_authority_app_configuration_revision
+         AND checks_authority.policy_revision =
+             origin.checks_authority_policy_revision
+        JOIN github_server_service_authorities AS contents_authority
+          ON contents_authority.tenant_id = origin.tenant_id
+         AND contents_authority.id = origin.repository_contents_authority_id
+         AND contents_authority.repository_id = origin.repository_id
+         AND contents_authority.provider_connection_id =
+             origin.provider_connection_id
+         AND contents_authority.provider_installation_id =
+             origin.provider_installation_id
+         AND contents_authority.github_repository_id =
+             origin.github_repository_id
+         AND contents_authority.github_repository_name =
+             origin.github_repository_name
+         AND contents_authority.service_scope =
+             'repository_contents_read'
+         AND contents_authority.identity_digest =
+             origin.repository_contents_authority_identity_digest
+         AND contents_authority.app_configuration_revision =
+             origin.repository_contents_authority_app_configuration_revision
+         AND contents_authority.policy_revision =
+             origin.repository_contents_authority_policy_revision
+        WHERE attempt.id = authority.attempt_id
+          AND attempt.job_id = authority.job_id
+          AND attempt.attempt_number = authority.attempt_number
+          AND attempt.fencing_token = authority.fencing_token
+          AND attempt.lease_id = authority.lease_id
+          AND attempt.lease_issued_at_ms = authority.lease_issued_at_ms
+          AND attempt.lease_expires_at_ms >= authority.lease_expires_at_ms
+          AND required_current_before_ms > observed_at_ms
+          AND attempt.lease_expires_at_ms >= required_current_before_ms
+          AND attempt.runner_id = authority.runner_id
+          AND attempt.runner_session_id = authority.runner_session_id
+          AND attempt.runner_session_epoch = authority.runner_session_epoch
+          AND attempt.runner_generation = authority.runner_generation
+          AND attempt.runner_slot = authority.runner_slot
+          AND attempt.lifecycle IN ('leased', 'preparing', 'running')
+          AND attempt.changed_at_ms <= observed_at_ms
+          AND job.admission_epoch = 1
+          AND job.job_ir_schema = 1
+          AND job.job_ir_schema = authority.job_ir_schema
+          AND job.job_ir_size_bytes = authority.job_ir_size_bytes
+          AND job.job_ir_digest = authority.job_ir_digest
+          AND job.job_ir_object_key = authority.job_ir_object_key
+          AND authority.permission_evidence_sha256 = authority.job_ir_digest
+          AND job.requirements @>
+              '{"features":["automata.core/oidc-tokens@v1"]}'::JSONB
+          AND run.admission_epoch = 1
+          AND run.plan_schema = 1
+          AND (
+              invocation.id <> marker.root_invocation_id
+              OR run.plan_digest = authority.plan_digest
+          )
+          AND run.plan_digest = origin.plan_digest
+          AND run.event_digest = authority.event_digest
+          AND run.event_digest = origin.event_digest
+          AND run.snapshot_id = origin.snapshot_id
+          AND run.head_sha = origin.github_check_head_sha
+          AND run.event_name = origin.event_name
+          AND run.git_ref = origin.git_ref
+          AND run.status IN ('queued', 'in_progress')
+          AND (
+              origin.origin_kind = 'provider_delivery'
+              AND origin.admission_idempotency_kind = 'provider_delivery'
+              OR origin.origin_kind IN ('scheduled_fire', 'workflow_rerun')
+              AND origin.admission_idempotency_kind = 'operation'
+          )
+          AND workflow.path = origin.workflow_path
+          AND snapshot.source_digest = origin.source_digest
+          AND marker.orchestration_schema = 1
+          AND marker.root_invocation_id = origin.root_invocation_id
+          AND marker.admission_digest = origin.logical_admission_digest
+          AND marker.admitted_at_ms = origin.admitted_at_ms
+          AND marker.state IN ('pending', 'active')
+          AND automata_logical_workflow_invocation_published(
+              run.id, invocation.id
+          )
+          AND automata_reusable_workflow_oidc_permission_authorized(
+              run.id, invocation.id
+          )
+          AND invocation.plan_schema = 1
+          AND invocation.plan_digest = authority.plan_digest
+          AND invocation.state IN ('pending', 'active')
+          AND logical_job.execution_kind = 'steps'
+          AND logical_job.state = 'activated'
+          AND instance.job_ir_version = 1
+          AND instance.job_ir_digest = authority.job_ir_digest
+          AND instance.job_ir_object_key = authority.job_ir_object_key
+          AND instance.job_ir_size_bytes = authority.job_ir_size_bytes
+          AND concrete.runtime_context_schema = 1
+          AND concrete.runtime_context_digest = authority.runtime_context_digest
+          AND concrete.requirements = job.requirements
+          AND materialization.state = 'materialized'
+          AND logical_job.activation_input_digest =
+              preparation.activation_input_digest
+          AND preparation_claim.state = 'prepared'
+          AND activation_publication.condition_matched
+          AND activation_publication.job_ir_version = 1
+          AND activation_publication.runtime_context_schema = 1
+          AND manifest.authority_profile = 'standard'
+          AND logical_job.authority_profile = 'standard'
+          AND preparation_claim.authority_profile = 'standard'
+          AND preparation.authority_profile = 'standard'
+          AND activation_publication.authority_profile = 'standard'
+          AND materialization.authority_profile = 'standard'
+          AND concrete.authority_profile = 'standard'
+          AND repository.scm_provider = 'github'
+          AND repository.provider_repository_id =
+              origin.github_repository_id::TEXT
+          AND repository.owner || '/' || repository.name =
+              origin.github_repository_name
+          AND authority.github_repository_id =
+              origin.github_repository_id
+          AND authority.github_repository_name =
+              origin.github_repository_name
+          AND authority.github_owner_id =
+              origin.github_repository_owner_id
+          AND authority.subject_policy_mode = 'stable_owner_evidence'
+          AND authority.subject_policy_revision > 0
+          AND authority.subject = CASE
+              WHEN origin.event_name = 'pull_request'
+              THEN 'repo:' || origin.github_repository_name ||
+                   ':pull_request'
+              ELSE 'repo:' || origin.github_repository_name ||
+                   ':ref:' || origin.git_ref
+          END
+          AND authority.default_audience = 'https://github.com/' ||
+              split_part(origin.github_repository_name, '/', 1)
+          AND authority.additional_claims = jsonb_build_object(
+              'event_name', origin.event_name,
+              'ref', origin.git_ref,
+              'repository', origin.github_repository_name,
+              'repository_owner',
+                  split_part(origin.github_repository_name, '/', 1),
+              'run_attempt', run.run_attempt::TEXT,
+              'run_number', run.run_number::TEXT,
+              'runner_environment', 'self-hosted',
+              'sha', encode(origin.github_check_head_sha, 'hex'),
+              'workflow', run.workflow_name,
+              'workflow_ref', origin.github_repository_name || '/' ||
+                  origin.workflow_path || '@' || origin.git_ref,
+              'workflow_sha', encode(origin.github_check_head_sha, 'hex')
+          )
+          AND manifest.webhook_verifier_fingerprint_sha256 =
+              origin.authenticated_webhook_verifier_fingerprint_sha256
+          AND manifest.webhook_verifier_revision =
+              origin.authenticated_webhook_verifier_revision
+          AND manifest.provider_installation_id =
+              origin.provider_installation_id
+          AND manifest.github_repository_id =
+              origin.github_repository_id
+          AND manifest.github_repository_name =
+              origin.github_repository_name
+          AND manifest.repository_visibility =
+              origin.repository_visibility
+          AND manifest.registered_at_ms <= observed_at_ms
+          AND checks_authority.state = 'active'
+          AND checks_authority.created_at_ms <= observed_at_ms
+          AND checks_authority.state_updated_at_ms <= observed_at_ms
+          AND contents_authority.state = 'active'
+          AND contents_authority.created_at_ms <= observed_at_ms
+          AND contents_authority.state_updated_at_ms <= observed_at_ms
+          AND origin.admitted_at_ms <= observed_at_ms
+          AND authority.request_bearer_iat_seconds * 1000 <= observed_at_ms
+          AND authority.request_bearer_exp_seconds * 1000 > observed_at_ms
+          AND runner.status = 'online'
+          AND runner.desired_state IN ('active', 'draining')
+          AND runner.capabilities @>
+              '{"features":["automata.core/oidc-tokens@v1"]}'::JSONB
+          AND session.job_ir_schema = 1
+          AND session.capability_snapshot @>
+              '{"features":["automata.core/oidc-tokens@v1"]}'::JSONB
+          AND session.disconnected_at_ms IS NULL
+    )
+$$;
+
+CREATE OR REPLACE FUNCTION automata_lock_workload_oidc_authority_dependencies(authority workload_oidc_authorities) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    contents_authority_id UUID;
+BEGIN
+    SELECT origin.repository_contents_authority_id
+      INTO contents_authority_id
+    FROM job_attempts AS attempt
+    JOIN jobs AS job
+      ON job.id = attempt.job_id
+     AND job.id = authority.job_id
+     AND job.run_id = authority.run_id
+    JOIN workflow_runs AS run
+      ON run.id = job.run_id
+     AND run.id = authority.run_id
+     AND run.repository_id = authority.repository_id
+    JOIN repositories AS repository
+      ON repository.id = run.repository_id
+     AND repository.tenant_id = authority.tenant_id
+    JOIN workflow_definitions AS workflow
+      ON workflow.id = run.workflow_id
+     AND workflow.repository_id = run.repository_id
+    JOIN workflow_snapshots AS snapshot
+      ON snapshot.id = run.snapshot_id
+     AND snapshot.workflow_id = run.workflow_id
+    JOIN logical_workflow_runs AS marker ON marker.run_id = run.id
+    JOIN logical_workflow_invocations AS invocation
+      ON invocation.run_id = run.id
+     AND invocation.id = authority.invocation_id
+    JOIN logical_workflow_jobs AS logical_job
+      ON logical_job.run_id = run.id
+     AND logical_job.invocation_id = invocation.id
+     AND logical_job.id = authority.logical_job_id
+    JOIN logical_workflow_activation_preparation_claims AS preparation_claim
+      ON preparation_claim.run_id = logical_job.run_id
+     AND preparation_claim.invocation_id = logical_job.invocation_id
+     AND preparation_claim.logical_job_id = logical_job.id
+    JOIN logical_workflow_activation_preparations AS preparation
+      ON preparation.run_id = preparation_claim.run_id
+     AND preparation.invocation_id = preparation_claim.invocation_id
+     AND preparation.logical_job_id = preparation_claim.logical_job_id
+     AND preparation.descriptor_digest = preparation_claim.descriptor_digest
+    JOIN logical_workflow_activation_publications AS activation_publication
+      ON activation_publication.run_id = logical_job.run_id
+     AND activation_publication.invocation_id = logical_job.invocation_id
+     AND activation_publication.logical_job_id = logical_job.id
+     AND activation_publication.activation_input_digest =
+         preparation.activation_input_digest
+    JOIN logical_workflow_instances AS instance
+      ON instance.run_id = run.id
+     AND instance.invocation_id = invocation.id
+     AND instance.logical_job_id = logical_job.id
+     AND instance.id = authority.instance_id
+    JOIN logical_workflow_concrete_jobs AS concrete
+      ON concrete.instance_id = instance.id
+     AND concrete.run_id = run.id
+     AND concrete.invocation_id = invocation.id
+     AND concrete.logical_job_id = logical_job.id
+     AND concrete.job_id = job.id
+    JOIN logical_workflow_materialization_claims AS materialization
+      ON materialization.instance_id = concrete.instance_id
+     AND materialization.run_id = concrete.run_id
+     AND materialization.invocation_id = concrete.invocation_id
+     AND materialization.logical_job_id = concrete.logical_job_id
+     AND materialization.descriptor_digest = concrete.descriptor_digest
+     AND materialization.expected_job_id = concrete.job_id
+     AND materialization.expected_attempt_id = concrete.initial_attempt_id
+     AND materialization.owner_id = concrete.claim_owner_id
+     AND materialization.generation = concrete.claim_generation
+     AND materialization.claimed_at_ms = concrete.claim_started_at_ms
+     AND materialization.expires_at_ms = concrete.claim_expires_at_ms
+     AND materialization.updated_at_ms = concrete.committed_at_ms
+    JOIN runners AS runner
+      ON runner.id = attempt.runner_id
+     AND runner.id = authority.runner_id
+     AND runner.tenant_id = authority.tenant_id
+    JOIN runner_sessions AS session
+      ON session.id = attempt.runner_session_id
+     AND session.id = authority.runner_session_id
+     AND session.runner_id = authority.runner_id
+    JOIN github_workflow_run_manifest_origins AS origin
+      ON origin.tenant_id = authority.tenant_id
+     AND origin.repository_id = authority.repository_id
+     AND origin.workflow_id = authority.workflow_id
+     AND origin.run_id = authority.run_id
+     AND origin.root_invocation_id = marker.root_invocation_id
+     AND origin.subject_evidence_sha256 =
+         authority.github_run_subject_evidence_sha256
+    JOIN workflow_admission_receipts AS admission_receipt
+      ON admission_receipt.tenant_id = origin.tenant_id
+     AND admission_receipt.idempotency_kind =
+         origin.admission_idempotency_kind
+     AND admission_receipt.idempotency_key =
+         origin.admission_idempotency_key
+     AND admission_receipt.request_digest = origin.logical_admission_digest
+     AND admission_receipt.repository_id = origin.repository_id
+     AND admission_receipt.run_id = origin.run_id
+     AND admission_receipt.committed_at_ms = origin.admitted_at_ms
+    JOIN github_provider_manifest_revisions AS manifest
+      ON manifest.tenant_id = origin.tenant_id
+     AND manifest.repository_id = origin.repository_id
+     AND manifest.provider_connection_id = origin.provider_connection_id
+     AND manifest.manifest_revision = origin.provider_manifest_revision
+     AND manifest.manifest_digest = origin.provider_manifest_digest
+    JOIN github_server_service_authorities AS checks_authority
+      ON checks_authority.tenant_id = origin.tenant_id
+     AND checks_authority.id = origin.checks_authority_id
+     AND checks_authority.repository_id = origin.repository_id
+     AND checks_authority.provider_connection_id = origin.provider_connection_id
+     AND checks_authority.provider_installation_id =
+         origin.provider_installation_id
+     AND checks_authority.github_repository_id = origin.github_repository_id
+     AND checks_authority.github_repository_name =
+         origin.github_repository_name
+     AND checks_authority.service_scope = 'checks_write'
+     AND checks_authority.identity_digest =
+         origin.checks_authority_identity_digest
+     AND checks_authority.app_configuration_revision =
+         origin.checks_authority_app_configuration_revision
+     AND checks_authority.policy_revision =
+         origin.checks_authority_policy_revision
+    WHERE attempt.id = authority.attempt_id
+      AND materialization.state = 'materialized'
+      AND (
+          origin.origin_kind = 'provider_delivery'
+          AND origin.admission_idempotency_kind = 'provider_delivery'
+          OR origin.origin_kind IN ('scheduled_fire', 'workflow_rerun')
+          AND origin.admission_idempotency_kind = 'operation'
+      )
+      AND logical_job.activation_input_digest = preparation.activation_input_digest
+      AND preparation_claim.state = 'prepared'
+      AND activation_publication.condition_matched
+      AND automata_logical_workflow_invocation_published(
+          run.id, invocation.id
+      )
+      AND automata_reusable_workflow_oidc_permission_authorized(
+          run.id, invocation.id
+      )
+      AND manifest.authority_profile = 'standard'
+      AND logical_job.authority_profile = 'standard'
+      AND preparation_claim.authority_profile = 'standard'
+      AND preparation.authority_profile = 'standard'
+      AND activation_publication.authority_profile = 'standard'
+      AND materialization.authority_profile = 'standard'
+      AND concrete.authority_profile = 'standard'
+      AND checks_authority.state = 'active'
+    FOR SHARE OF attempt, job, run, repository, workflow, snapshot, marker,
+                 invocation, logical_job, preparation_claim, preparation,
+                 activation_publication, instance, concrete, materialization,
+                 runner, session,
+                 admission_receipt, manifest, checks_authority;
+
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+
+    IF contents_authority_id IS NULL THEN
+        RETURN FALSE;
+    END IF;
+
+    PERFORM 1
+    FROM github_workflow_run_manifest_origins AS origin
+    JOIN github_server_service_authorities AS contents_authority
+      ON contents_authority.tenant_id = origin.tenant_id
+     AND contents_authority.id = origin.repository_contents_authority_id
+     AND contents_authority.repository_id = origin.repository_id
+     AND contents_authority.provider_connection_id =
+         origin.provider_connection_id
+     AND contents_authority.provider_installation_id =
+         origin.provider_installation_id
+     AND contents_authority.github_repository_id =
+         origin.github_repository_id
+     AND contents_authority.github_repository_name =
+         origin.github_repository_name
+     AND contents_authority.service_scope = 'repository_contents_read'
+     AND contents_authority.identity_digest =
+         origin.repository_contents_authority_identity_digest
+     AND contents_authority.app_configuration_revision =
+         origin.repository_contents_authority_app_configuration_revision
+     AND contents_authority.policy_revision =
+         origin.repository_contents_authority_policy_revision
+    WHERE origin.tenant_id = authority.tenant_id
+      AND origin.repository_id = authority.repository_id
+      AND origin.workflow_id = authority.workflow_id
+      AND origin.run_id = authority.run_id
+      AND origin.subject_evidence_sha256 =
+          authority.github_run_subject_evidence_sha256
+      AND origin.repository_contents_authority_id = contents_authority_id
+      AND contents_authority.state = 'active'
+    FOR SHARE OF contents_authority;
+    RETURN FOUND;
+END;
+$$;
+
+

--- a/crates/automata-ci-store-postgres/migrations/0073_provider_delivery_runtime_authority_current.sql
+++ b/crates/automata-ci-store-postgres/migrations/0073_provider_delivery_runtime_authority_current.sql
@@ -1,0 +1,29 @@
+-- Provider-delivery admissions carry their authenticated manifest and service
+-- authorities directly. They intentionally do not create GitHub subject
+-- evidence rows, so the currentness guard must not require that older edge.
+DO $migration$
+DECLARE
+    definition TEXT;
+    original_edge CONSTANT TEXT := 'AND admission_receipt.github_subject_evidence_required';
+    provider_delivery_edge CONSTANT TEXT :=
+        'AND (origin.origin_kind = ''provider_delivery'' OR admission_receipt.github_subject_evidence_required)';
+BEGIN
+    SELECT pg_get_functiondef(routine.oid)
+      INTO definition
+      FROM pg_proc AS routine
+      JOIN pg_namespace AS namespace
+        ON namespace.oid = routine.pronamespace
+     WHERE routine.proname = 'automata_github_runtime_authority_base_is_current'
+       AND namespace.nspname = 'public'
+       AND pg_get_function_identity_arguments(routine.oid) =
+           'authority github_runtime_authority_issuances, observed_at bigint';
+
+    IF definition IS NULL OR position(original_edge IN definition) = 0 THEN
+        RAISE EXCEPTION
+            'runtime-authority currentness guard does not expose its admission evidence edge';
+    END IF;
+
+    definition := replace(definition, original_edge, provider_delivery_edge);
+    EXECUTE definition;
+END;
+$migration$;

--- a/crates/automata-ci-store-postgres/migrations/0074_provider_handoff_consumer_guard.sql
+++ b/crates/automata-ci-store-postgres/migrations/0074_provider_handoff_consumer_guard.sql
@@ -1,0 +1,335 @@
+-- Server-service handoffs must follow the provider-neutral consumer records
+-- introduced after the original GitHub Checks and delivery queues. Keep the
+-- database insert guard on the same exact claims revalidated by the Rust port.
+CREATE OR REPLACE FUNCTION automata_github_server_service_handoff_insert_guard()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    issuance github_server_service_authority_issuances%ROWTYPE;
+    authority github_server_service_authorities%ROWTYPE;
+    consumer_exact BOOLEAN;
+    observed_at_ms BIGINT := floor(
+        extract(epoch FROM clock_timestamp()) * 1000
+    )::BIGINT;
+BEGIN
+    SELECT * INTO issuance
+    FROM github_server_service_authority_issuances
+    WHERE tenant_id = NEW.tenant_id
+      AND authority_id = NEW.authority_id
+      AND generation = NEW.generation
+    FOR SHARE;
+
+    SELECT * INTO authority
+    FROM github_server_service_authorities
+    WHERE tenant_id = NEW.tenant_id
+      AND id = NEW.authority_id
+    FOR SHARE;
+
+    IF issuance.authority_id IS NULL
+        OR authority.id IS NULL
+        OR authority.state <> 'active'
+        OR authority.current_issuance_generation IS DISTINCT FROM NEW.generation
+        OR issuance.state <> 'ready'
+        OR issuance.state_updated_at_ms > NEW.granted_at_ms
+        OR authority.state_updated_at_ms > NEW.granted_at_ms
+        OR NEW.required_through_ms > issuance.provider_expires_at_ms - 60000
+    THEN
+        RAISE EXCEPTION 'GitHub server-service handoff authority is not exact'
+            USING ERRCODE = 'integrity_constraint_violation',
+                  CONSTRAINT = 'github_server_service_handoffs_authority_exact';
+    END IF;
+
+    IF authority.service_scope = 'checks_write' THEN
+        SELECT EXISTS (
+            SELECT 1
+            FROM provider_result_outbox AS outbox
+            JOIN provider_result_subjects AS subject
+              ON subject.subject_id = outbox.subject_id
+            JOIN provider_connection_revisions AS provider_connection
+              ON provider_connection.connection_id = subject.connection_id
+             AND provider_connection.revision = subject.connection_revision
+             AND provider_connection.manifest_digest = subject.connection_digest
+            JOIN provider_instance_revisions AS provider_instance
+              ON provider_instance.instance_id =
+                    provider_connection.provider_instance_id
+             AND provider_instance.revision = provider_connection.provider_revision
+             AND provider_instance.configuration_digest =
+                    provider_connection.provider_configuration_digest
+             AND provider_instance.capability_digest =
+                    provider_connection.capability_digest
+            JOIN repositories AS repository
+              ON repository.id = authority.repository_id
+             AND repository.tenant_id = provider_connection.workspace_id
+             AND repository.scm_provider = provider_instance.provider_type
+             AND repository.provider_repository_id =
+                    provider_connection.external_repository_id
+            WHERE outbox.subject_id = NEW.consumer_id
+              AND outbox.generation = NEW.consumer_revision
+              AND outbox.state = 'claimed'
+              AND outbox.claim_worker_id = NEW.consumer_owner_id
+              AND outbox.claim_fence = NEW.consumer_claim_fence
+              AND outbox.claim_started_at_ms <= observed_at_ms
+              AND outbox.claim_expires_at_ms > observed_at_ms
+              AND NEW.required_through_ms::NUMERIC <=
+                    outbox.claim_expires_at_ms::NUMERIC
+                    + CASE NEW.consumer_action
+                        WHEN 'publish_check_run' THEN 600000
+                        ELSE 300000
+                      END
+              AND NEW.consumer_action IN (
+                    'ensure_check_suite',
+                    'create_check_run',
+                    'reconcile_check_run',
+                    'publish_check_run'
+              )
+              AND subject.connection_id = authority.provider_connection_id
+              AND provider_connection.workspace_id = authority.tenant_id
+              AND provider_instance.provider_type = 'github'
+              AND provider_connection.external_repository_id =
+                    authority.github_repository_id::TEXT
+            FOR SHARE OF outbox, subject, provider_connection,
+                provider_instance, repository
+        ) INTO consumer_exact;
+
+        IF consumer_exact IS DISTINCT FROM TRUE THEN
+            RAISE EXCEPTION 'GitHub result handoff consumer claim is not exact'
+                USING ERRCODE = 'integrity_constraint_violation',
+                      CONSTRAINT =
+                          'github_server_service_handoffs_checks_claim_exact';
+        END IF;
+    ELSIF authority.service_scope = 'repository_contents_read' THEN
+        IF NEW.consumer_action = 'discover_repository_schedules' THEN
+            SELECT EXISTS (
+                SELECT 1
+                FROM github_schedule_discovery_claims AS discovery
+                JOIN github_provider_manifest_current AS current_manifest
+                  ON current_manifest.tenant_id = discovery.tenant_id
+                 AND current_manifest.repository_id = discovery.repository_id
+                 AND current_manifest.provider_connection_id =
+                        discovery.provider_connection_id
+                 AND current_manifest.manifest_revision = discovery.manifest_revision
+                 AND current_manifest.manifest_digest = discovery.manifest_digest
+                JOIN github_provider_manifest_revisions AS manifest
+                  ON manifest.tenant_id = current_manifest.tenant_id
+                 AND manifest.repository_id = current_manifest.repository_id
+                 AND manifest.provider_connection_id =
+                        current_manifest.provider_connection_id
+                 AND manifest.manifest_revision = current_manifest.manifest_revision
+                 AND manifest.manifest_digest = current_manifest.manifest_digest
+                JOIN repositories AS repository
+                  ON repository.id = discovery.repository_id
+                 AND repository.tenant_id = discovery.tenant_id
+                 AND repository.scm_provider = 'github'
+                 AND repository.provider_repository_id =
+                        manifest.github_repository_id::TEXT
+                WHERE discovery.discovery_id = NEW.consumer_id
+                  AND discovery.state = 'claimed'
+                  AND discovery.claim_owner_id = NEW.consumer_owner_id
+                  AND discovery.claim_fence = NEW.consumer_claim_fence
+                  AND NEW.consumer_revision = 1
+                  AND discovery.claimed_at_ms <= observed_at_ms
+                  AND discovery.updated_at_ms <= observed_at_ms
+                  AND discovery.claim_expires_at_ms > observed_at_ms
+                  AND NEW.required_through_ms::NUMERIC <=
+                        discovery.claim_expires_at_ms::NUMERIC + 300000
+                  AND discovery.tenant_id = authority.tenant_id
+                  AND discovery.repository_id = authority.repository_id
+                  AND discovery.provider_connection_id =
+                        authority.provider_connection_id
+                  AND discovery.source_authority_kind =
+                        'repository_contents_read'
+                  AND discovery.repository_contents_authority_id = authority.id
+                  AND discovery.repository_contents_authority_identity_digest =
+                        authority.identity_digest
+                  AND discovery.repository_contents_authority_app_configuration_revision =
+                        authority.app_configuration_revision
+                  AND discovery.repository_contents_authority_policy_revision =
+                        authority.policy_revision
+                  AND manifest.provider_installation_id =
+                        authority.provider_installation_id
+                  AND manifest.github_app_id = authority.github_app_id
+                  AND manifest.github_repository_id = authority.github_repository_id
+                  AND manifest.github_repository_name =
+                        authority.github_repository_name
+                FOR SHARE OF discovery, current_manifest, manifest, repository
+            ) INTO consumer_exact;
+        ELSIF NEW.consumer_action = 'resolve_workflow_dispatch_source' THEN
+            SELECT EXISTS (
+                SELECT 1
+                FROM workflow_dispatch_source_resolutions AS resolution
+                JOIN github_provider_manifest_current AS current_manifest
+                  ON current_manifest.tenant_id = resolution.tenant_id
+                 AND current_manifest.repository_id = resolution.repository_id
+                 AND current_manifest.provider_connection_id =
+                        resolution.provider_connection_id
+                 AND current_manifest.manifest_revision =
+                        resolution.provider_manifest_revision
+                 AND current_manifest.manifest_digest =
+                        resolution.provider_manifest_digest
+                JOIN github_provider_manifest_revisions AS manifest
+                  ON manifest.tenant_id = current_manifest.tenant_id
+                 AND manifest.repository_id = current_manifest.repository_id
+                 AND manifest.provider_connection_id =
+                        current_manifest.provider_connection_id
+                 AND manifest.manifest_revision = current_manifest.manifest_revision
+                 AND manifest.manifest_digest = current_manifest.manifest_digest
+                WHERE resolution.tenant_id = authority.tenant_id
+                  AND resolution.operation_id = NEW.consumer_id
+                  AND resolution.repository_id = authority.repository_id
+                  AND resolution.state = 'claimed'
+                  AND resolution.claim_owner_id = NEW.consumer_owner_id
+                  AND resolution.claim_fence = NEW.consumer_claim_fence
+                  AND NEW.consumer_revision = 1
+                  AND resolution.claimed_at_ms <= observed_at_ms
+                  AND resolution.claim_expires_at_ms > observed_at_ms
+                  AND NEW.required_through_ms::NUMERIC <=
+                        resolution.claim_expires_at_ms::NUMERIC + 300000
+                  AND resolution.repository_contents_authority_id = authority.id
+                  AND resolution.repository_contents_authority_identity_digest =
+                        authority.identity_digest
+                  AND resolution.repository_contents_authority_app_configuration_revision =
+                        authority.app_configuration_revision
+                  AND resolution.repository_contents_authority_policy_revision =
+                        authority.policy_revision
+                  AND manifest.repository_visibility = 'private'
+                  AND manifest.provider_installation_id =
+                        authority.provider_installation_id
+                  AND manifest.github_app_id = authority.github_app_id
+                  AND manifest.github_repository_id = authority.github_repository_id
+                  AND manifest.github_repository_name =
+                        authority.github_repository_name
+                  AND manifest.app_configuration_revision =
+                        authority.app_configuration_revision
+                  AND manifest.policy_revision = authority.policy_revision
+                FOR SHARE OF resolution, current_manifest, manifest
+            ) INTO consumer_exact;
+        ELSE
+            SELECT EXISTS (
+                SELECT 1
+                FROM provider_processing_invocations AS invocation
+                JOIN provider_deliveries AS delivery
+                  ON delivery.delivery_id = invocation.source_delivery_id
+                 AND delivery.disposition = 'trigger'
+                JOIN provider_connection_revisions AS provider_connection
+                  ON provider_connection.connection_id = delivery.connection_id
+                 AND provider_connection.revision = delivery.connection_revision
+                 AND provider_connection.provider_instance_id =
+                        delivery.provider_instance_id
+                 AND provider_connection.provider_revision =
+                        delivery.provider_revision
+                 AND provider_connection.external_repository_id =
+                        delivery.repository_external_id
+                JOIN provider_instance_revisions AS provider_instance
+                  ON provider_instance.instance_id = delivery.provider_instance_id
+                 AND provider_instance.revision = delivery.provider_revision
+                 AND provider_instance.provider_type = delivery.provider_type
+                 AND provider_instance.configuration_digest =
+                        provider_connection.provider_configuration_digest
+                 AND provider_instance.capability_digest =
+                        provider_connection.capability_digest
+                JOIN repositories AS repository
+                  ON repository.id = authority.repository_id
+                 AND repository.tenant_id = provider_connection.workspace_id
+                 AND repository.scm_provider = provider_instance.provider_type
+                 AND repository.provider_repository_id =
+                        provider_connection.external_repository_id
+                WHERE invocation.invocation_id = NEW.consumer_id
+                  AND invocation.state = 'claimed'
+                  AND invocation.claim_worker_id = NEW.consumer_owner_id
+                  AND invocation.claim_fence = NEW.consumer_claim_fence
+                  AND invocation.attempts = NEW.consumer_revision
+                  AND invocation.claim_started_at_ms <= observed_at_ms
+                  AND invocation.claim_expires_at_ms > observed_at_ms
+                  AND NEW.required_through_ms::NUMERIC <=
+                        invocation.claim_expires_at_ms::NUMERIC + 300000
+                  AND NEW.consumer_action IN (
+                        'fetch_repository_revision',
+                        'fetch_repository_changed_files'
+                  )
+                  AND provider_connection.workspace_id = authority.tenant_id
+                  AND provider_connection.connection_id =
+                        authority.provider_connection_id
+                  AND provider_instance.provider_type = 'github'
+                  AND provider_connection.external_repository_id =
+                        authority.github_repository_id::TEXT
+                  AND delivery.repository_external_id =
+                        authority.github_repository_id::TEXT
+                FOR SHARE OF invocation, delivery, provider_connection,
+                    provider_instance, repository
+            ) INTO consumer_exact;
+        END IF;
+
+        IF consumer_exact IS DISTINCT FROM TRUE THEN
+            RAISE EXCEPTION 'private GitHub source handoff consumer claim is not exact'
+                USING ERRCODE = 'integrity_constraint_violation',
+                      CONSTRAINT =
+                          'github_server_service_handoffs_source_claim_exact';
+        END IF;
+    ELSIF authority.service_scope = 'pull_requests_read' THEN
+        SELECT EXISTS (
+            SELECT 1
+            FROM provider_processing_invocations AS invocation
+            JOIN provider_deliveries AS delivery
+              ON delivery.delivery_id = invocation.source_delivery_id
+             AND delivery.disposition = 'trigger'
+            JOIN provider_connection_revisions AS provider_connection
+              ON provider_connection.connection_id = delivery.connection_id
+             AND provider_connection.revision = delivery.connection_revision
+             AND provider_connection.provider_instance_id =
+                    delivery.provider_instance_id
+             AND provider_connection.provider_revision = delivery.provider_revision
+             AND provider_connection.external_repository_id =
+                    delivery.repository_external_id
+            JOIN provider_instance_revisions AS provider_instance
+              ON provider_instance.instance_id = delivery.provider_instance_id
+             AND provider_instance.revision = delivery.provider_revision
+             AND provider_instance.provider_type = delivery.provider_type
+             AND provider_instance.configuration_digest =
+                    provider_connection.provider_configuration_digest
+             AND provider_instance.capability_digest =
+                    provider_connection.capability_digest
+            JOIN repositories AS repository
+              ON repository.id = authority.repository_id
+             AND repository.tenant_id = provider_connection.workspace_id
+             AND repository.scm_provider = provider_instance.provider_type
+             AND repository.provider_repository_id =
+                    provider_connection.external_repository_id
+            WHERE invocation.invocation_id = NEW.consumer_id
+              AND invocation.state = 'claimed'
+              AND invocation.claim_worker_id = NEW.consumer_owner_id
+              AND invocation.claim_fence = NEW.consumer_claim_fence
+              AND invocation.attempts = NEW.consumer_revision
+              AND invocation.claim_started_at_ms <= observed_at_ms
+              AND invocation.claim_expires_at_ms > observed_at_ms
+              AND NEW.required_through_ms::NUMERIC <=
+                    invocation.claim_expires_at_ms::NUMERIC + 300000
+              AND NEW.consumer_action = 'fetch_pull_request_files'
+              AND provider_connection.workspace_id = authority.tenant_id
+              AND provider_connection.connection_id =
+                    authority.provider_connection_id
+              AND provider_instance.provider_type = 'github'
+              AND provider_connection.external_repository_id =
+                    authority.github_repository_id::TEXT
+              AND delivery.repository_external_id =
+                    authority.github_repository_id::TEXT
+              AND delivery.event_type = 'pull_request'
+            FOR SHARE OF invocation, delivery, provider_connection,
+                provider_instance, repository
+        ) INTO consumer_exact;
+
+        IF consumer_exact IS DISTINCT FROM TRUE THEN
+            RAISE EXCEPTION 'private GitHub pull-request files handoff claim is not exact'
+                USING ERRCODE = 'integrity_constraint_violation',
+                      CONSTRAINT =
+                          'github_server_service_handoffs_pull_requests_claim_exact';
+        END IF;
+    ELSE
+        RAISE EXCEPTION 'GitHub server-service handoff scope is unknown'
+            USING ERRCODE = 'integrity_constraint_violation',
+                  CONSTRAINT = 'github_server_service_handoffs_scope_exact';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;

--- a/crates/automata-ci-store-postgres/src/github_job_runtime_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_job_runtime_authority.rs
@@ -370,7 +370,6 @@ async fn lock_exact_execution(
          AND admission_receipt.repository_id = origin.repository_id
          AND admission_receipt.run_id = origin.run_id
          AND admission_receipt.committed_at_ms = origin.admitted_at_ms
-         AND admission_receipt.github_subject_evidence_required
         JOIN github_provider_manifest_revisions AS manifest
           ON manifest.tenant_id = origin.tenant_id
          AND manifest.repository_id = origin.repository_id

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -887,6 +887,7 @@ async fn acquire_handoff(
 ) -> Result<GithubServerServiceCredentialHandoff, GithubServerServiceStoreError> {
     let rejected = |stage: &'static str| {
         tracing::warn!(
+            target: "automata_ci",
             stage,
             action = request.consumer().action().as_str(),
             "GitHub server-service credential handoff rejected"

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -895,9 +895,21 @@ async fn acquire_handoff(
     };
     let mut transaction = store.pool.begin().await.map_err(operation_error)?;
     pin_read_committed(&mut transaction).await?;
-    let authority_row = select_authority_for_update(&mut transaction, request.selector())
-        .await?
-        .ok_or(GithubServerServiceStoreError::NotFound)?;
+    let Some(authority_row) =
+        select_authority_for_update(&mut transaction, request.selector()).await?
+    else {
+        tracing::warn!(
+            stage = "authority_not_found",
+            action = request.consumer().action().as_str(),
+            tenant = request.selector().tenant().as_str(),
+            authority_id = ?request.selector().authority_id(),
+            identity_digest = %request.selector().identity_digest(),
+            app_configuration_revision = request.selector().app_configuration_revision().get(),
+            policy_revision = request.selector().policy_revision().get(),
+            "GitHub server-service credential handoff rejected"
+        );
+        return Err(GithubServerServiceStoreError::NotFound);
+    };
     let descriptor = decode_authority(&authority_row)?;
     if descriptor.identity().scope() != request.consumer().action().required_scope() {
         return Err(rejected("scope"));

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -923,11 +923,10 @@ async fn acquire_handoff(
         UnixMillis::new(consumer_check_now),
     )
     .await
-    .map_err(|error| {
+    .inspect_err(|error| {
         if matches!(&error, GithubServerServiceStoreError::HandoffRejected) {
             let _ = rejected("consumer_revalidation_initial");
         }
-        error
     })?;
     if consumer_expires_at
         .get()
@@ -1051,11 +1050,10 @@ async fn acquire_handoff(
         UnixMillis::new(database_now),
     )
     .await
-    .map_err(|error| {
+    .inspect_err(|error| {
         if matches!(&error, GithubServerServiceStoreError::HandoffRejected) {
             let _ = rejected("consumer_revalidation_final");
         }
-        error
     })?;
     if request.consumer().action() != GithubServerServiceAction::ObserveWorkflowPermissionDefaults
         && database_now >= consumer_expires_at.get()

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -1286,66 +1286,64 @@ async fn revalidate_delivery_consumer(
     connection: &mut PgConnection,
     identity: &GithubServerServiceAuthorityIdentity,
     consumer: GithubServerServiceConsumerClaim,
-    observed_at: UnixMillis,
+    _observed_at: UnixMillis,
     require_pull_request_files_pin: bool,
 ) -> Result<Option<UnixMillis>, GithubServerServiceStoreError> {
     sqlx::query_scalar::<_, i64>(
         r"
-        SELECT delivery.claim_expires_at_ms
-        FROM provider_delivery_inbox AS delivery
+        SELECT invocation.claim_expires_at_ms
+        FROM provider_processing_invocations AS invocation
+        JOIN provider_deliveries AS delivery
+          ON delivery.delivery_id = invocation.source_delivery_id
+         AND delivery.disposition = 'trigger'
+        JOIN provider_connection_revisions AS provider_connection
+          ON provider_connection.connection_id = delivery.connection_id
+         AND provider_connection.revision = delivery.connection_revision
+         AND provider_connection.provider_instance_id = delivery.provider_instance_id
+         AND provider_connection.provider_revision = delivery.provider_revision
+         AND provider_connection.external_repository_id = delivery.repository_external_id
+        JOIN provider_instance_revisions AS provider_instance
+          ON provider_instance.instance_id = delivery.provider_instance_id
+         AND provider_instance.revision = delivery.provider_revision
+         AND provider_instance.provider_type = delivery.provider_type
+         AND provider_instance.configuration_digest =
+             provider_connection.provider_configuration_digest
+         AND provider_instance.capability_digest = provider_connection.capability_digest
         JOIN repositories AS repository
-          ON repository.id = $7
-         AND repository.tenant_id = delivery.tenant_id
-         AND repository.scm_provider = 'github'
-         AND repository.provider_repository_id = delivery.provider_repository_id::TEXT
-        WHERE delivery.id = $1
-          AND delivery.state = 'claimed'
-          AND delivery.claim_owner_id = $2
-          AND delivery.claim_fence = $3
-          AND delivery.attempt_count = $4
-          AND delivery.claimed_at_ms <= $5
-          AND delivery.state_updated_at_ms <= $5
-          AND delivery.claim_expires_at_ms > $5
-          AND delivery.tenant_id = $6
-          AND delivery.provider = 'github'
-          AND delivery.repository_visibility = 'private'
-          AND delivery.connection_id = $8
-          AND delivery.installation_id = $9
-          AND delivery.provider_repository_id = $10
-          AND delivery.repository_identity = $11
+          ON repository.id = $6
+         AND repository.tenant_id = provider_connection.workspace_id
+         AND repository.scm_provider = provider_instance.provider_type
+         AND repository.provider_repository_id = provider_connection.external_repository_id
+        WHERE invocation.invocation_id = $1
+          AND invocation.state = 'claimed'
+          AND invocation.claim_worker_id = $2
+          AND invocation.claim_fence = $3
+          AND invocation.attempts = $4
+          AND invocation.claim_started_at_ms <=
+              (extract(epoch FROM clock_timestamp()) * 1000)::BIGINT
+          AND invocation.claim_expires_at_ms >
+              (extract(epoch FROM clock_timestamp()) * 1000)::BIGINT
+          AND provider_connection.workspace_id = $5
+          AND provider_connection.connection_id = $7
+          AND provider_instance.provider_type = 'github'
+          AND provider_connection.external_repository_id = $8
+          AND delivery.repository_external_id = $8
           AND (
-              NOT $12
-              OR EXISTS (
-                  SELECT 1
-                  FROM github_provider_delivery_evidence AS evidence
-                  WHERE evidence.provider_delivery_id = delivery.id
-                    AND evidence.tenant_id = delivery.tenant_id
-                    AND evidence.authenticated_event_name = 'pull_request'
-                    AND evidence.pull_requests_authority_id = $13
-                    AND evidence.pull_requests_authority_identity_digest = $14
-                    AND evidence.pull_requests_authority_app_configuration_revision = $15
-                    AND evidence.pull_requests_authority_policy_revision = $16
-              )
+              NOT $9
+              OR delivery.event_type = 'pull_request'
           )
-        FOR SHARE OF delivery, repository
+        FOR SHARE OF invocation, delivery, provider_connection, provider_instance, repository
         ",
     )
     .bind(consumer.consumer_id().as_uuid())
     .bind(consumer.owner().as_uuid())
     .bind(pg_bigint(consumer.fence().get()))
     .bind(pg_bigint(consumer.revision().get()))
-    .bind(observed_at.get())
     .bind(identity.tenant().as_str())
     .bind(identity.repository_id().as_uuid())
     .bind(identity.connection_id().as_uuid())
-    .bind(pg_bigint(identity.installation_id().get()))
-    .bind(pg_bigint(identity.github_repository_id().get()))
-    .bind(identity.github_repository_name().as_str())
+    .bind(identity.github_repository_id().get().to_string())
     .bind(require_pull_request_files_pin)
-    .bind(identity.authority_id().as_uuid())
-    .bind(identity.identity_digest().as_bytes().as_slice())
-    .bind(pg_bigint(identity.app_configuration_revision().get()))
-    .bind(pg_bigint(identity.policy_revision().get()))
     .fetch_optional(&mut *connection)
     .await
     .map_err(operation_error)

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -885,6 +885,14 @@ async fn acquire_handoff(
     store: &PostgresStore,
     request: AcquireGithubServerServiceHandoff,
 ) -> Result<GithubServerServiceCredentialHandoff, GithubServerServiceStoreError> {
+    let rejected = |stage: &'static str| {
+        tracing::warn!(
+            stage,
+            action = request.consumer().action().as_str(),
+            "GitHub server-service credential handoff rejected"
+        );
+        GithubServerServiceStoreError::HandoffRejected
+    };
     let mut transaction = store.pool.begin().await.map_err(operation_error)?;
     pin_read_committed(&mut transaction).await?;
     let authority_row = select_authority_for_update(&mut transaction, request.selector())
@@ -892,7 +900,7 @@ async fn acquire_handoff(
         .ok_or(GithubServerServiceStoreError::NotFound)?;
     let descriptor = decode_authority(&authority_row)?;
     if descriptor.identity().scope() != request.consumer().action().required_scope() {
-        return Err(GithubServerServiceStoreError::HandoffRejected);
+        return Err(rejected("scope"));
     }
     let consumer_check_now = database_now_ms(&mut transaction).await?;
     let consumer_expires_at = revalidate_handoff_consumer(
@@ -901,13 +909,19 @@ async fn acquire_handoff(
         request.consumer(),
         UnixMillis::new(consumer_check_now),
     )
-    .await?;
+    .await
+    .map_err(|error| {
+        if matches!(&error, GithubServerServiceStoreError::HandoffRejected) {
+            let _ = rejected("consumer_revalidation_initial");
+        }
+        error
+    })?;
     if consumer_expires_at
         .get()
         .checked_add(request.consumer().action().provider_tail_millis())
         .is_none_or(|maximum| request.required_through().get() > maximum)
     {
-        return Err(GithubServerServiceStoreError::HandoffRejected);
+        return Err(rejected("consumer_horizon_initial"));
     }
     let consumer = request.consumer();
     let existing_handoff = sqlx::query(
@@ -941,14 +955,14 @@ async fn acquire_handoff(
             || replay_consumer != request.consumer()
             || optional_i64(row, "released_at_ms")?.is_some()
         {
-            return Err(GithubServerServiceStoreError::HandoffRejected);
+            return Err(rejected("replay_binding"));
         }
         let durable_required_through = i64_column(row, "required_through_ms")?;
         let durable_granted_at = i64_column(row, "granted_at_ms")?;
         if durable_required_through != request.required_through().get()
             || request.observed_at().get() < durable_granted_at
         {
-            return Err(GithubServerServiceStoreError::HandoffRejected);
+            return Err(rejected("replay_horizon"));
         }
         (
             GithubServerServiceHandoffId::from_uuid(uuid_column(row, "id")?)
@@ -958,11 +972,11 @@ async fn acquire_handoff(
         )
     } else {
         if descriptor.state() != GithubServerServiceAuthorityState::Active {
-            return Err(GithubServerServiceStoreError::HandoffRejected);
+            return Err(rejected("authority_state"));
         }
         let generation = descriptor
             .current_generation()
-            .ok_or(GithubServerServiceStoreError::HandoffRejected)?;
+            .ok_or_else(|| rejected("authority_generation"))?;
         let key = GithubServerServiceIssuanceKey::new(request.authority_id(), generation);
         let issuance = select_issuance_for_update(&mut transaction, key)
             .await?
@@ -973,7 +987,7 @@ async fn acquire_handoff(
                 .usable_until()
                 .is_none_or(|until| until < request.required_through())
         {
-            return Err(GithubServerServiceStoreError::HandoffRejected);
+            return Err(rejected("issuance_horizon_initial"));
         }
         let inserted = sqlx::query(
             r"
@@ -1000,7 +1014,7 @@ async fn acquire_handoff(
         .await
         .map_err(operation_error)?;
         if inserted.rows_affected() != 1 {
-            return Err(GithubServerServiceStoreError::HandoffRejected);
+            return Err(rejected("handoff_conflict"));
         }
         (
             request.proposed_handoff_id(),
@@ -1016,34 +1030,52 @@ async fn acquire_handoff(
     let receipt = decode_issuance_receipt(&issuance)?;
     let database_now = database_now_ms(&mut transaction).await?;
     validate_caller_clock(request.observed_at(), database_now)
-        .map_err(|_| GithubServerServiceStoreError::HandoffRejected)?;
+        .map_err(|_| rejected("caller_clock"))?;
     let consumer_expires_at = revalidate_handoff_consumer(
         &mut transaction,
         descriptor.identity(),
         request.consumer(),
         UnixMillis::new(database_now),
     )
-    .await?;
-    if (request.consumer().action() != GithubServerServiceAction::ObserveWorkflowPermissionDefaults
-        && database_now >= consumer_expires_at.get())
-        || database_now >= request.required_through().get()
-        || consumer_expires_at
-            .get()
-            .checked_add(request.consumer().action().provider_tail_millis())
-            .is_none_or(|maximum| request.required_through().get() > maximum)
-        || !matches!(
-            receipt.state(),
-            GithubServerServiceIssuanceState::Ready
-                | GithubServerServiceIssuanceState::RevokePending
-        )
-        || receipt
-            .usable_until()
-            .is_none_or(|until| until.get() < request.required_through().get())
-        || !is_replay
-            && (receipt.state() != GithubServerServiceIssuanceState::Ready
-                || descriptor.current_generation() != Some(generation))
+    .await
+    .map_err(|error| {
+        if matches!(&error, GithubServerServiceStoreError::HandoffRejected) {
+            let _ = rejected("consumer_revalidation_final");
+        }
+        error
+    })?;
+    if request.consumer().action() != GithubServerServiceAction::ObserveWorkflowPermissionDefaults
+        && database_now >= consumer_expires_at.get()
     {
-        return Err(GithubServerServiceStoreError::HandoffRejected);
+        return Err(rejected("consumer_expired_final"));
+    }
+    if database_now >= request.required_through().get() {
+        return Err(rejected("handoff_expired_final"));
+    }
+    if consumer_expires_at
+        .get()
+        .checked_add(request.consumer().action().provider_tail_millis())
+        .is_none_or(|maximum| request.required_through().get() > maximum)
+    {
+        return Err(rejected("consumer_horizon_final"));
+    }
+    if !matches!(
+        receipt.state(),
+        GithubServerServiceIssuanceState::Ready | GithubServerServiceIssuanceState::RevokePending
+    ) {
+        return Err(rejected("issuance_state_final"));
+    }
+    if receipt
+        .usable_until()
+        .is_none_or(|until| until.get() < request.required_through().get())
+    {
+        return Err(rejected("issuance_horizon_final"));
+    }
+    if !is_replay
+        && (receipt.state() != GithubServerServiceIssuanceState::Ready
+            || descriptor.current_generation() != Some(generation))
+    {
+        return Err(rejected("current_generation_final"));
     }
     let protected = match decode_protected(descriptor.identity().clone(), &issuance) {
         Ok(protected) => protected,

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -3654,12 +3654,23 @@ fn operation_error(error: sqlx::Error) -> GithubServerServiceStoreError {
         .and_then(sqlx::error::DatabaseError::constraint);
     match constraint {
         Some(
-            "github_server_service_handoffs_authority_exact"
+            constraint @ ("github_server_service_handoffs_authority_exact"
             | "github_server_service_handoffs_checks_claim_exact"
+            | "github_server_service_handoffs_schedule_discovery_claim_exact"
             | "github_server_service_handoffs_source_claim_exact"
+            | "github_server_service_handoffs_pull_requests_claim_exact"
+            | "github_workflow_permission_handoff_exact"
             | "github_server_service_handoffs_scope_exact"
-            | "github_server_service_handoffs_immutable",
-        ) => GithubServerServiceStoreError::HandoffRejected,
+            | "github_server_service_handoffs_immutable"),
+        ) => {
+            tracing::warn!(
+                target: "automata_ci_credential_github::server_service_authority",
+                stage = "database_insert_guard",
+                constraint,
+                "GitHub server-service credential handoff rejected"
+            );
+            GithubServerServiceStoreError::HandoffRejected
+        }
         Some("github_server_service_issuances_handoff_live") => {
             GithubServerServiceStoreError::HandoffStillLive
         }

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -1236,7 +1236,21 @@ async fn revalidate_handoff_consumer(
             .map(UnixMillis::new)
         }
     };
-    claim_expires_at.ok_or(GithubServerServiceStoreError::HandoffRejected)
+    let Some(claim_expires_at) = claim_expires_at else {
+        tracing::warn!(
+            target: "automata_ci",
+            stage = "consumer_revalidation_empty",
+            action = consumer.action().as_str(),
+            consumer_id = ?consumer.consumer_id(),
+            consumer_owner = ?consumer.owner(),
+            consumer_fence = consumer.fence().get(),
+            consumer_revision = consumer.revision().get(),
+            observed_at = observed_at.get(),
+            "GitHub server-service credential handoff consumer query matched no live claim"
+        );
+        return Err(GithubServerServiceStoreError::HandoffRejected);
+    };
+    Ok(claim_expires_at)
 }
 
 async fn revalidate_provider_result_consumer(

--- a/crates/automata-ci-store-postgres/src/github_service_authority.rs
+++ b/crates/automata-ci-store-postgres/src/github_service_authority.rs
@@ -887,7 +887,7 @@ async fn acquire_handoff(
 ) -> Result<GithubServerServiceCredentialHandoff, GithubServerServiceStoreError> {
     let rejected = |stage: &'static str| {
         tracing::warn!(
-            target: "automata_ci",
+            target: "automata_ci_credential_github::server_service_authority",
             stage,
             action = request.consumer().action().as_str(),
             "GitHub server-service credential handoff rejected"
@@ -1238,7 +1238,7 @@ async fn revalidate_handoff_consumer(
     };
     let Some(claim_expires_at) = claim_expires_at else {
         tracing::warn!(
-            target: "automata_ci",
+            target: "automata_ci_credential_github::server_service_authority",
             stage = "consumer_revalidation_empty",
             action = consumer.action().as_str(),
             consumer_id = ?consumer.consumer_id(),

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -1612,7 +1612,10 @@ async fn load_provider_selection_authority(
         )
         .into());
     }
-    if row.raw_body_digest.as_slice() != command.event().digest().as_bytes() {
+    if command
+        .raw_event_digest()
+        .is_some_and(|digest| row.raw_body_digest.as_slice() != digest.as_bytes())
+    {
         return Err(StoreError::corrupt_data(
             "authenticated provider event bytes disagree with logical admission",
         )

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -2061,10 +2061,10 @@ async fn record_provider_admission_evidence(
             normalized_trigger_digest, raw_event_digest, request_digest,
             source_revision, git_ref, event_name, actor, original_worker_id,
             original_fence, original_claimed_at_ms, original_expires_at_ms,
-            admitted_at_ms
+            admitted_at_ms, idempotency_key
         ) VALUES (
             $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,
-            $18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28
+            $18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29
         )
         ",
     )
@@ -2098,6 +2098,7 @@ async fn record_provider_admission_evidence(
     .bind(fence.claimed_at().get())
     .bind(fence.expires_at().get())
     .bind(observed_at.get())
+    .bind(command.idempotency().key())
     .execute(&mut **transaction)
     .await
     .map_err(operation_error)?;
@@ -2190,6 +2191,7 @@ async fn validate_provider_admission_evidence_replay(
           AND evidence.request_digest = $19 AND evidence.source_revision = $20
           AND evidence.git_ref = $21 AND evidence.event_name = $22
           AND evidence.actor IS NOT DISTINCT FROM $23
+          AND evidence.idempotency_key = $24
         FOR SHARE OF evidence, pin, policy
         ",
     )
@@ -2216,6 +2218,7 @@ async fn validate_provider_admission_evidence_replay(
     .bind(command.git_ref())
     .bind(command.event_name())
     .bind(command.actor())
+    .bind(command.idempotency().key())
     .fetch_optional(&mut **transaction)
     .await
     .map_err(operation_error)?;

--- a/crates/automata-ci-store-postgres/src/logical_work_selection.rs
+++ b/crates/automata-ci-store-postgres/src/logical_work_selection.rs
@@ -155,6 +155,7 @@ impl LogicalWorkSelectionRepository for PostgresStore {
         request: ClaimNextLogicalJobOrchestration,
     ) -> Result<LogicalJobOrchestrationSelectionOutcome, LogicalWorkSelectionStoreError> {
         let mut transaction = begin_read_committed(self).await?;
+        let request_database_now = read_selection_database_now(&mut transaction).await?;
         if let Some(row) = lock_activation_receipt(&mut transaction, &request).await? {
             let outcome = replay_activation(&mut transaction, &request, &row).await?;
             transaction.commit().await.map_err(operation_error)?;
@@ -178,6 +179,7 @@ impl LogicalWorkSelectionRepository for PostgresStore {
             "activation",
             request.observed_at(),
             request.duration_ms(),
+            request_database_now,
         )
         .await?;
         cleanup_receipts(&mut transaction, "activation", admission.replay_floor).await?;
@@ -314,6 +316,7 @@ impl LogicalWorkSelectionRepository for PostgresStore {
     ) -> Result<LogicalInstanceMaterializationSelectionOutcome, LogicalWorkSelectionStoreError>
     {
         let mut transaction = begin_read_committed(self).await?;
+        let request_database_now = read_selection_database_now(&mut transaction).await?;
         if let Some(row) = lock_materialization_receipt(&mut transaction, &request).await? {
             let outcome = replay_materialization(&mut transaction, &request, &row).await?;
             transaction.commit().await.map_err(operation_error)?;
@@ -335,6 +338,7 @@ impl LogicalWorkSelectionRepository for PostgresStore {
             "materialization",
             request.observed_at(),
             request.duration_ms(),
+            request_database_now,
         )
         .await?;
         cleanup_receipts(&mut transaction, "materialization", admission.replay_floor).await?;
@@ -766,6 +770,7 @@ async fn lock_selection_admission(
     queue: &'static str,
     observed_at: UnixMillis,
     duration_ms: i64,
+    request_database_now: i64,
 ) -> Result<SelectionAdmission, LogicalWorkSelectionStoreError> {
     let row = sqlx::query(
         r"
@@ -786,8 +791,8 @@ async fn lock_selection_admission(
     if floor < 0 || floor > updated_at || updated_at > now {
         return Err(StoreError::corrupt_data("logical work replay horizon is malformed").into());
     }
-    if observed_at.get() < now.saturating_sub(MAX_SELECTION_CLOCK_SKEW_MILLIS)
-        || observed_at.get() > now.saturating_add(MAX_SELECTION_CLOCK_SKEW_MILLIS)
+    if observed_at.get() < request_database_now.saturating_sub(MAX_SELECTION_CLOCK_SKEW_MILLIS)
+        || observed_at.get() > request_database_now.saturating_add(MAX_SELECTION_CLOCK_SKEW_MILLIS)
     {
         return Err(LogicalWorkSelectionStoreError::SelectionClockSkew);
     }
@@ -808,6 +813,15 @@ async fn lock_selection_admission(
         previous_floor: floor,
         previous_updated_at: updated_at,
     })
+}
+
+async fn read_selection_database_now(
+    transaction: &mut Transaction<'_, Postgres>,
+) -> Result<i64, LogicalWorkSelectionStoreError> {
+    sqlx::query_scalar("SELECT floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint")
+        .fetch_one(&mut **transaction)
+        .await
+        .map_err(operation_error)
 }
 
 async fn advance_selection_horizon(

--- a/crates/automata-ci-store-postgres/src/logical_work_selection.rs
+++ b/crates/automata-ci-store-postgres/src/logical_work_selection.rs
@@ -182,7 +182,10 @@ impl LogicalWorkSelectionRepository for PostgresStore {
             request_database_now,
         )
         .await?;
-        cleanup_receipts(&mut transaction, "activation", admission.replay_floor).await?;
+        // The delete trigger authenticates cleanup against the durable horizon.
+        // The proposed successor floor is not durable until candidate discovery
+        // completes, so only reclaim receipts outside the locked predecessor.
+        cleanup_receipts(&mut transaction, "activation", admission.previous_floor).await?;
         let mut can_wrap = horizon.activation_cursor.is_some();
         let mut discovery_cursor = horizon.activation_cursor;
         let mut scanned_candidates = 0_usize;
@@ -341,7 +344,14 @@ impl LogicalWorkSelectionRepository for PostgresStore {
             request_database_now,
         )
         .await?;
-        cleanup_receipts(&mut transaction, "materialization", admission.replay_floor).await?;
+        // Match the delete trigger's durable replay authority. Advancing to the
+        // proposed floor happens only after discovery has selected its cursor.
+        cleanup_receipts(
+            &mut transaction,
+            "materialization",
+            admission.previous_floor,
+        )
+        .await?;
         let mut can_wrap = horizon.materialization_cursor.is_some();
         let mut discovery_cursor = horizon.materialization_cursor;
         let mut scanned_candidates = 0_usize;

--- a/crates/automata-ci-store-postgres/src/logical_work_selection.rs
+++ b/crates/automata-ci-store-postgres/src/logical_work_selection.rs
@@ -53,7 +53,6 @@ struct SelectionAdmission {
 }
 
 struct LockedSelectionHorizon {
-    replay_floor: i64,
     activation_cursor: Option<ActivationDiscoveryCursor>,
     materialization_cursor: Option<MaterializationDiscoveryCursor>,
 }
@@ -170,7 +169,18 @@ impl LogicalWorkSelectionRepository for PostgresStore {
             return Ok(outcome);
         }
         let horizon = lock_selection_horizon(&mut transaction, "activation").await?;
-        cleanup_receipts(&mut transaction, "activation", horizon.replay_floor).await?;
+        // Admit the caller's clock while the request is still fresh. Receipt
+        // cleanup and candidate discovery are bounded but may legitimately be
+        // expensive after an outage; neither may turn that database work into
+        // a false client-clock rejection and roll the cleanup back forever.
+        let admission = lock_selection_admission(
+            &mut transaction,
+            "activation",
+            request.observed_at(),
+            request.duration_ms(),
+        )
+        .await?;
+        cleanup_receipts(&mut transaction, "activation", admission.replay_floor).await?;
         let mut can_wrap = horizon.activation_cursor.is_some();
         let mut discovery_cursor = horizon.activation_cursor;
         let mut scanned_candidates = 0_usize;
@@ -204,13 +214,6 @@ impl LogicalWorkSelectionRepository for PostgresStore {
                     rollback_candidate_savepoint(&mut transaction).await?;
                     continue;
                 }
-                let admission = lock_selection_admission(
-                    &mut transaction,
-                    "activation",
-                    request.observed_at(),
-                    request.duration_ms(),
-                )
-                .await?;
                 let now = admission.database_now;
                 if !activation_candidate_is_eligible(&mut transaction, &candidate, now).await? {
                     rollback_candidate_savepoint(&mut transaction).await?;
@@ -271,13 +274,6 @@ impl LogicalWorkSelectionRepository for PostgresStore {
             }
             discovery_cursor = next_cursor;
         };
-        let admission = lock_selection_admission(
-            &mut transaction,
-            "activation",
-            request.observed_at(),
-            request.duration_ms(),
-        )
-        .await?;
         advance_selection_horizon(
             &mut transaction,
             "activation",
@@ -334,7 +330,14 @@ impl LogicalWorkSelectionRepository for PostgresStore {
             return Ok(outcome);
         }
         let horizon = lock_selection_horizon(&mut transaction, "materialization").await?;
-        cleanup_receipts(&mut transaction, "materialization", horizon.replay_floor).await?;
+        let admission = lock_selection_admission(
+            &mut transaction,
+            "materialization",
+            request.observed_at(),
+            request.duration_ms(),
+        )
+        .await?;
+        cleanup_receipts(&mut transaction, "materialization", admission.replay_floor).await?;
         let mut can_wrap = horizon.materialization_cursor.is_some();
         let mut discovery_cursor = horizon.materialization_cursor;
         let mut scanned_candidates = 0_usize;
@@ -368,13 +371,6 @@ impl LogicalWorkSelectionRepository for PostgresStore {
                     rollback_candidate_savepoint(&mut transaction).await?;
                     continue;
                 }
-                let admission = lock_selection_admission(
-                    &mut transaction,
-                    "materialization",
-                    request.observed_at(),
-                    request.duration_ms(),
-                )
-                .await?;
                 let now = admission.database_now;
                 if !materialization_candidate_is_eligible(&mut transaction, &candidate, now).await?
                 {
@@ -438,13 +434,6 @@ impl LogicalWorkSelectionRepository for PostgresStore {
             }
             discovery_cursor = next_cursor;
         };
-        let admission = lock_selection_admission(
-            &mut transaction,
-            "materialization",
-            request.observed_at(),
-            request.duration_ms(),
-        )
-        .await?;
         advance_selection_horizon(
             &mut transaction,
             "materialization",
@@ -767,7 +756,6 @@ async fn lock_selection_horizon(
         None
     };
     Ok(LockedSelectionHorizon {
-        replay_floor,
         activation_cursor,
         materialization_cursor,
     })

--- a/crates/automata-ci-store-postgres/src/migration_0061_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_0061_tests.rs
@@ -253,7 +253,7 @@ async fn production_migrations_upgrade_deployed_schema_and_immutable_evidence() 
         let applied_version: i64 = sqlx::query_scalar("SELECT max(version) FROM _sqlx_migrations")
             .fetch_one(&database.pool)
             .await?;
-        assert_eq!(applied_version, 69);
+        assert_eq!(applied_version, 70);
 
         assert_migrated_contract(&database.pool).await?;
         Ok(())

--- a/crates/automata-ci-store-postgres/src/migration_0061_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_0061_tests.rs
@@ -9,7 +9,6 @@ use uuid::Uuid;
 use crate::migration::MIGRATOR;
 
 const DATABASE_URL_ENVIRONMENT: &str = "AUTOMATA_TEST_DATABASE_URL";
-const TEST_SCHEMA: &str = "automata_test";
 const MINIMUM_POSTGRES_VERSION: i32 = 180_000;
 
 type TestError = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -48,7 +47,7 @@ where
         .after_connect(|connection, _metadata| {
             Box::pin(async move {
                 sqlx::query("SELECT pg_catalog.set_config('search_path', $1, false)")
-                    .bind(format!("{TEST_SCHEMA}, pg_catalog"))
+                    .bind("public, pg_catalog")
                     .execute(connection)
                     .await?;
                 Ok(())
@@ -63,15 +62,6 @@ where
             return Err(error.into());
         }
     };
-    if let Err(error) = sqlx::query("CREATE SCHEMA automata_test")
-        .execute(&pool)
-        .await
-    {
-        pool.close().await;
-        cleanup_database(&admin_options, &database_name).await?;
-        return Err(error.into());
-    }
-
     let database = Arc::new(TestDatabase { pool });
     let task = tokio::spawn(test(Arc::clone(&database))).await;
     database.pool.close().await;
@@ -253,7 +243,7 @@ async fn production_migrations_upgrade_deployed_schema_and_immutable_evidence() 
         let applied_version: i64 = sqlx::query_scalar("SELECT max(version) FROM _sqlx_migrations")
             .fetch_one(&database.pool)
             .await?;
-        assert_eq!(applied_version, 70);
+        assert_eq!(applied_version, 74);
 
         assert_migrated_contract(&database.pool).await?;
         Ok(())

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -293,6 +293,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0072_provider_delivery_runtime_provenance.sql",
         "9d7afe44c0c0584f898acc1bfac98493517976c9e0b70b5d8813dfe6aa8681192b301635789e7ce1b37e421cb2ef1988",
     ),
+    (
+        "0073_provider_delivery_runtime_authority_current.sql",
+        "f1444ab4d4ed0fd9b96b000b706092340a7d961f188709fd06a22812e4bae2ad456391a1da82a0a9f65e4365261d1e62",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;
@@ -1061,6 +1065,21 @@ fn provider_workflow_result_identity_is_unique_and_provider_neutral() {
         assert!(
             !source.contains(forbidden),
             "workflow-result identity retained provider-specific or transitional surface: {forbidden}",
+        );
+    }
+}
+
+#[test]
+fn provider_delivery_runtime_authority_currentness_does_not_require_subject_evidence() {
+    let source = include_str!("../migrations/0073_provider_delivery_runtime_authority_current.sql");
+    for required in [
+        "automata_github_runtime_authority_base_is_current",
+        "origin.origin_kind = ''provider_delivery''",
+        "admission_receipt.github_subject_evidence_required",
+    ] {
+        assert!(
+            source.contains(required),
+            "currentness repair lost: {required}"
         );
     }
 }

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -289,6 +289,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0071_provider_delivery_preparation_provenance.sql",
         "037a2b0a9219ce44a72dbbde9bc5f49f268a7ef94b1d0706126e1aeab5cdc056c9eb3e70686ee28d2c6b0abdccd16516",
     ),
+    (
+        "0072_provider_delivery_runtime_provenance.sql",
+        "9d7afe44c0c0584f898acc1bfac98493517976c9e0b70b5d8813dfe6aa8681192b301635789e7ce1b37e421cb2ef1988",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -285,6 +285,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0070_provider_admission_idempotency_key.sql",
         "0526cf85598c894b8b08216a9db0ef92b5e58116f1db690ddb2582249453d1a050f68d130ee356e80d7d5f5f8440d87a",
     ),
+    (
+        "0071_provider_delivery_preparation_provenance.sql",
+        "037a2b0a9219ce44a72dbbde9bc5f49f268a7ef94b1d0706126e1aeab5cdc056c9eb3e70686ee28d2c6b0abdccd16516",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -281,6 +281,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0069_provider_instance_webhook_endpoints.sql",
         "b47bdc4fd116ceca54490f5ed7ab4ecb07122dd62ea50cf893749218b2066f654d58b6ff6c3da081ac6f2da860e4ac4a",
     ),
+    (
+        "0070_provider_admission_idempotency_key.sql",
+        "0526cf85598c894b8b08216a9db0ef92b5e58116f1db690ddb2582249453d1a050f68d130ee356e80d7d5f5f8440d87a",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;

--- a/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
+++ b/crates/automata-ci-store-postgres/src/migration_layout_tests.rs
@@ -297,6 +297,10 @@ const CANONICAL_MIGRATIONS: &[(&str, &str)] = &[
         "0073_provider_delivery_runtime_authority_current.sql",
         "f1444ab4d4ed0fd9b96b000b706092340a7d961f188709fd06a22812e4bae2ad456391a1da82a0a9f65e4365261d1e62",
     ),
+    (
+        "0074_provider_handoff_consumer_guard.sql",
+        "cc8e6393ec556f8e209a06b19f0333b97729a1dbd85509debc1b04a374eb6f3ff1c707709e3fb2c0a0326d81d637d4df",
+    ),
 ];
 
 const BASELINE_MIGRATION_COUNT: u32 = 26;
@@ -969,6 +973,39 @@ fn provider_result_outbox_is_current_only_provider_neutral_and_fenced() {
         assert!(
             !source.contains(forbidden),
             "provider result outbox retained provider-specific or legacy surface: {forbidden}",
+        );
+    }
+}
+
+#[test]
+fn github_service_handoffs_revalidate_current_provider_consumers() {
+    let source = include_str!("../migrations/0074_provider_handoff_consumer_guard.sql");
+
+    for required in [
+        "FROM provider_result_outbox AS outbox",
+        "JOIN provider_result_subjects AS subject",
+        "outbox.generation = NEW.consumer_revision",
+        "outbox.claim_worker_id = NEW.consumer_owner_id",
+        "outbox.claim_fence = NEW.consumer_claim_fence",
+        "FROM provider_processing_invocations AS invocation",
+        "JOIN provider_deliveries AS delivery",
+        "FROM workflow_dispatch_source_resolutions AS resolution",
+        "NEW.consumer_action = 'fetch_pull_request_files'",
+        "delivery.event_type = 'pull_request'",
+    ] {
+        assert!(
+            source.contains(required),
+            "provider handoff guard lost current consumer binding: {required}",
+        );
+    }
+    for superseded in [
+        "github_check_projection_outbox",
+        "github_check_subjects",
+        "provider_delivery_inbox",
+    ] {
+        assert!(
+            !source.contains(superseded),
+            "provider handoff guard retained superseded consumer storage: {superseded}",
         );
     }
 }

--- a/crates/automata-ci-store-postgres/src/protected_environment.rs
+++ b/crates/automata-ci-store-postgres/src/protected_environment.rs
@@ -1622,6 +1622,22 @@ async fn issue_leased_job_secret_grants(
     let reusable_permission: String = gate
         .try_get("reusable_secret_permission")
         .map_err(operation_error)?;
+
+    // Standard jobs may carry an authority profile even when their compiled
+    // plan contains no secret references.  In that case there is no secret
+    // authority to issue, so provider-event provenance is intentionally not
+    // consulted.  Unknown provenance must still reject every non-empty
+    // selection below.
+    let expected_count: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM job_secret_selections WHERE attempt_id = $1")
+            .bind(request.attempt_id().as_uuid())
+            .fetch_one(&mut *transaction)
+            .await
+            .map_err(operation_error)?;
+    if expected_count == 0 {
+        transaction.commit().await.map_err(operation_error)?;
+        return Ok(Vec::new());
+    }
     if !matches!(event_trust.as_str(), "trusted" | "untrusted")
         || !matches!(
             source_kind.as_str(),
@@ -1646,12 +1662,6 @@ async fn issue_leased_job_secret_grants(
             return Err(ProtectedEnvironmentStoreError::AuthorityRejected);
         }
     }
-    let expected_count: i64 =
-        sqlx::query_scalar("SELECT count(*) FROM job_secret_selections WHERE attempt_id = $1")
-            .bind(request.attempt_id().as_uuid())
-            .fetch_one(&mut *transaction)
-            .await
-            .map_err(operation_error)?;
     if !secret_selection_permission_allows_issue(
         &invocation_kind,
         &reusable_permission,

--- a/crates/automata-ci-store-postgres/src/runtime_authority.rs
+++ b/crates/automata-ci-store-postgres/src/runtime_authority.rs
@@ -4643,6 +4643,15 @@ fn fencing_i64(value: FencingToken) -> i64 {
 }
 
 fn operation_error(error: sqlx::Error) -> GithubRuntimeAuthorityStoreError {
+    let code = error
+        .as_database_error()
+        .and_then(sqlx::error::DatabaseError::code)
+        .map(|value| value.into_owned());
+    let constraint = error
+        .as_database_error()
+        .and_then(sqlx::error::DatabaseError::constraint)
+        .map(str::to_owned);
+    tracing::error!(code = ?code, constraint = ?constraint, "GitHub runtime-authority database operation failed");
     GithubRuntimeAuthorityStoreError::operation(error)
 }
 

--- a/crates/automata-ci-store-postgres/src/runtime_authority.rs
+++ b/crates/automata-ci-store-postgres/src/runtime_authority.rs
@@ -3264,7 +3264,6 @@ async fn lock_exact_authority_graph(
          AND admission.repository_id = origin.repository_id
          AND admission.run_id = origin.run_id
          AND admission.committed_at_ms = origin.admitted_at_ms
-         AND admission.github_subject_evidence_required
         JOIN github_provider_manifest_revisions AS manifest
           ON manifest.tenant_id = origin.tenant_id
          AND manifest.repository_id = origin.repository_id

--- a/crates/automata-ci-store-postgres/src/runtime_authority.rs
+++ b/crates/automata-ci-store-postgres/src/runtime_authority.rs
@@ -4646,7 +4646,7 @@ fn operation_error(error: sqlx::Error) -> GithubRuntimeAuthorityStoreError {
     let code = error
         .as_database_error()
         .and_then(sqlx::error::DatabaseError::code)
-        .map(|value| value.into_owned());
+        .map(std::borrow::Cow::into_owned);
     let constraint = error
         .as_database_error()
         .and_then(sqlx::error::DatabaseError::constraint)

--- a/crates/automata-ci-store-postgres/src/workload_oidc.rs
+++ b/crates/automata-ci-store-postgres/src/workload_oidc.rs
@@ -747,7 +747,6 @@ async fn lock_current_execution(
          AND admission_receipt.repository_id = origin.repository_id
          AND admission_receipt.run_id = origin.run_id
          AND admission_receipt.committed_at_ms = origin.admitted_at_ms
-         AND admission_receipt.github_subject_evidence_required
         JOIN github_provider_manifest_revisions AS manifest
           ON manifest.tenant_id = origin.tenant_id
          AND manifest.repository_id = origin.repository_id

--- a/crates/automata-ci-store/src/logical_orchestration.rs
+++ b/crates/automata-ci-store/src/logical_orchestration.rs
@@ -900,6 +900,7 @@ pub struct AdmitLogicalWorkflowRun {
     root_invocation_id: LogicalWorkflowInvocationId,
     event_name: String,
     event: AdmissionObject,
+    raw_event_digest: Option<Sha256Digest>,
     head_sha: GitObjectId,
     actor: Option<String>,
     display_title: Option<String>,
@@ -961,6 +962,7 @@ impl AdmitLogicalWorkflowRun {
                 root_invocation_id,
                 event_name: event_name.into(),
                 event,
+                raw_event_digest: None,
                 head_sha,
                 actor: None,
                 display_title: None,
@@ -1081,6 +1083,13 @@ impl AdmitLogicalWorkflowRun {
         &self.event
     }
 
+    /// Returns the exact authenticated provider webhook body digest, when the
+    /// admission was created from a provider delivery.
+    #[must_use]
+    pub const fn raw_event_digest(&self) -> Option<Sha256Digest> {
+        self.raw_event_digest
+    }
+
     /// Returns the immutable head commit digest bytes.
     #[must_use]
     pub const fn head_sha(&self) -> GitObjectId {
@@ -1135,6 +1144,13 @@ impl AdmitLogicalWorkflowRunBuilder {
     #[must_use]
     pub fn trust_snapshot(mut self, trust_snapshot: TrustSnapshot) -> Self {
         self.command.trust_snapshot = trust_snapshot;
+        self
+    }
+
+    /// Binds the raw webhook digest separately from canonical event bytes.
+    #[must_use]
+    pub fn raw_event_digest(mut self, digest: Option<Sha256Digest>) -> Self {
+        self.command.raw_event_digest = digest;
         self
     }
 

--- a/crates/automata-ci-store/src/logical_work_selection.rs
+++ b/crates/automata-ci-store/src/logical_work_selection.rs
@@ -129,6 +129,26 @@ impl ClaimNextLogicalJobOrchestration {
     pub const fn duration_ms(&self) -> i64 {
         self.duration_ms
     }
+
+    /// Rebinds the caller timestamp immediately before a store attempt.
+    ///
+    /// Selection custody owns the stable identity; the timestamp is an
+    /// attempt-local admission observation and must not age while custody or
+    /// the database pool is contended.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same validation error as [`Self::new`] for an invalid
+    /// timestamp or duration.
+    pub fn with_observed_at(
+        &self,
+        observed_at: UnixMillis,
+    ) -> Result<Self, LogicalWorkSelectionValueError> {
+        validate_request(observed_at, self.duration_ms)?;
+        let mut request = self.clone();
+        request.observed_at = observed_at;
+        Ok(request)
+    }
 }
 
 /// Kind of inert orchestration discovery evidence recorded by the selector.
@@ -297,6 +317,26 @@ impl ClaimNextLogicalInstanceMaterialization {
     #[must_use]
     pub const fn duration_ms(&self) -> i64 {
         self.duration_ms
+    }
+
+    /// Rebinds the caller timestamp immediately before a store attempt.
+    ///
+    /// Selection custody owns the stable identity; the timestamp is an
+    /// attempt-local admission observation and must not age while custody or
+    /// the database pool is contended.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same validation error as [`Self::new`] for an invalid
+    /// timestamp or duration.
+    pub fn with_observed_at(
+        &self,
+        observed_at: UnixMillis,
+    ) -> Result<Self, LogicalWorkSelectionValueError> {
+        validate_request(observed_at, self.duration_ms)?;
+        let mut request = self.clone();
+        request.observed_at = observed_at;
+        Ok(request)
     }
 }
 

--- a/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
+++ b/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
@@ -3431,13 +3431,18 @@ impl AutonomousWorkflowService {
         submitted: bool,
     ) -> Result<QueuePoll, AutonomousWorkflowError> {
         let submission = async {
+            let now = trusted_now(self.clock.as_ref())
+                .map_err(|_| AutonomousWorkflowLeaseError::AuthorityRejected)?;
+            let store_request = request
+                .with_observed_at(now)
+                .map_err(|_| AutonomousWorkflowLeaseError::AuthorityRejected)?;
             if !submitted {
                 self.custody
                     .mark_orchestration_selection_submitted(&request)?;
             }
             Ok::<_, AutonomousWorkflowLeaseError>(
                 self.selections
-                    .claim_next_logical_job_orchestration(request.clone())
+                    .claim_next_logical_job_orchestration(store_request)
                     .await,
             )
         };
@@ -3457,7 +3462,10 @@ impl AutonomousWorkflowService {
             }
             Err(error) => {
                 self.custody.set_orchestration(OrchestrationCustody::Idle);
-                return selection_failure(&error, AutonomousWorkflowQueue::Orchestration);
+                return Ok(selection_failure(
+                    &error,
+                    AutonomousWorkflowQueue::Orchestration,
+                ));
             }
             Ok(LogicalJobOrchestrationSelectionOutcome::Idle) => {
                 self.custody.set_orchestration(OrchestrationCustody::Idle);
@@ -3875,13 +3883,18 @@ impl AutonomousWorkflowService {
         submitted: bool,
     ) -> Result<QueuePoll, AutonomousWorkflowError> {
         let submission = async {
+            let now = trusted_now(self.clock.as_ref())
+                .map_err(|_| AutonomousWorkflowLeaseError::AuthorityRejected)?;
+            let store_request = request
+                .with_observed_at(now)
+                .map_err(|_| AutonomousWorkflowLeaseError::AuthorityRejected)?;
             if !submitted {
                 self.custody
                     .mark_materialization_selection_submitted(&request)?;
             }
             Ok::<_, AutonomousWorkflowLeaseError>(
                 self.selections
-                    .claim_next_logical_instance_materialization(request.clone())
+                    .claim_next_logical_instance_materialization(store_request)
                     .await,
             )
         };
@@ -3906,7 +3919,10 @@ impl AutonomousWorkflowService {
             Err(error) => {
                 self.custody
                     .set_materialization(MaterializationCustody::Idle);
-                return selection_failure(&error, AutonomousWorkflowQueue::Materialization);
+                return Ok(selection_failure(
+                    &error,
+                    AutonomousWorkflowQueue::Materialization,
+                ));
             }
             Ok(LogicalInstanceMaterializationSelectionOutcome::Idle) => {
                 self.custody
@@ -4324,16 +4340,14 @@ fn unavailable_or_shutdown(
 fn selection_failure(
     error: &automata_ci_store::LogicalWorkSelectionStoreError,
     queue: AutonomousWorkflowQueue,
-) -> Result<QueuePoll, AutonomousWorkflowError> {
+) -> QueuePoll {
     // Selection is a read/claim poll.  A rejected or malformed candidate must
     // not terminate the control plane: the transaction has rolled back and the
     // next bounded poll can re-read the authoritative graph after maintenance
     // or a concurrent worker has advanced it.  Fatal authority errors remain
     // enforced at consume/finalization boundaries, after a durable claim exists.
     tracing::warn!(%error, ?queue, "logical work selection failed; retrying bounded poll");
-    Ok(QueuePoll::Outcome(AutonomousWorkflowOutcome::Unavailable(
-        queue,
-    )))
+    QueuePoll::Outcome(AutonomousWorkflowOutcome::Unavailable(queue))
 }
 
 fn selection_submission_failure(

--- a/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
+++ b/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
@@ -3443,7 +3443,10 @@ impl AutonomousWorkflowService {
         };
         let outcome = match await_custody(shutdown, submission).await {
             Ok(Ok(outcome)) => outcome,
-            Ok(Err(_)) => return Err(AutonomousWorkflowError::AuthorityRejected),
+            Ok(Err(error)) => {
+                self.custody.set_orchestration(OrchestrationCustody::Idle);
+                return selection_submission_failure(error, AutonomousWorkflowQueue::Orchestration);
+            }
             Err(error) => {
                 return unavailable_or_shutdown(error, AutonomousWorkflowQueue::Orchestration);
             }
@@ -3884,7 +3887,14 @@ impl AutonomousWorkflowService {
         };
         let outcome = match await_custody(shutdown, submission).await {
             Ok(Ok(outcome)) => outcome,
-            Ok(Err(_)) => return Err(AutonomousWorkflowError::AuthorityRejected),
+            Ok(Err(error)) => {
+                self.custody
+                    .set_materialization(MaterializationCustody::Idle);
+                return selection_submission_failure(
+                    error,
+                    AutonomousWorkflowQueue::Materialization,
+                );
+            }
             Err(error) => {
                 return unavailable_or_shutdown(error, AutonomousWorkflowQueue::Materialization);
             }
@@ -4312,15 +4322,28 @@ fn unavailable_or_shutdown(
 }
 
 fn selection_failure(
-    error: &automata_ci_store::LogicalWorkSelectionStoreError,
+    _error: &automata_ci_store::LogicalWorkSelectionStoreError,
     queue: AutonomousWorkflowQueue,
 ) -> Result<QueuePoll, AutonomousWorkflowError> {
-    if is_repository_unavailable(error) {
-        Ok(QueuePoll::Outcome(AutonomousWorkflowOutcome::Unavailable(
-            queue,
-        )))
-    } else {
-        Err(AutonomousWorkflowError::AuthorityRejected)
+    // Selection is a read/claim poll.  A rejected or malformed candidate must
+    // not terminate the control plane: the transaction has rolled back and the
+    // next bounded poll can re-read the authoritative graph after maintenance
+    // or a concurrent worker has advanced it.  Fatal authority errors remain
+    // enforced at consume/finalization boundaries, after a durable claim exists.
+    Ok(QueuePoll::Outcome(AutonomousWorkflowOutcome::Unavailable(
+        queue,
+    )))
+}
+
+fn selection_submission_failure(
+    error: AutonomousWorkflowLeaseError,
+    queue: AutonomousWorkflowQueue,
+) -> Result<QueuePoll, AutonomousWorkflowError> {
+    match error {
+        AutonomousWorkflowLeaseError::Shutdown => Err(AutonomousWorkflowError::Shutdown),
+        AutonomousWorkflowLeaseError::DeadlineElapsed
+        | AutonomousWorkflowLeaseError::Unavailable
+        | AutonomousWorkflowLeaseError::AuthorityRejected => Ok(unavailable_poll(queue)),
     }
 }
 

--- a/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
+++ b/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
@@ -3458,7 +3458,12 @@ impl AutonomousWorkflowService {
         };
         let selected = match outcome {
             Err(error) if is_repository_unavailable(&error) => {
-                tracing::warn!(%error, queue = ?AutonomousWorkflowQueue::Orchestration, "logical work selection unavailable; retrying bounded poll");
+                tracing::warn!(
+                    %error,
+                    error_chain = %error_source_chain(&error),
+                    queue = ?AutonomousWorkflowQueue::Orchestration,
+                    "logical work selection unavailable; retrying bounded poll"
+                );
                 return Ok(unavailable_poll(AutonomousWorkflowQueue::Orchestration));
             }
             Err(error) => {
@@ -3915,7 +3920,12 @@ impl AutonomousWorkflowService {
         };
         let selected = match outcome {
             Err(error) if is_repository_unavailable(&error) => {
-                tracing::warn!(%error, queue = ?AutonomousWorkflowQueue::Materialization, "logical work selection unavailable; retrying bounded poll");
+                tracing::warn!(
+                    %error,
+                    error_chain = %error_source_chain(&error),
+                    queue = ?AutonomousWorkflowQueue::Materialization,
+                    "logical work selection unavailable; retrying bounded poll"
+                );
                 return Ok(unavailable_poll(AutonomousWorkflowQueue::Materialization));
             }
             Err(error) => {
@@ -4416,6 +4426,22 @@ fn is_repository_unavailable(error: &automata_ci_store::LogicalWorkSelectionStor
         error,
         automata_ci_store::LogicalWorkSelectionStoreError::Store(StoreError::Operation(_))
     )
+}
+
+/// Formats the trusted repository error source chain without changing the
+/// stable, sanitized top-level error message exposed to callers.
+fn error_source_chain(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut chain = Vec::new();
+    let mut source = error.source();
+    while let Some(current) = source {
+        chain.push(current.to_string());
+        source = current.source();
+    }
+    if chain.is_empty() {
+        String::from("none")
+    } else {
+        chain.join(" -> ")
+    }
 }
 
 #[cfg(test)]

--- a/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
+++ b/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
@@ -4322,7 +4322,7 @@ fn unavailable_or_shutdown(
 }
 
 fn selection_failure(
-    _error: &automata_ci_store::LogicalWorkSelectionStoreError,
+    error: &automata_ci_store::LogicalWorkSelectionStoreError,
     queue: AutonomousWorkflowQueue,
 ) -> Result<QueuePoll, AutonomousWorkflowError> {
     // Selection is a read/claim poll.  A rejected or malformed candidate must
@@ -4330,6 +4330,7 @@ fn selection_failure(
     // next bounded poll can re-read the authoritative graph after maintenance
     // or a concurrent worker has advanced it.  Fatal authority errors remain
     // enforced at consume/finalization boundaries, after a durable claim exists.
+    tracing::warn!(%error, ?queue, "logical work selection failed; retrying bounded poll");
     Ok(QueuePoll::Outcome(AutonomousWorkflowOutcome::Unavailable(
         queue,
     )))
@@ -4339,6 +4340,7 @@ fn selection_submission_failure(
     error: AutonomousWorkflowLeaseError,
     queue: AutonomousWorkflowQueue,
 ) -> Result<QueuePoll, AutonomousWorkflowError> {
+    tracing::warn!(%error, ?queue, "logical work selection submission failed; retrying bounded poll");
     match error {
         AutonomousWorkflowLeaseError::Shutdown => Err(AutonomousWorkflowError::Shutdown),
         AutonomousWorkflowLeaseError::DeadlineElapsed

--- a/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
+++ b/crates/automata-ci-workflow-service/src/autonomous_workflow.rs
@@ -3458,6 +3458,7 @@ impl AutonomousWorkflowService {
         };
         let selected = match outcome {
             Err(error) if is_repository_unavailable(&error) => {
+                tracing::warn!(%error, queue = ?AutonomousWorkflowQueue::Orchestration, "logical work selection unavailable; retrying bounded poll");
                 return Ok(unavailable_poll(AutonomousWorkflowQueue::Orchestration));
             }
             Err(error) => {
@@ -3914,6 +3915,7 @@ impl AutonomousWorkflowService {
         };
         let selected = match outcome {
             Err(error) if is_repository_unavailable(&error) => {
+                tracing::warn!(%error, queue = ?AutonomousWorkflowQueue::Materialization, "logical work selection unavailable; retrying bounded poll");
                 return Ok(unavailable_poll(AutonomousWorkflowQueue::Materialization));
             }
             Err(error) => {

--- a/crates/automata-ci-workflow-service/src/model.rs
+++ b/crates/automata-ci-workflow-service/src/model.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use automata_ci_core::{
-    GitObjectId, JobRuntimeContext, TrustSnapshot, WorkflowPlan, WorkflowPlanVersion,
+    GitObjectId, JobRuntimeContext, Sha256Digest, TrustSnapshot, WorkflowPlan, WorkflowPlanVersion,
 };
 use automata_ci_store::{
     LogicalWorkflowAdmissionReceipt, MAX_ADMISSION_EVENT_BYTES, MAX_ADMISSION_OBJECT_BYTES,
@@ -149,6 +149,7 @@ pub struct WorkflowAdmissionRequest {
     workflow_path: String,
     source: Bytes,
     event: Bytes,
+    raw_event_digest: Option<Sha256Digest>,
     event_media_type: String,
     plan: WorkflowPlan,
     base_context: JobRuntimeContext,
@@ -192,6 +193,7 @@ impl WorkflowAdmissionRequest {
                 workflow_path: workflow_path.into(),
                 source,
                 event,
+                raw_event_digest: None,
                 event_media_type: WORKFLOW_EVENT_MEDIA_TYPE.to_owned(),
                 plan,
                 base_context,
@@ -237,6 +239,13 @@ impl WorkflowAdmissionRequest {
     /// Returns the exact immutable provider event bytes.
     pub const fn event(&self) -> &Bytes {
         &self.event
+    }
+
+    /// Returns the exact authenticated provider webhook body digest, when the
+    /// request originated from a provider delivery.
+    #[must_use]
+    pub const fn raw_event_digest(&self) -> Option<Sha256Digest> {
+        self.raw_event_digest
     }
 
     /// Returns the immutable event evidence media type.
@@ -342,6 +351,13 @@ impl WorkflowAdmissionRequestBuilder {
     #[must_use]
     pub fn event_media_type(mut self, media_type: impl Into<String>) -> Self {
         self.request.event_media_type = media_type.into();
+        self
+    }
+
+    /// Binds the raw webhook digest separately from canonical event bytes.
+    #[must_use]
+    pub fn raw_event_digest(mut self, digest: Sha256Digest) -> Self {
+        self.request.raw_event_digest = Some(digest);
         self
     }
 

--- a/crates/automata-ci-workflow-service/src/provider_trigger.rs
+++ b/crates/automata-ci-workflow-service/src/provider_trigger.rs
@@ -165,6 +165,7 @@ impl ProviderWorkflowApplicationService {
     /// Returns a sanitized application error for invalid archive/evidence,
     /// request construction, unavailable admission infrastructure, or a
     /// contradictory durable admission.
+    #[allow(clippy::too_many_lines)] // The two-pass application proof stays atomic.
     pub async fn apply(
         &self,
         request: ProviderWorkflowApplicationRequest,

--- a/crates/automata-ci-workflow-service/src/provider_trigger.rs
+++ b/crates/automata-ci-workflow-service/src/provider_trigger.rs
@@ -603,6 +603,7 @@ fn admission_request(
         idempotency,
         *request.source.revision(),
     )
+    .raw_event_digest(request.delivery.evidence().raw_body().digest())
     .trust_snapshot(request.trust.clone())
     .git_ref(request.execution_ref.full())
     .workflow_name(workflow_name)

--- a/crates/automata-ci-workflow-service/src/provider_trigger.rs
+++ b/crates/automata-ci-workflow-service/src/provider_trigger.rs
@@ -226,7 +226,16 @@ impl ProviderWorkflowApplicationService {
                         )) => ProviderWorkflowDisposition::Rejected(
                             ProviderWorkflowRejection::RunNumberExhausted,
                         ),
-                        Err(error) => return Err(admission_error(&error)),
+                        Err(error) => {
+                            let mapped = admission_error(&error);
+                            tracing::warn!(
+                                workflow_path = %workflow.path,
+                                ?error,
+                                ?mapped,
+                                "provider workflow admission failed"
+                            );
+                            return Err(mapped);
+                        }
                     }
                 }
                 CompilationDisposition::NotSelected(reason) => {
@@ -252,10 +261,15 @@ impl ProviderWorkflowApplicationService {
                 created_at,
                 outcome,
             )?;
-            self.results
-                .project_invocation(result_request)
-                .await
-                .map_err(provider_result_error)?;
+            if let Err(error) = self.results.project_invocation(result_request).await {
+                let mapped = provider_result_error(error);
+                tracing::warn!(
+                    workflow_path = %workflow.path,
+                    ?mapped,
+                    "provider workflow result projection failed"
+                );
+                return Err(mapped);
+            }
             results.push(ProviderWorkflowApplicationReport {
                 path: workflow.path,
                 disposition: outcome,

--- a/crates/automata-ci-workflow-service/src/service.rs
+++ b/crates/automata-ci-workflow-service/src/service.rs
@@ -725,6 +725,7 @@ fn build_command(
         jobs,
         admitted_at,
     )
+    .raw_event_digest(request.raw_event_digest())
     .base_context(base_context.metadata.clone())
     .trust_snapshot(request.trust_snapshot().clone())
     .concurrency(concurrency)

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -1062,7 +1062,11 @@ fn build_provider_runtime(
     let result_adapters = ProviderResultAdapterRegistry::new([github.result_adapter()])
         .map_err(|_| ServerCompositionError::InvalidGithubProviderConfiguration)?;
     let contexts = ProviderRuntimeContextResolver::new(manifests);
-    let result_config = ProviderResultWorkerConfig::new(60_000, 1_000)
+    // Result publication crosses the provider handoff and can contend with
+    // runner/admission transactions. Keep the claim live long enough for the
+    // bounded durable handoff while remaining below the provider model's
+    // fifteen-minute claim ceiling.
+    let result_config = ProviderResultWorkerConfig::new(5 * 60_000, 1_000)
         .map_err(|_| ServerCompositionError::InvalidGithubProviderConfiguration)?;
     let result_workers = github
         .connection_ids()

--- a/crates/automata-ci/src/server/composition.rs
+++ b/crates/automata-ci/src/server/composition.rs
@@ -1062,12 +1062,14 @@ fn build_provider_runtime(
     let result_adapters = ProviderResultAdapterRegistry::new([github.result_adapter()])
         .map_err(|_| ServerCompositionError::InvalidGithubProviderConfiguration)?;
     let contexts = ProviderRuntimeContextResolver::new(manifests);
-    // Result publication crosses the provider handoff and can contend with
-    // runner/admission transactions. Keep the claim live long enough for the
-    // bounded durable handoff while remaining below the provider model's
-    // fifteen-minute claim ceiling.
-    let result_config = ProviderResultWorkerConfig::new(5 * 60_000, 1_000)
-        .map_err(|_| ServerCompositionError::InvalidGithubProviderConfiguration)?;
+    // Result publication resolves durable workflow context before opening the
+    // provider handoff. Use the model's full bounded lease so database
+    // contention cannot consume the claim before credential acquisition.
+    let result_config = ProviderResultWorkerConfig::new(
+        automata_ci_provider::MAX_PROVIDER_RESULT_LEASE_MILLIS,
+        1_000,
+    )
+    .map_err(|_| ServerCompositionError::InvalidGithubProviderConfiguration)?;
     let result_workers = github
         .connection_ids()
         .iter()

--- a/crates/automata-ci/src/server/github_provider_credentials.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials.rs
@@ -1068,6 +1068,7 @@ fn map_handoff_error(
     error: &GithubServerServiceHandoffError,
 ) -> GithubProviderCredentialHandoffError {
     match error {
+        GithubServerServiceHandoffError::Rejected => GithubProviderCredentialHandoffError::Rejected,
         GithubServerServiceHandoffError::Repository
         | GithubServerServiceHandoffError::Unavailable => {
             GithubProviderCredentialHandoffError::Unavailable

--- a/crates/automata-ci/src/server/github_provider_credentials.rs
+++ b/crates/automata-ci/src/server/github_provider_credentials.rs
@@ -1328,7 +1328,7 @@ impl GithubProviderCredentialAdapters {
         &self,
         request: GithubResultCredentialRequest<'_>,
     ) -> Result<GithubResultCredential, GithubResultCredentialProviderError> {
-        let (selector, repository) = self
+        let (selector, repository) = match self
             .operation_authority(
                 request.context(),
                 request.claimed().subject().repository().external_id(),
@@ -1338,7 +1338,18 @@ impl GithubProviderCredentialAdapters {
                 GithubServerServiceScope::ChecksWrite,
             )
             .await
-            .map_err(common_result_handoff_error)?;
+        {
+            Ok(authority) => authority,
+            Err(error) => {
+                tracing::warn!(
+                    stage = "authority_resolution",
+                    operation = ?request.operation(),
+                    reason = ?error,
+                    "GitHub result credential acquisition failed"
+                );
+                return Err(common_result_handoff_error(error));
+            }
+        };
         let consumer = common_result_consumer(&request)?;
         let observed_at = self
             .observation_clock
@@ -1352,11 +1363,18 @@ impl GithubProviderCredentialAdapters {
             request.required_through(),
         )
         .map_err(common_result_handoff_error)?;
-        let handoff = self
-            .handoffs
-            .acquire(handoff_request)
-            .await
-            .map_err(common_result_handoff_error)?;
+        let handoff = match self.handoffs.acquire(handoff_request).await {
+            Ok(handoff) => handoff,
+            Err(error) => {
+                tracing::warn!(
+                    stage = "durable_handoff",
+                    operation = ?request.operation(),
+                    reason = ?error,
+                    "GitHub result credential acquisition failed"
+                );
+                return Err(common_result_handoff_error(error));
+            }
+        };
         if handoff.selector != selector
             || handoff.consumer != consumer
             || handoff.key.authority_id() != selector.authority_id()

--- a/crates/automata-ci/src/server/mod.rs
+++ b/crates/automata-ci/src/server/mod.rs
@@ -216,6 +216,7 @@ pub async fn serve(args: &ServerArgs) -> Result<()> {
         .provider_runtime
         .as_ref()
         .map(ProviderRuntime::ingress);
+    let provider_webhook_ingress_enabled = provider_ingress.is_some();
     let router = match http::router_with_readiness_web_data(
         readiness.clone(),
         components.web_data.clone(),
@@ -268,6 +269,7 @@ pub async fn serve(args: &ServerArgs) -> Result<()> {
         results_address = %results_address,
         metrics_address = ?metrics_address,
         results_public_url = %config.results_public_endpoint.url(),
+        provider_webhook_ingress_enabled,
         version = build.version,
         commit = build.commit,
         "control plane listening"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -177,13 +177,13 @@ Work from a clean branch based on `main`.
    `vX.Y.Z` release link.
 4. Run the local rehearsal and the normal test suite.
 5. Merge through the repository's merge queue and wait for
-   `Automata CI / required` to succeed on the resulting commit.
+   `Automata CI / .ci/workflows/ci.yml` to succeed on the resulting commit.
 
 Before any mutation, the release gate requires the tagged commit to be in
 `main` and queries GitHub for one latest Check with all of these properties:
 
 - App ID `4558711`, slug `automata-ci`, and organization owner `automata-ci`;
-- check name `Automata CI / required`;
+- check name `Automata CI / .ci/workflows/ci.yml`;
 - the exact tagged commit and a successful terminal conclusion;
 - an `automata-check:<UUID>` external identity; and
 - the `https://ci.automata-ci.com/automata-ci/automata/actions` dashboard path.

--- a/scripts/ci/tests/release-native.test.py
+++ b/scripts/ci/tests/release-native.test.py
@@ -18,7 +18,7 @@ required = (
     "name: Release\n",
     'tags:\n      - "v*"',
     "python3 scripts/ci/verify-release-authority.py",
-    "check_name=Automata CI / required",
+    "check_name=Automata CI / .ci/workflows/ci.yml",
     "AUTOMATA_SCRATCH_RUNTIME=none",
     "AUTOMATA_SERVICE_PROXY_OCI_BUILDER: buildah-chroot",
     "AUTOMATA_SERVICE_PROXY_PROCESS_PROBE: metadata-only",

--- a/scripts/ci/tests/verify-release-authority.test.py
+++ b/scripts/ci/tests/verify-release-authority.test.py
@@ -24,7 +24,7 @@ def documents() -> tuple[dict, dict]:
         "total_count": 1,
         "check_runs": [
             {
-                "name": "Automata CI / required",
+                "name": "Automata CI / .ci/workflows/ci.yml",
                 "head_sha": COMMIT,
                 "status": "completed",
                 "conclusion": "success",

--- a/scripts/ci/verify-release-authority.py
+++ b/scripts/ci/verify-release-authority.py
@@ -13,7 +13,7 @@ import urllib.parse
 APP_ID = 4_558_711
 APP_OWNER = "automata-ci"
 APP_SLUG = "automata-ci"
-CHECK_NAME = "Automata CI / required"
+CHECK_NAME = "Automata CI / .ci/workflows/ci.yml"
 DASHBOARD_ORIGIN = "https://ci.automata-ci.com"
 EXTERNAL_ID = re.compile(
     r"automata-check:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"


### PR DESCRIPTION
## Summary
- bind GitHub result handoffs to the current provider-neutral result and delivery claims
- keep runtime authority and provider-delivery provenance current across the workflow path
- expose rejection stages and preserve bounded, fenced recovery behavior
- align release authority checks and documentation with the live workflow check identity

This is the production hotfix lineage that restored the merge queue and was deployed as release `4ab1ba6092bdc0841177a68591dd4daaa0f7d8c2`.

## Verification
- `cargo fmt --all -- --check`
- focused store migration contract tests
- production migration 0074 syntax validation in a rolled-back transaction
- `python3 scripts/ci/tests/release-native.test.py`
- `python3 scripts/ci/tests/verify-release-authority.test.py`
- merge-group CI for PR #393 passed frontend, Rust, and PostgreSQL
