### PR TITLE
fix: preserve pull request execution revision

### DIFF
--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -1729,9 +1729,13 @@ fn provider_trigger_matches_command(
         NormalizedTrigger::RepositoryDispatch(value) => value.actor(),
     }
     .map(|actor| actor.external_id().as_str());
-    let source_matches = trigger
-        .workflow_source_revision()
-        .is_none_or(|revision| revision == command.head_sha());
+    let source_matches = trigger.workflow_source_revision().is_none_or(|revision| {
+        command
+            .trust_snapshot()
+            .evidence()
+            .source_revision()
+            .is_some_and(|source_revision| source_revision == revision.to_string())
+    });
     let reference_matches = trigger.workflow_execution_ref().map_or_else(
         || command.git_ref() == format!("refs/heads/{default_branch}"),
         |git_ref| git_ref.full() == command.git_ref(),

--- a/crates/automata-ci-store-postgres/src/logical_orchestration.rs
+++ b/crates/automata-ci-store-postgres/src/logical_orchestration.rs
@@ -1729,13 +1729,9 @@ fn provider_trigger_matches_command(
         NormalizedTrigger::RepositoryDispatch(value) => value.actor(),
     }
     .map(|actor| actor.external_id().as_str());
-    let source_matches = trigger.workflow_source_revision().is_none_or(|revision| {
-        command
-            .trust_snapshot()
-            .evidence()
-            .source_revision()
-            .is_some_and(|source_revision| source_revision == revision.to_string())
-    });
+    let source_matches = trigger
+        .workflow_source_revision()
+        .is_none_or(|revision| revision == command.head_sha());
     let reference_matches = trigger.workflow_execution_ref().map_or_else(
         || command.git_ref() == format!("refs/heads/{default_branch}"),
         |git_ref| git_ref.full() == command.git_ref(),

--- a/crates/automata-ci-store/src/logical_orchestration.rs
+++ b/crates/automata-ci-store/src/logical_orchestration.rs
@@ -1241,11 +1241,11 @@ impl AdmitLogicalWorkflowRunBuilder {
         }
         if !command.trust_snapshot.is_construction_placeholder() {
             let evidence = command.trust_snapshot.evidence();
-            let execution_revision = command.head_sha.to_string();
+            let source_revision = command.head_sha.to_string();
             if evidence.target_repository().is_none_or(|repository| {
                 repository.id() != command.repository.provider_repository_id()
             }) || evidence.execution_ref() != Some(command.git_ref.as_str())
-                || evidence.execution_revision() != Some(execution_revision.as_str())
+                || evidence.source_revision() != Some(source_revision.as_str())
             {
                 return Err(LogicalWorkflowAdmissionValueError::InvalidTrustSnapshot);
             }

--- a/crates/automata-ci-store/tests/logical_orchestration_api.rs
+++ b/crates/automata-ci-store/tests/logical_orchestration_api.rs
@@ -145,7 +145,7 @@ fn trust_snapshot_with_revisions(
 }
 
 #[test]
-fn trust_snapshot_must_bind_the_exact_admitted_execution_origin() {
+fn trust_snapshot_must_bind_the_exact_admitted_source_origin() {
     let build = |snapshot: TrustSnapshot| {
         AdmitLogicalWorkflowRun::builder(
             TenantScope::from_authenticated_tenant_id("logical-tenant").expect("tenant"),
@@ -186,6 +186,16 @@ fn trust_snapshot_must_bind_the_exact_admitted_execution_origin() {
     let revision = "09".repeat(20);
 
     assert!(build(trust_snapshot("repository-7", "refs/heads/main", &revision)).is_ok());
+    assert!(
+        build(trust_snapshot_with_revisions(
+            "repository-7",
+            "refs/heads/main",
+            &revision,
+            &"0a".repeat(20),
+        ))
+        .is_ok(),
+        "the execution revision may differ from the admitted check subject"
+    );
     for conflicting in [
         trust_snapshot("repository-8", "refs/heads/main", &revision),
         trust_snapshot("repository-7", "refs/heads/other", &revision),

--- a/crates/automata-ci-store/tests/logical_orchestration_api.rs
+++ b/crates/automata-ci-store/tests/logical_orchestration_api.rs
@@ -113,6 +113,15 @@ fn command(
 }
 
 fn trust_snapshot(repository_id: &str, git_ref: &str, revision: &str) -> TrustSnapshot {
+    trust_snapshot_with_revisions(repository_id, git_ref, revision, revision)
+}
+
+fn trust_snapshot_with_revisions(
+    repository_id: &str,
+    git_ref: &str,
+    source_revision: &str,
+    execution_revision: &str,
+) -> TrustSnapshot {
     let actor = TrustActorEvidence::new(
         "provider-actor-17",
         TrustActorKind::User,
@@ -128,7 +137,7 @@ fn trust_snapshot(repository_id: &str, git_ref: &str, revision: &str) -> TrustSn
                 .with_triggering_actor(actor)
                 .with_repositories(repository.clone(), repository)
                 .with_refs(git_ref, git_ref, git_ref)
-                .with_revisions(revision, revision, revision)
+                .with_revisions(source_revision, source_revision, execution_revision)
                 .with_fork(false)
                 .with_token_recursion(TrustTokenRecursion::Suppressed),
         )

--- a/crates/automata-ci-workflow-service/src/github_dispatch.rs
+++ b/crates/automata-ci-workflow-service/src/github_dispatch.rs
@@ -650,7 +650,8 @@ impl GithubWorkflowDispatchEvidence {
             && self.document.repository.name == request.repository().name()
             && self.document.workflow.path == request.workflow_path()
             && self.document.workflow.git_ref == request.git_ref()
-            && self.document.workflow.commit_sha == request.commit_sha()
+            && self.document.workflow.commit_sha == request.source_revision()
+            && self.document.workflow.commit_sha == request.execution_revision()
             && matches!(
                 request.idempotency(),
                 WorkflowAdmissionIdempotency::Operation(operation_id)

--- a/crates/automata-ci-workflow-service/src/logical_projection.rs
+++ b/crates/automata-ci-workflow-service/src/logical_projection.rs
@@ -243,7 +243,8 @@ fn project_github_logical_job(
 ) -> Result<ProjectedGithubLogicalJob, LogicalJobProjectionError> {
     let plan = request.job.plan();
     reject_unsupported_semantics(request.job)?;
-    validate_plan_execution(plan, &request.execution)?;
+    let trust_snapshot = required_trust_snapshot(request.trust_snapshot, request.instance)?;
+    validate_plan_execution(plan, &request.execution, trust_snapshot)?;
     if request.instance.identity().logical_job_key() != request.job.key().value().as_str() {
         return Err(LogicalJobProjectionError::InstanceJobMismatch);
     }
@@ -251,7 +252,6 @@ fn project_github_logical_job(
     let LogicalJobKind::Steps(step_job) = request.job.execution() else {
         unreachable!("unsupported reusable jobs were rejected above");
     };
-    let trust_snapshot = required_trust_snapshot(request.trust_snapshot, request.instance)?;
     let runner = request
         .instance
         .runner()
@@ -599,6 +599,7 @@ fn literal_value_template(value: &ValueTemplate) -> Option<&str> {
 fn validate_plan_execution(
     plan: &automata_ci_core::WorkflowPlan,
     execution: &JobExecutionContext,
+    trust_snapshot: &TrustSnapshot,
 ) -> Result<(), LogicalJobProjectionError> {
     if plan.source().provider() != "github" || plan.event().provider() != "github" {
         return Err(LogicalJobProjectionError::ProviderMismatch);
@@ -616,8 +617,11 @@ fn validate_plan_execution(
     let PlanSourceOrigin::Repository { revision, .. } = plan.source().origin() else {
         return Err(LogicalJobProjectionError::NonRepositorySource);
     };
-    if let Some(commit_sha) = plan.event().commit_sha()
-        && commit_sha != *revision
+    let evidence = trust_snapshot.evidence();
+    let source_revision = revision.to_string();
+    let event_revision = plan.event().commit_sha().map(|value| value.to_string());
+    if evidence.source_revision() != Some(source_revision.as_str())
+        || event_revision.as_deref() != evidence.execution_revision()
     {
         return Err(LogicalJobProjectionError::ExecutionProvenanceMismatch);
     }

--- a/crates/automata-ci-workflow-service/src/model.rs
+++ b/crates/automata-ci-workflow-service/src/model.rs
@@ -155,7 +155,8 @@ pub struct WorkflowAdmissionRequest {
     base_context: JobRuntimeContext,
     trust_snapshot: TrustSnapshot,
     idempotency: WorkflowAdmissionIdempotency,
-    commit_sha: GitObjectId,
+    source_revision: GitObjectId,
+    execution_revision: GitObjectId,
     git_ref: String,
     workflow_name: String,
     actor: Option<String>,
@@ -184,7 +185,7 @@ impl WorkflowAdmissionRequest {
         plan: WorkflowPlan,
         base_context: JobRuntimeContext,
         idempotency: WorkflowAdmissionIdempotency,
-        commit_sha: GitObjectId,
+        source_revision: GitObjectId,
     ) -> WorkflowAdmissionRequestBuilder {
         WorkflowAdmissionRequestBuilder {
             request: Self {
@@ -199,7 +200,8 @@ impl WorkflowAdmissionRequest {
                 base_context,
                 trust_snapshot: TrustSnapshot::deny_all_unclassified(),
                 idempotency,
-                commit_sha,
+                source_revision,
+                execution_revision: source_revision,
                 git_ref: String::new(),
                 workflow_name: String::new(),
                 actor: None,
@@ -281,9 +283,18 @@ impl WorkflowAdmissionRequest {
     }
 
     #[must_use]
-    /// Returns the canonical source commit identifier.
-    pub const fn commit_sha(&self) -> GitObjectId {
-        self.commit_sha
+    /// Returns the immutable revision containing the admitted workflow source.
+    pub const fn source_revision(&self) -> GitObjectId {
+        self.source_revision
+    }
+
+    /// Returns the immutable revision executed by the workflow run.
+    ///
+    /// Pull-request events can execute a provider-created merge revision while
+    /// loading the workflow definition from the pull-request head revision.
+    #[must_use]
+    pub const fn execution_revision(&self) -> GitObjectId {
+        self.execution_revision
     }
 
     #[must_use]
@@ -330,6 +341,13 @@ impl WorkflowAdmissionRequest {
 }
 
 impl WorkflowAdmissionRequestBuilder {
+    /// Binds the immutable revision executed by the workflow run.
+    #[must_use]
+    pub const fn execution_revision(mut self, execution_revision: GitObjectId) -> Self {
+        self.request.execution_revision = execution_revision;
+        self
+    }
+
     /// Binds the pure trust-policy result derived from authenticated event facts.
     #[must_use]
     pub fn trust_snapshot(mut self, trust_snapshot: TrustSnapshot) -> Self {
@@ -555,13 +573,13 @@ fn validate_plan_provenance(
     if plan.source().provider() != request.repository.provider()
         || plan.event().provider() != request.repository.provider()
         || repository != expected_repository
-        || *revision != request.commit_sha()
+        || *revision != request.source_revision()
         || path != request.workflow_path()
         || plan.source().source_id() != request.workflow_path()
         || plan
             .event()
             .commit_sha()
-            .is_some_and(|sha| sha != request.commit_sha())
+            .is_some_and(|sha| sha != request.execution_revision())
         || plan
             .event()
             .git_ref()

--- a/crates/automata-ci-workflow-service/src/model.rs
+++ b/crates/automata-ci-workflow-service/src/model.rs
@@ -587,6 +587,19 @@ fn validate_plan_provenance(
     {
         return Err(WorkflowAdmissionRequestError::ProvenanceMismatch);
     }
+    if !request.trust_snapshot().is_construction_placeholder() {
+        let evidence = request.trust_snapshot().evidence();
+        let source_revision = request.source_revision().to_string();
+        let execution_revision = request.execution_revision().to_string();
+        if evidence.target_repository().is_none_or(|repository| {
+            repository.id() != request.repository().provider_repository_id()
+        }) || evidence.execution_ref() != Some(request.git_ref())
+            || evidence.source_revision() != Some(source_revision.as_str())
+            || evidence.execution_revision() != Some(execution_revision.as_str())
+        {
+            return Err(WorkflowAdmissionRequestError::ProvenanceMismatch);
+        }
+    }
     if let WorkflowAdmissionIdempotency::ProviderDelivery(delivery) = request.idempotency()
         && plan.event().delivery_id() != Some(delivery.as_str())
     {

--- a/crates/automata-ci-workflow-service/src/provider_trigger.rs
+++ b/crates/automata-ci-workflow-service/src/provider_trigger.rs
@@ -358,7 +358,7 @@ fn result_coordinates(
     let object = request
         .trust
         .evidence()
-        .execution_revision()
+        .source_revision()
         .ok_or(ProviderWorkflowApplicationError::InvalidEvidence)
         .and_then(|revision| {
             automata_ci_core::GitObjectId::from_provider_hex(revision)

--- a/crates/automata-ci-workflow-service/src/provider_trigger.rs
+++ b/crates/automata-ci-workflow-service/src/provider_trigger.rs
@@ -593,6 +593,9 @@ fn admission_request(
     .map_err(|_| ProviderWorkflowApplicationError::InvalidEvidence)?;
     let event = ActionsProviderEventDocument::from_normalized_trigger(trigger)
         .map_err(|_| ProviderWorkflowApplicationError::InvalidEvidence)?;
+    let execution_revision = trigger
+        .workflow_execution_revision()
+        .unwrap_or(*request.source.revision());
     let mut builder = WorkflowAdmissionRequest::builder(
         tenant,
         coordinates,
@@ -604,6 +607,7 @@ fn admission_request(
         idempotency,
         *request.source.revision(),
     )
+    .execution_revision(execution_revision)
     .raw_event_digest(request.delivery.evidence().raw_body().digest())
     .trust_snapshot(request.trust.clone())
     .git_ref(request.execution_ref.full())
@@ -623,6 +627,12 @@ fn event_provenance(
     // `github` is the current durable identifier of the Actions-compatible
     // source/event dialect. Host-provider identity is stored separately in
     // admission repository and common delivery evidence.
+    let execution_revision = request
+        .delivery
+        .trigger()
+        .trigger()
+        .workflow_execution_revision()
+        .unwrap_or(*request.source.revision());
     WorkflowEventProvenance::new("github", event_name)
         .with_delivery_id(
             request
@@ -632,7 +642,7 @@ fn event_provenance(
                 .external_id()
                 .as_str(),
         )
-        .with_commit_sha(*request.source.revision())
+        .with_commit_sha(execution_revision)
         .with_git_ref(request.execution_ref.full())
 }
 

--- a/crates/automata-ci-workflow-service/src/service.rs
+++ b/crates/automata-ci-workflow-service/src/service.rs
@@ -721,7 +721,7 @@ fn build_command(
         ids.logical_invocation_id(run_id),
         request.plan().event().name(),
         event.metadata.clone(),
-        request.execution_revision(),
+        request.source_revision(),
         jobs,
         admitted_at,
     )

--- a/crates/automata-ci-workflow-service/src/service.rs
+++ b/crates/automata-ci-workflow-service/src/service.rs
@@ -389,7 +389,7 @@ impl WorkflowAdmissionService {
                         workflow_id,
                         request.workflow_path(),
                         request.git_ref(),
-                        request.commit_sha(),
+                        request.execution_revision(),
                         source_blob.metadata.clone(),
                         operation_id,
                         event_blob.metadata.digest(),
@@ -721,7 +721,7 @@ fn build_command(
         ids.logical_invocation_id(run_id),
         request.plan().event().name(),
         event.metadata.clone(),
-        request.commit_sha(),
+        request.execution_revision(),
         jobs,
         admitted_at,
     )
@@ -773,7 +773,7 @@ fn prepare_reusable_workflow_expansion(
     }
     let catalog = GithubReusableWorkflowCatalog::compile_reachable(
         request.repository().path(),
-        request.commit_sha(),
+        request.source_revision(),
         request.plan(),
         request.repository_workflow_sources().iter().cloned(),
     )?;
@@ -862,7 +862,7 @@ fn prepare_reusable_workflow_expansion(
         .map_err(|_| WorkflowAdmissionError::Internal)?;
         let descriptor_digest = catalog_descriptor_digest(
             path,
-            request.commit_sha(),
+            request.source_revision(),
             source.digest(),
             plan.digest(),
             contract_digest,
@@ -872,7 +872,7 @@ fn prepare_reusable_workflow_expansion(
         admitted_catalog.push(AdmittedReusableWorkflowCatalogEntry::new(
             *id,
             path,
-            request.commit_sha(),
+            request.source_revision(),
             source.clone(),
             plan.clone(),
             contract_digest,
@@ -1737,7 +1737,7 @@ fn canonical_request_digest(
     ] {
         digest_field(&mut digest, value.as_bytes());
     }
-    digest_field(&mut digest, request.commit_sha().as_bytes());
+    digest_field(&mut digest, request.source_revision().as_bytes());
     digest_optional_field(&mut digest, request.actor());
     digest_optional_field(&mut digest, request.display_title());
     digest_optional_field(&mut digest, request.commit_subject());

--- a/crates/automata-ci-workflow-service/tests/event_limits.rs
+++ b/crates/automata-ci-workflow-service/tests/event_limits.rs
@@ -32,8 +32,9 @@ fn rebuild(
         original.plan().clone(),
         original.base_context().clone(),
         original.idempotency().clone(),
-        original.commit_sha(),
+        original.source_revision(),
     )
+    .execution_revision(original.execution_revision())
     .git_ref(original.git_ref())
     .workflow_name(original.workflow_name())
     .actor(original.actor().expect("fixture actor"))

--- a/crates/automata-ci-workflow-service/tests/projection.rs
+++ b/crates/automata-ci-workflow-service/tests/projection.rs
@@ -33,6 +33,22 @@ use automata_ci_workflow_service::{
 };
 use bytes::Bytes;
 
+#[test]
+fn pull_request_admission_accepts_a_provider_merge_revision() {
+    let request = support::pull_request_with_merge_revision("pull-request-merge");
+
+    assert_ne!(request.source_revision(), request.execution_revision());
+    assert!(matches!(
+        request.plan().source().origin(),
+        automata_ci_core::PlanSourceOrigin::Repository { revision, .. }
+            if *revision == request.source_revision()
+    ));
+    assert_eq!(
+        request.plan().event().commit_sha(),
+        Some(request.execution_revision())
+    );
+}
+
 #[tokio::test]
 async fn run_name_is_evaluated_once_and_is_identical_on_replay() {
     let request = run_name_request(
@@ -171,8 +187,9 @@ async fn human_projection_is_bound_into_the_logical_admission() {
         original.plan().clone(),
         original.base_context().clone(),
         original.idempotency().clone(),
-        original.commit_sha(),
+        original.source_revision(),
     )
+    .execution_revision(original.execution_revision())
     .git_ref(original.git_ref())
     .workflow_name(original.workflow_name())
     .actor("octocat")
@@ -615,8 +632,9 @@ fn try_rebuild_with_base(
         original.plan().clone(),
         base_context,
         original.idempotency().clone(),
-        original.commit_sha(),
+        original.source_revision(),
     )
+    .execution_revision(original.execution_revision())
     .git_ref(original.git_ref())
     .workflow_name(original.workflow_name())
     .actor(original.actor().expect("fixture actor"))

--- a/crates/automata-ci-workflow-service/tests/support/mod.rs
+++ b/crates/automata-ci-workflow-service/tests/support/mod.rs
@@ -83,6 +83,55 @@ pub fn push_request(tenant: &str) -> WorkflowAdmissionRequest {
     )
 }
 
+pub fn pull_request_with_merge_revision(tenant: &str) -> WorkflowAdmissionRequest {
+    let source_revision =
+        automata_ci_core::GitObjectId::from_provider_hex(REVISION).expect("source revision");
+    let execution_revision = automata_ci_core::GitObjectId::from_provider_hex(
+        "abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    )
+    .expect("execution revision");
+    let provenance = SourceProvenance::new(
+        SourceId::new(WORKFLOW_PATH),
+        SourceOrigin::Repository {
+            repository: Arc::from(REPOSITORY),
+            revision: source_revision,
+            path: Arc::from(WORKFLOW_PATH),
+        },
+    );
+    let parsed =
+        GithubWorkflowFrontend::default().parse(ParseWorkflowRequest::new(provenance, CI_SOURCE));
+    let compiled = GithubWorkflowCompiler::new().compile(
+        CompileWorkflowRequest::new(
+            parsed.plan().expect("source plan"),
+            WorkflowEventProvenance::new("github", "pull_request")
+                .with_delivery_id(DELIVERY)
+                .with_commit_sha(execution_revision)
+                .with_git_ref(GIT_REF),
+        )
+        .with_event_metadata(ProviderEventMetadata::pull_request("synchronize", "main")),
+    );
+    assert!(compiled.is_accepted(), "{:#?}", compiled.diagnostics());
+    WorkflowAdmissionRequest::builder(
+        TenantScope::from_authenticated_tenant_id(tenant).expect("tenant"),
+        AdmissionRepositoryCoordinates::new("github", "repository-automata", REPOSITORY)
+            .expect("repository"),
+        WORKFLOW_PATH,
+        Bytes::from_static(CI_SOURCE.as_bytes()),
+        Bytes::from_static(b"{\"action\":\"synchronize\"}"),
+        compiled.into_parts().0.expect("compiled plan"),
+        JobRuntimeContext::empty_base(),
+        WorkflowAdmissionIdempotency::provider_delivery(DELIVERY).expect("delivery"),
+        source_revision,
+    )
+    .execution_revision(execution_revision)
+    .git_ref(GIT_REF)
+    .workflow_name("CI")
+    .actor("local-bootstrap")
+    .run_attempt(1)
+    .build()
+    .expect("valid pull request admission")
+}
+
 pub fn compile_ci_at_path(
     workflow_path: &str,
     event_name: &str,
@@ -165,8 +214,9 @@ pub fn changed_event_request(original: &WorkflowAdmissionRequest) -> WorkflowAdm
         original.plan().clone(),
         original.base_context().clone(),
         original.idempotency().clone(),
-        original.commit_sha(),
+        original.source_revision(),
     )
+    .execution_revision(original.execution_revision())
     .git_ref(original.git_ref())
     .workflow_name(original.workflow_name())
     .actor(original.actor().expect("fixture actor"))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,8 +76,13 @@ workflow YAML + event
         |
  fenced activation and matrix expansion
         |
-       JobIR
+JobIR
 ```
+
+Workflow source provenance and execution provenance are independent evidence.
+For pull requests, the workflow file is loaded from the head revision while
+the run may execute GitHub's synthetic merge revision; admission retains and
+validates both rather than treating the merge revision as the workflow source.
 
 `WorkflowFrontend` parses and validates the GitHub dialect. The compiler lowers
 it with event provenance into logical state. Activation evaluates the


### PR DESCRIPTION
Pull-request workflow sources and execution revisions are distinct when GitHub supplies a synthetic merge commit. Preserve both through admission and validate each against its owning trust evidence.

Adds a regression for a head/merge split and documents the contract.